### PR TITLE
docs: mark Phase 4 Stage 4D complete + link enhancement backlog

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,12 @@ HoneyLLM is a Chrome extension that detects prompt injection attacks and malicio
 - **4A** (`5721fbf`) — probe-error propagation; replaces the `probe_error`-as-flag sentinel with structured `errorMessage` / `analysisError` fields and an UNKNOWN verdict status. Fixes a silent false-negative where MLC engine failures produced CLEAN+confidence=1.0.
 - **4B** (`1c6ce78` + `3b2feea` + docs `d45974c`) — chunk serialization + `MAX_CHUNKS_PER_PAGE` cap + single-flight `initEngine` + RUN_PROBES engine-ready gate. Resolves an init race that was masking as an MLC state bug.
 - **4C** (`57c2c01` + `a52e976` + `1e4e2b4`) — Gemini Nano affected-baseline (27 real rows via a manual EPP-Chrome harness), manual FP curation, and Nano-vs-Gemma comparison addendum. Nano-as-canary validated for EPP-enrolled users.
-- **4D** — dual-path canary architecture (user-managed selection, toolbar icon state, canary-themed assets). In progress.
+- **4D** (`607241d` + `e67f1ea` + `fd99e8d` + `81f2f21` + `0f16ad7`) — dual-path canary architecture: canary catalog with Gemma/Nano/Qwen + `auto` selector, popup radio UI with live availability badges, verdict payload stamps the actual canary id, mid-session fallback toast, per-tab toolbar icon state with colour-coded verdict variants, canary-themed SVG + 20 generated PNGs.
 - **4E–4G** — Chromium-family compatibility audit, Track B resumption (B5 + B7 report), image-injection multimodal probe. Scheduled.
+
+**Accepted-but-unreviewed enhancement backlog** — captured in `docs/backlog/phase4-enhancement-requests.md` and tracked as a Phase 8 candidate:
+- Delta-cache for page snapshots (IndexedDB + bfcache signal; speeds revisits and relieves the 4096-token context window).
+- Turboquant on WebGPU/Chrome (sub-4-bit weight quantisation; cuts Gemma-2-2b footprint roughly in half, frees memory for a larger KV cache).
 
 See `/Users/node3/.claude/plans/honeyllm-phase-4.md` for the full Phase 4 plan.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -78,14 +78,17 @@ The core analysis pipeline:
 1. Receive `PAGE_SNAPSHOT` from content script
 2. Concatenate visible + hidden text
 3. Chunk into segments of `MAX_CHUNK_CHARS` (14,000) chars
-4. For each chunk, send `RUN_PROBES` to offscreen document
-5. Collect `PROBE_RESULTS` from all chunks
-6. Merge results — deduplicate by probe name, keep highest score
-7. Run behavioral analyzer on merged results
-8. Run policy engine to compute verdict
-9. Send `VERDICT` back to content script
-10. Send `APPLY_MITIGATION` if score >= SUSPICIOUS threshold
-11. Persist verdict to Chrome storage by origin
+4. Cap at `MAX_CHUNKS_PER_PAGE` (4) chunks (Phase 4 Stage 4B.1) — excess chunks are dropped and `analysisError: 'chunk_count_capped'` is stamped on the verdict
+5. For each chunk **sequentially** (not concurrently — Phase 4 Stage 4B.1), send `RUN_PROBES` to offscreen document and await results
+6. Collect `PROBE_RESULTS` + the `canaryId` the offscreen stamped (Phase 4 Stage 4D.3)
+7. Merge results — prefer non-errored chunk-runs; for non-errored results, keep highest score per probe name
+8. Aggregate `analysisError` across probes and chunks (Phase 4 Stage 4A)
+9. Run behavioral analyzer on merged results
+10. Run policy engine to compute verdict (emits `UNKNOWN` if all probes errored; otherwise score-derived CLEAN/SUSPICIOUS/COMPROMISED)
+11. Send `VERDICT` back to content script
+12. Send `APPLY_MITIGATION` if score >= SUSPICIOUS threshold
+13. Persist verdict to Chrome storage by origin (includes `analysisError` and `canaryId`)
+14. Update toolbar icon via `setTabVerdict()` (Phase 4 Stage 4D.4)
 
 ### Keepalive (`src/service-worker/keepalive.ts`)
 
@@ -95,21 +98,46 @@ Prevents service worker hibernation using Chrome alarms (24-second period) and c
 
 Manages the offscreen document lifecycle — creates it on demand, tracks whether it exists, handles the single-instance constraint.
 
