### PR TITLE
chore(#26): standardise branch + PR + issue workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,50 @@
+name: Bug report
+description: Something is broken or behaving incorrectly.
+title: "bug: <short description>"
+labels: ["bug"]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear, concrete description of the bug.
+      placeholder: When I do X, Y happens. I expected Z.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps
+      description: Minimal steps to reproduce. Include URLs, models, browser version if relevant.
+      placeholder: |
+        1. Load extension on chrome-stable 137
+        2. Visit <url>
+        3. Observe <wrong behaviour>
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      description: What should have happened?
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Browser, OS, extension version, model. Skip fields that don't apply.
+      value: |
+        - Browser:
+        - OS:
+        - Extension version (commit SHA or tag):
+        - Model / canary:
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / screenshots
+      description: SW console output, stack traces, screenshots. Wrap logs in code fences.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discussion / question
+    url: https://github.com/JimmyCapps/zentropy/discussions
+    about: For open-ended questions or design discussion (not bug reports or feature requests).

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,46 @@
+name: Feature request
+description: A new capability or enhancement to existing behaviour.
+title: "feat: <short description>"
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What problem does this solve, or what does it unlock?
+      placeholder: Currently X is hard / impossible / slow. With this change, Y becomes possible.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Sketch the approach. Doesn't need to be final — alternatives welcome.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you've thought about + why they were ruled out.
+    validations:
+      required: false
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      description: Rough estimate of effort.
+      options:
+        - small (a few hours, single file)
+        - medium (a day, a few files)
+        - large (multi-day, multi-file)
+        - unknown
+    validations:
+      required: true
+  - type: textarea
+    id: phase
+    attributes:
+      label: Phase / milestone
+      description: Which project phase does this belong to? (Phase 4 / 5 / 8 / etc.)
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/finding.yml
+++ b/.github/ISSUE_TEMPLATE/finding.yml
@@ -1,0 +1,40 @@
+name: Finding / observation
+description: An observation from testing or use that needs follow-up but isn't necessarily a bug.
+title: "finding: <short description>"
+labels: ["finding"]
+body:
+  - type: textarea
+    id: observed
+    attributes:
+      label: What was observed
+      description: Concrete description of the behaviour or pattern noticed.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Where did this surface? (Phase 3 baseline run, 4D verification, live testing, etc.)
+    validations:
+      required: true
+  - type: textarea
+    id: hypothesis
+    attributes:
+      label: Likely cause / hypothesis
+      description: Best guess at the underlying cause, if any.
+    validations:
+      required: false
+  - type: textarea
+    id: impact
+    attributes:
+      label: Why it matters
+      description: User impact, project impact, downstream effect on other phases.
+    validations:
+      required: true
+  - type: textarea
+    id: handling
+    attributes:
+      label: Proposed handling
+      description: Fix now? Defer to a phase? Spin out a separate enhancement issue?
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,40 @@
+<!--
+Thanks for opening a PR! Please fill in each section below — the description
+is the durable record of why this change exists, and outlives commit messages
+and issue threads.
+-->
+
+## Summary
+
+<!-- 1–3 bullets describing what this changes and why. -->
+
+Closes #<!-- issue number -->
+
+## Approach
+
+<!-- Key design decisions. Alternatives considered + why this one won.
+Anything a future reader (or reviewer) needs to understand the diff. -->
+
+## Impact
+
+<!-- Concrete effects: data deltas, perf numbers, FP rate changes, schema
+changes, new fields, behaviour shifts. "None" is a valid answer. -->
+
+## Test plan
+
+<!-- How you verified this works. Mark items as you complete them. -->
+
+- [ ] `npm run build` green
+- [ ] `npm test` green
+- [ ] Manual verification: <!-- describe, or N/A -->
+
+## Risk / rollback
+
+<!-- What could break in production / for other contributors? How would you
+revert if it does? "Low risk, single-file change, revert via git revert"
+is a fine answer for small fixes. -->
+
+## Screenshots / artifacts
+
+<!-- Optional: UI screenshots, before/after numbers, log excerpts. Delete
+this section if not applicable. -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+# Mirrors the local pre-push hook: typecheck + test + build on every PR
+# targeting main and every push to main. Uses only static npm commands; no
+# untrusted event inputs are interpolated into shell scripts.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+# Cancel in-flight runs on the same ref when a newer push arrives.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Default token permissions: read-only for repo contents, no write access.
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: typecheck + test + build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,47 +1,151 @@
 # Contributing to HoneyLLM
 
-## Getting Started
+Thanks for contributing! This document describes the standard workflow for any change — from a one-line typo fix to a multi-day feature. The same rules apply to humans and to autonomous agent sessions (Claude Code, etc.).
 
-1. Fork the repository
-2. Clone your fork: `git clone https://github.com/<your-username>/zentropy.git`
-3. Install dependencies: `npm install`
-4. Create a branch: `git checkout -b feat/your-feature`
+## Getting started
 
-## Development Workflow
+1. Fork the repository (or clone directly if you have write access).
+2. `git clone https://github.com/<your-username>/zentropy.git`
+3. `npm install`
 
-1. Make your changes
-2. Run type checking: `npm run typecheck`
-3. Run unit tests: `npm test`
-4. Build the extension: `npm run build`
-5. Test in Chrome by loading `dist/` as an unpacked extension
-6. Run E2E tests if modifying detection or mitigation logic: `npm run test:e2e`
+## The standard workflow
 
-## Pull Requests
+Every code change follows this loop:
 
-- Keep PRs focused on a single change
-- Include tests for new probes, analyzers, or scoring rules
-- Update documentation if adding new features
-- Use conventional commit messages: `feat:`, `fix:`, `refactor:`, `test:`, `docs:`
+```
+GitHub issue → feature branch → commits → PR linked to issue → CI green → squash-merge → branch deleted
+```
 
-## Adding a New Probe
+No direct commits to `main`. Even cosmetic single-file fixes go through a PR. The PR description is the durable record of *why* a change exists, and outlives commit messages and issue threads.
 
-1. Create a new file in `src/probes/` implementing the `Probe` interface from `base-probe.ts`
-2. Add corresponding tests in `src/probes/<name>.test.ts`
-3. Register the probe in `src/offscreen/probe-runner.ts`
-4. Add scoring rules in `src/policy/rules.ts`
-5. Update the max score constant in `src/shared/constants.ts`
+### 1. Find or open an issue
 
-## Adding a New Behavioral Analyzer
+- Search existing issues first to avoid duplication.
+- Use one of the issue templates (Bug / Feature / Finding) — they prompt for the context reviewers will need.
+- For larger work, comment on the issue to claim it before starting, so two contributors don't end up doing the same thing.
 
-1. Create a new file in `src/analysis/`
-2. Add tests in `src/analysis/<name>.test.ts`
-3. Wire it into `src/analysis/behavioral-analyzer.ts`
-4. Add the flag to `BehavioralFlags` in `src/types/verdict.ts`
-5. Add scoring weight in `src/policy/rules.ts`
+### 2. Create a branch
 
-## Code Style
+Branch from the latest `main`, using this naming convention:
 
-- TypeScript strict mode — no `any` types
-- Immutable patterns — return new objects, don't mutate
-- Small files — aim for under 400 lines
-- No comments unless explaining a non-obvious "why"
+```
+<type>/issue-<N>-<short-slug>
+```
+
+Where `<type>` is one of:
+
+| Type       | Use for                                          |
+|------------|--------------------------------------------------|
+| `feat`     | New capability or user-visible enhancement       |
+| `fix`      | Bug fix or regression repair                     |
+| `refactor` | Code change with no behavioural difference       |
+| `docs`     | Documentation only                               |
+| `chore`    | Tooling, deps, CI, repo hygiene                  |
+| `test`     | Test-only changes (no production code)           |
+
+Examples: `fix/issue-13-classifier-v2`, `feat/issue-9-image-probe-4G1`, `chore/issue-26-contributor-workflow`.
+
+Push the branch early so other sessions can see it.
+
+### 3. Make changes
+
+- Run `npm run typecheck`, `npm test`, and `npm run build` locally before pushing.
+- The local pre-push hook also runs these — don't bypass it (`--no-verify`).
+- Use conventional commit messages: `feat:`, `fix:`, `refactor:`, `test:`, `docs:`, `chore:`. Reference the issue number in the scope when applicable, e.g. `fix(phase3-#13): ...`.
+- Keep PRs focused. If scope grows, split into a new issue + branch.
+
+### 4. Open a PR
+
+Open as soon as there's something worth showing — draft is fine. The PR template asks for:
+
+- **Summary** — what and why, with `Closes #<issue>` so the issue auto-closes on merge.
+- **Approach** — key design decisions and alternatives considered.
+- **Impact** — concrete effects (data deltas, perf numbers, schema changes).
+- **Test plan** — how you verified.
+- **Risk / rollback** — what could break and how to revert.
+
+### 5. CI must be green
+
+The `CI` workflow runs typecheck + test + build on every PR. It mirrors the local pre-push hook so passing locally is a strong signal it'll pass in CI.
+
+### 6. Merge
+
+- **Squash-merge** is the default — keeps `main` history one-commit-per-feature/fix, which lines up cleanly with issues and PRs.
+- Self-merge is allowed for now. When in doubt, ask for review.
+- The feature branch auto-deletes on merge.
+
+## Parallel work / agent coordination
+
+When multiple sessions (human or agent) work in parallel:
+
+- One session per branch. Push the branch immediately after creating it so other sessions see it via `git fetch`.
+- Avoid touching files that an open PR also touches. Coordinate via issue comments if overlap is unavoidable.
+- If two PRs end up conflicting, the second-to-merge rebases on top of `main` (`git rebase main`, then `git push --force-with-lease`).
+- Don't merge `main` into feature branches — rebase keeps PR history clean.
+
+## Project-specific recipes
+
+### Adding a new probe
+
+1. Create a new file in `src/probes/` implementing the `Probe` interface from `base-probe.ts`.
+2. Add corresponding tests in `src/probes/<name>.test.ts`.
+3. Register the probe in `src/offscreen/probe-runner.ts`.
+4. Add scoring rules in `src/policy/rules.ts`.
+5. Update the max score constant in `src/shared/constants.ts`.
+
+### Adding a new behavioral analyzer
+
+1. Create a new file in `src/analysis/`.
+2. Add tests in `src/analysis/<name>.test.ts`.
+3. Wire it into `src/analysis/behavioral-analyzer.ts`.
+4. Add the flag to `BehavioralFlags` in `src/types/verdict.ts`.
+5. Add scoring weight in `src/policy/rules.ts`.
+
+### Loading the extension for manual testing
+
+Build the extension (`npm run build`) and load `dist/` as an unpacked extension in Chrome (`chrome://extensions/` → Developer mode → Load unpacked). Run E2E tests with `npm run test:e2e` if modifying detection or mitigation logic.
+
+## Code style
+
+- TypeScript strict mode — no `any`. Use `unknown` and narrow when input is external.
+- Immutable patterns — return new objects, don't mutate.
+- Small files — aim for under 400 lines, hard cap around 800.
+- No comments unless explaining a non-obvious "why" (a hidden constraint, a workaround for a specific bug, behaviour that would surprise a reader). Don't narrate what the code does.
+- Interfaces for object shapes that may be extended; type aliases for unions, intersections, mapped types.
+
+## Branch protection (currently disabled — recipe for fast turn-on)
+
+Branch protection on `main` is **intentionally not enabled** as of writing — collaborators are aligned and the user wants to minimise roadblocks. The workflow expectation above stands regardless.
+
+If protection becomes necessary (new contributor without context, an accidental direct push, etc.), apply these settings via the GitHub UI at *Settings → Branches → Add rule for `main`*:
+
+| Setting | Value |
+|---|---|
+| Require a pull request before merging | ✓ |
+| Require approvals | 1 (or 0 for solo work) |
+| Dismiss stale pull request approvals when new commits are pushed | ✓ |
+| Require status checks to pass before merging | ✓ |
+| Required status checks | `verify` (from `.github/workflows/ci.yml`) |
+| Require branches to be up to date before merging | ✓ |
+| Require linear history | ✓ (matches squash-merge default) |
+| Restrict deletions | ✓ |
+| Do not allow bypassing the above settings | ✓ |
+| Allow force pushes | ✗ |
+
+Repo-level settings (*Settings → General*):
+
+| Setting | Value |
+|---|---|
+| Allow merge commits | ✗ |
+| Allow squash merging | ✓ (default) |
+| Allow rebase merging | ✗ (or ✓ if you want stacked-PR support) |
+| Automatically delete head branches | ✓ |
+
+Optional follow-on:
+
+- **CODEOWNERS** at `.github/CODEOWNERS` for path-based reviewer assignment.
+- **Lighter bar for docs-only PRs** via path-based protection rule exemptions, if review-wait friction shows up.
+
+## Questions
+
+For open-ended discussion, use [GitHub Discussions](https://github.com/JimmyCapps/zentropy/discussions). For bug reports or feature requests, open an issue with the appropriate template.


### PR DESCRIPTION
## Summary

- Adds the scaffolding for a multi-contributor workflow: every change goes through issue → branch → PR → squash-merge, applying equally to humans and to autonomous agent sessions.
- Includes PR + issue templates, a CI workflow that mirrors the local pre-push hook, and a rewritten `CONTRIBUTING.md` that documents the process plus a ready-to-apply recipe for branch protection (currently disabled per user direction).

Closes #26

## Approach

**Scope decisions driven by user intent:**
- Branch protection on `main` is intentionally **not enabled** — collaborators are aligned and the user wants to minimise roadblocks. The workflow expectation stands regardless, enforced socially rather than by GitHub rules for now.
- The full protection-settings recipe is captured in `CONTRIBUTING.md` so it can be turned on via the GitHub UI in minutes without re-deriving what's needed.
- CI workflow built and tested as a functioning gate so "turn on required checks" is a one-click follow-up if protection is ever enabled.

**Trade-offs:**
- PR + issue templates use the modern `.yml` form for richer validation (required fields, dropdowns). Contributors get a structured prompt rather than a blank box.
- CI uses Node 22 LTS rather than matching the maintainer's local Node 25 — broader contributor compatibility.
- `permissions: contents: read` at the workflow level + `concurrency: cancel-in-progress` for cost + clarity.

## Impact

- Every future change (from any contributor, human or agent) now has a structured prompt + a durable PR description template.
- CI runs on every PR and every push to `main` — first feedback a contributor gets is deterministic.
- Agent sessions picking up work will default to branch + PR workflow via a new project-memory note (saved alongside this change, outside the repo).

## Test plan

- [x] `npm run typecheck` green
- [x] `npm test` green (256 tests)
- [x] `npm run build` green
- [x] Pre-push hook green
- [ ] CI workflow runs green on this PR (will verify after push)
- [ ] PR template renders when opening future PRs via `gh pr create` with no body
- [ ] Issue templates appear in the new-issue picker on github.com

## Risk / rollback

Low risk — all additions are scaffolding files. No production-code changes. Rollback: `git revert` the commit. Re-enabling the previous `CONTRIBUTING.md` is a two-line edit if the rewrite proves unwelcome.

## Screenshots / artifacts

Files added:
- `.github/pull_request_template.md`
- `.github/ISSUE_TEMPLATE/{bug,feature,finding,config}.yml`
- `.github/workflows/ci.yml`
- `CONTRIBUTING.md` (rewrite preserving existing probe/analyzer recipes + code-style section)