### PR TITLE
docs(#30): audit pass — fix stale constants, model refs, test count

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@ HoneyLLM is a Chrome extension that detects prompt injection attacks and malicio
 - Delta-cache for page snapshots (IndexedDB + bfcache signal; speeds revisits and relieves the 4096-token context window).
 - Turboquant on WebGPU/Chrome (sub-4-bit weight quantisation; cuts Gemma-2-2b footprint roughly in half, frees memory for a larger KV cache).
 
-See `/Users/node3/.claude/plans/honeyllm-phase-4.md` for the full Phase 4 plan.
-
 ## How It Works
 
 When you visit a page, HoneyLLM silently analyzes its content through a multi-stage pipeline:
@@ -30,7 +28,7 @@ When you visit a page, HoneyLLM silently analyzes its content through a multi-st
 ```
 Page Load
   → Content script extracts visible text, hidden DOM, script fingerprints, metadata
-  → Service worker chunks content (14K chars per chunk)
+  → Service worker chunks content (11K chars per chunk; sized for Gemma's 4096-token context window)
   → Offscreen document runs 3 LLM probes per chunk via WebGPU
   → Behavioral analyzer detects role drift, exfiltration intent, instruction compliance
   → Policy engine scores results → CLEAN | SUSPICIOUS | COMPROMISED
@@ -157,7 +155,7 @@ src/
 │   ├── keepalive.ts   # Service worker persistence
 │   └── offscreen-manager.ts  # Offscreen document lifecycle
 ├── offscreen/         # LLM inference context
-│   ├── engine.ts      # MLC-LLM WebGPU engine (Phi-3-mini / TinyLlama fallback)
+│   ├── engine.ts      # Dual-path engine: MLC WebGPU (Gemma / Qwen) + Chrome built-in Gemini Nano
 │   ├── probe-runner.ts # Sequential probe execution
 │   └── index.ts       # Message handler
 ├── probes/            # LLM-based detection probes
@@ -184,12 +182,12 @@ src/
 
 ## Tech Stack
 
-- **LLM Inference (default)** — [MLC-LLM](https://mlc.ai/) via WebGPU (Gemma-2-2b-it primary, Qwen2.5-0.5B fast-path fallback, TinyLlama/Phi-3-mini legacy fallbacks). All on-device, private, cross-browser-compatible.
+- **LLM Inference (default)** — [MLC-LLM](https://mlc.ai/) via WebGPU. Primary canary `gemma-2-2b-it-q4f16_1-MLC`; fast-path fallback `Qwen2.5-0.5B-Instruct-q4f16_1-MLC`. All on-device, private, cross-browser-compatible. Phase 2 also baselined Phi-3-mini and TinyLlama; they're not currently in the canary catalog but rows for both are kept in `docs/testing/inbrowser-results.json` as the historical baseline.
 - **LLM Inference (Nano path, Phase 4)** — Chrome's built-in `window.LanguageModel` API (Gemini Nano). EPP-gated; available only in Google Chrome profiles enrolled in the Early Preview Program.
 - **Extension** — Chrome Manifest V3 with offscreen document API.
 - **Build** — Vite + custom multi-format build script (`build.ts`); esbuild for the standalone Nano harness.
 - **Language** — TypeScript (strict mode).
-- **Testing** — Vitest (unit, 230+ tests) + Playwright (E2E) + standalone HTML harnesses for EPP-gated paths.
+- **Testing** — Vitest (unit, 256 tests as of 2026-04-18) + Playwright (E2E) + standalone HTML harnesses for EPP-gated paths.
 
 ## License
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -77,7 +77,7 @@ The core analysis pipeline:
 
 1. Receive `PAGE_SNAPSHOT` from content script
 2. Concatenate visible + hidden text
-3. Chunk into segments of `MAX_CHUNK_CHARS` (14,000) chars
+3. Chunk into segments of `MAX_CHUNK_CHARS` (11,000) chars — sized for Gemma's 4096-token context window after accounting for system prompt + scaffolding
 4. Cap at `MAX_CHUNKS_PER_PAGE` (4) chunks (Phase 4 Stage 4B.1) — excess chunks are dropped and `analysisError: 'chunk_count_capped'` is stamped on the verdict
 5. For each chunk **sequentially** (not concurrently — Phase 4 Stage 4B.1), send `RUN_PROBES` to offscreen document and await results
 6. Collect `PROBE_RESULTS` + the `canaryId` the offscreen stamped (Phase 4 Stage 4D.3)
@@ -278,13 +278,20 @@ All builds inline dependencies (no chunk splitting) and minify output.
 
 | Constant | Value | Purpose |
 |----------|-------|---------|
-| `MODEL_PRIMARY` | Phi-3-mini-4k-instruct-q4f16_1-MLC | Primary inference model |
-| `MODEL_FALLBACK` | TinyLlama-1.1B-Chat-v1.0-q4f16_1-MLC | Fallback if primary fails |
-| `MAX_CHUNK_CHARS` | 14,000 | Text chunk size for probe input |
-| `MAX_CHUNK_TOKENS` | 3,500 | Token budget per chunk |
+| `MODEL_PRIMARY` | `gemma-2-2b-it-q4f16_1-MLC` | Legacy single-model alias kept for back-compat — current code reads from `CANARY_CATALOG` instead |
+| `MODEL_FALLBACK` | `Qwen2.5-0.5B-Instruct-q4f16_1-MLC` | Same — back-compat alias |
+| `CANARY_CATALOG` | (Gemma 2-2b, Gemini Nano, Qwen 2.5-0.5B) | Phase 4 Stage 4D source-of-truth for the dual-path engine |
+| `CANARY_FALLBACK_ORDER` | Nano → Gemma → Qwen | Selector walks this when user-selected canary is unavailable |
+| `DEFAULT_CANARY_ID` | `'auto'` | Triggers runtime availability detection on first load |
+| `MAX_CHUNK_CHARS` | 11,000 | Text chunk size for probe input. Computed as `MAX_CHUNK_TOKENS × APPROX_CHARS_PER_TOKEN`. Reduced from 14000 in Phase 4F (`bd72857`) after Wikipedia-length prose overflowed Gemma's 4096-token context window. |
+| `MAX_CHUNK_TOKENS` | 2,750 | Token budget per chunk (leaves ~600–1000 tokens of headroom for system prompt + response) |
+| `APPROX_CHARS_PER_TOKEN` | 4 | Heuristic; Gemma's actual ratio is closer to 3.3–3.5 chars/token, factored into the 2,750 budget |
+| `MAX_CHUNKS_PER_PAGE` | 4 | Phase 4 Stage 4B.1 cap. Excess chunks dropped with `analysisError: 'chunk_count_capped'` on the verdict |
 | `MAX_VISIBLE_TEXT_CHARS` | 50,000 | Visible text extraction cap |
 | `MAX_HIDDEN_TEXT_CHARS` | 10,000 | Hidden text extraction cap |
 | `KEEPALIVE_ALARM_PERIOD_SECONDS` | 24 | Chrome alarm interval |
 | `CONTENT_PING_INTERVAL_MS` | 20,000 | Content script ping interval |
 | `THRESHOLD_SUSPICIOUS` | 30 | Score for SUSPICIOUS verdict |
 | `THRESHOLD_COMPROMISED` | 65 | Score for COMPROMISED verdict |
+| `STORAGE_KEY_CANARY` | `'honeyllm:canary'` | User's preferred canary id, in `chrome.storage.sync` |
+| `STORAGE_KEY_NANO_AVAILABILITY` | `'honeyllm:nano-availability'` | Per-device cache of Nano availability, in `chrome.storage.local` |


### PR DESCRIPTION
## Summary

- Inventory + triage pass on all in-scope docs from #30; trivial factual fixups landed here, decision-needed drift items spun out as separate issues per the audit's \"flag, don't silently fix\" rule.
- Touches `README.md` and `docs/ARCHITECTURE.md` only. All edits ground-truthed against `src/shared/constants.ts` and the actual canary catalog.

Closes #30

## Approach

Walked every in-scope doc, noted drift with file:line refs, then triaged into:
- **Trivial in-PR fixups** — pure factual corrections where the source-of-truth is unambiguous (constants in code, test counts, file references).
- **Decision-needed** — anything requiring a human call on convention or workflow. Spun out as #31, #32, #33, #34.

This keeps the PR scope tight and gives you discrete decisions to make on the spin-outs rather than a single large \"please review every doc choice\" thread.

## Impact

Fixed in this PR (all factual, all ground-truthed):

| Doc | Before | After | Source of truth |
|---|---|---|---|
| `README.md:33` | `14K chars per chunk` | `11K chars per chunk; sized for Gemma's 4096-token context` | `MAX_CHUNK_CHARS = 11000` |
| `README.md:160` | `engine.ts # MLC-LLM WebGPU engine (Phi-3-mini / TinyLlama fallback)` | `engine.ts # Dual-path engine: MLC WebGPU (Gemma / Qwen) + Chrome built-in Gemini Nano` | `src/offscreen/engine.ts` Phase 4D |
| `README.md:187` | `Gemma-2-2b-it primary, Qwen2.5-0.5B fast-path fallback, TinyLlama/Phi-3-mini legacy fallbacks` | Drops legacy fallback claim; clarifies Phi-3/TinyLlama exist only as Phase 2 baseline rows | `CANARY_CATALOG` |
| `README.md:192` | `Vitest (unit, 230+ tests)` | `Vitest (unit, 256 tests as of 2026-04-18)` | `npm test` output |
| `README.md:24` | Absolute path leak `/Users/node3/.claude/plans/honeyllm-phase-4.md` | Removed | Plan files aren't tracked in repo |
| `ARCHITECTURE.md:80` | `MAX_CHUNK_CHARS (14,000)` | `MAX_CHUNK_CHARS (11,000) — sized for Gemma's 4096-token context window` | `MAX_CHUNK_CHARS` |
| `ARCHITECTURE.md:281–283` constants table | Phi-3-mini / TinyLlama / 14000 / 3500 (all stale) | Gemma-2-2b / Qwen / 11000 / 2750 + new Phase 4 rows: `CANARY_CATALOG`, `CANARY_FALLBACK_ORDER`, `DEFAULT_CANARY_ID`, `MAX_CHUNKS_PER_PAGE`, `STORAGE_KEY_CANARY`, `STORAGE_KEY_NANO_AVAILABILITY` | `src/shared/constants.ts` lines 52–175 |

Spun out as separate issues (require a human convention call, NOT silently fixed):

| Issue | Topic |
|---|---|
| #31 | Absolute-path leaks in historical session-launch prompts (`PHASE3_PROMPT.md`, `PHASE4_PROMPT.md`, `mlc-root-cause.md`, `FIXTURE_HOSTING_SETUP_PROMPT.md`, `MODEL_BEHAVIORAL_TEST_REPORT.md`) — leaving these as-is changes the doc's meaning. Needs a policy. |
| #32 | Forward-pointer convention for historical phase reports superseded by later fixes (e.g. `AFFECTED_BASELINE_REPORT.md` cites 15 FPs and defers to \"Phase 8 cleanup\" — that fix shipped in #13 and FPs are now 10). |
| #33 | Source-of-truth between `docs/backlog/phase4-enhancement-requests.md` and GitHub issue #6 — both cover the same ground without an explicit relationship. |
| #34 | README's \"~2 GB free memory\" requirement is unverified; backlog cites Gemma at ~1.5 GB. Needs re-measurement or per-canary qualification. |

Out of scope for this PR (per #30 rules):
- Wholesale rewriting of any doc.
- Architectural changes implied by drift — flagged via spin-outs instead of fixed silently.

## Test plan

- [x] `git push` pre-push hook green (typecheck + test + build)
- [x] No code changes — CI will run for consistency
- [x] All targeted drift verified gone (`grep` for `14,000|14000|14K|Phi-3-mini|TinyLlama|230\\+|/Users/node3/.claude` returns only intentional historical references in the changelog footnote)
- [ ] CI green on the PR

## Risk / rollback

Zero runtime risk. Rollback: `git revert` if any of the corrected numbers turn out to be wrong (none should — all from `src/shared/constants.ts`).