+### Toolbar Icon (`src/service-worker/toolbar-icon.ts`)
+
+Phase 4 Stage 4D.4. Per-tab icon state driven by verdicts:
+
+- Maintains an in-memory `Map<tabId, SecurityStatus>` mirroring verdicts so tab switches are instant.
+- On `persistVerdict()`, calls `chrome.action.setIcon({ tabId, path })` with the matching canary variant (`public/icons/icon-<state>-<size>.png` for CLEAN/SUSPICIOUS/COMPROMISED/UNKNOWN).
+- On `chrome.tabs.onActivated`, re-applies the icon for the newly-active tab.
+- On `chrome.tabs.onRemoved`, evicts the tab from the map.
+- Also sets `chrome.action.setBadgeBackgroundColor()` so the badge colour matches the verdict state.
+
+Icon assets are built from `public/icons/src/canary.svg` via `scripts/build-icons.ts` using `sharp` + `{{PLACEHOLDER}}` token substitution (not CSS custom properties — librsvg doesn't resolve those).
+
 ## Offscreen Document
 
 **Entry:** `src/offscreen/index.ts`
 
 ### Engine (`src/offscreen/engine.ts`)
 
-Initializes the MLC-LLM WebGPU inference engine:
+Phase 4 Stage 4D introduced a dual-path engine. Dispatches between two adapters via the canary catalog:
 
-- **Primary model:** `Phi-3-mini-4k-instruct-q4f16_1-MLC`
-- **Fallback model:** `TinyLlama-1.1B-Chat-v1.0-q4f16_1-MLC`
-- Reports loading progress via `ENGINE_STATUS` messages
+- **MLC adapter** (`createMlcEngineAdapter`) — WebGPU via `@mlc-ai/web-llm`:
+  - **Primary model:** `gemma-2-2b-it-q4f16_1-MLC` (Phase 3 Track A SHIP decision)
+  - **Fast-path fallback:** `Qwen2.5-0.5B-Instruct-q4f16_1-MLC`
+  - No enrollment gate. Works in any Chromium browser with WebGPU support.
+- **Nano adapter** (`createNanoEngineAdapter`) — Chrome's built-in `window.LanguageModel`:
+  - **Model:** `chrome-builtin-gemini-nano`
+  - EPP-gated. Only available in Chrome profiles enrolled in the Early Preview Program.
+  - Per-prompt session lifecycle (`create()` → `prompt()` → `destroy()`).
+  - Supports `expectedOutputs: [{ type: 'text', languages: ['en'] }]` and image inputs for Stage 4G.
+
+`initEngine()` is single-flight (Phase 4 Stage 4B.3) — concurrent callers during the load window await the same in-flight promise. `getLoadedCanaryId()` exposes the active canary id so the orchestrator can stamp it onto the verdict payload.
+
+**Canary selection (`CANARY_CATALOG`, `CANARY_FALLBACK_ORDER`, `STORAGE_KEY_CANARY`):**
+User-managed via the popup (`chrome.storage.sync`). On `'auto'` or unavailable selection, the selector walks the fallback chain Nano → Gemma → Qwen and picks the first available. Verdicts carry a `canaryId` field recording which canary actually produced them; the popup surfaces this and toasts a notice when the user-selected canary falls back.
+
+Reports loading progress via `ENGINE_STATUS` messages.
 
 ### Probe Runner (`src/offscreen/probe-runner.ts`)
 
-Executes all three probes sequentially on each text chunk, returns array of `ProbeResult` objects.
+Executes all three probes sequentially on each text chunk, returns array of `ProbeResult` objects. Probe errors are propagated as `errorMessage` on the result (Phase 4 Stage 4A) — not as a `probe_error` flag — so the policy engine can emit `UNKNOWN` verdicts when all probes on all chunks fail rather than masking failures as `CLEAN`.
 
 ## Probes
 


### PR DESCRIPTION
## Summary

Updates README and ARCHITECTURE to reflect that Phase 4 Stage 4D has shipped in full (4D.1 → 4D.4, commits `607241d` → `0f16ad7`), and links the accepted-but-unreviewed enhancement backlog from `docs/backlog/phase4-enhancement-requests.md`.

No code changes. 233/233 tests pass; build clean.

## Why now

The plan directive was: "create an issue specifying the change is accepted but not yet reviewed… create PR to pull updated doc removing the notes about 4D not being reviewed yet." This PR takes care of the doc update; the companion issue (#6) captures the enhancement requests for formal review.

## README changes

- Status section Stage 4D row: removed "In progress"; now lists the five commits that shipped the four subtasks plus the icon-variant fix.
- New "Accepted-but-unreviewed enhancement backlog" subsection pointing at `docs/backlog/phase4-enhancement-requests.md` and summarising the two ideas (delta-cache, turboquant).

## ARCHITECTURE changes

- Offscreen engine section updated from stale Phi-3/TinyLlama placeholders to describe the actual Stage 4D dual-path engine: MLC adapter (Gemma-2-2b primary, Qwen-0.5B fallback) plus Nano adapter (EPP-gated). Single-flight `initEngine` and canary selector contract documented.
- Probe runner section now calls out Phase 4A error propagation (`errorMessage` on `ProbeResult`, not `probe_error` flag).
- Service worker orchestrator pipeline steps expanded with the `MAX_CHUNKS_PER_PAGE` cap, sequential chunk dispatch, `canaryId` collection, and toolbar-icon update.
- New "Toolbar Icon" section documents the per-tab icon state mirror in `toolbar-icon.ts` and the SVG-to-PNG build pipeline.

## Related

- Closes: _none_ (this is docs-only; the enhancement review work lives in #6).
- References: #6 (accepted-but-unreviewed enhancement requests).
- Parent plan: `/Users/node3/.claude/plans/honeyllm-phase-4.md`.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` green (233/233)
- [x] `npx tsc --noEmit` clean
- [ ] Manual verification user reloads the extension in real EPP Chrome and sees:
  - Toolbar icon switches variants after analysis (green/amber/red/grey border).
  - Popup Canary card shows four radios with live availability badges.
  - Selecting a different canary shows the "takes effect on next analysis" toast.
  - Verdict data on subsequent loads stamps the correct `canaryId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)