### PR TITLE
docs(#33): migrate backlog to GitHub canonical; introduce docs/issues/

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,6 +141,24 @@ Phase test reports follow a fork-on-supersede pattern. The goal is to preserve t
 
 This is an Option C variant of the deferred decision in #32 (forked report pair, lightweight convention rather than CURRENT/HISTORICAL suffix split).
 
+## Issue-tracked design docs
+
+GitHub is the canonical source of truth for backlog items, enhancement proposals, and feature requests. Per the convention from #33, status / prioritisation / discussion live on the issue itself.
+
+When an issue's design rationale outgrows the issue body — long architectural sketches, trade-off tables, ASCII diagrams, multi-section trade-off analysis — write a per-issue document at `docs/issues/<N>-<slug>.md` and link it from the issue body.
+
+**Format:**
+- File path: `docs/issues/<issue-number>-<short-slug>.md`. Examples: `docs/issues/6-phase4-enhancements.md`, `docs/issues/9-image-injection-probe.md`.
+- Header must include a "Tracked in #N — see issue for current status" admonition pointing back to the canonical issue.
+- The doc holds rationale + design only. Status, owner, blocker relationships, and discussion stay on the issue.
+- One doc per issue. If an issue spawns sub-issues with their own designs, each gets its own file.
+
+**When NOT to create a per-issue doc:**
+- The design fits in 2-3 paragraphs — keep it in the issue body.
+- The doc would just restate what the issue already says — keep it in the issue body.
+
+The pattern preserves rich technical content alongside code while keeping GitHub as the entry point for everything that requires coordination.
+
 ## Branch protection (currently disabled — recipe for fast turn-on)
 
 Branch protection on `main` is **intentionally not enabled** as of writing — collaborators are aligned and the user wants to minimise roadblocks. The workflow expectation above stands regardless.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ HoneyLLM is a Chrome extension that detects prompt injection attacks and malicio
 - **4D** (`607241d` + `e67f1ea` + `fd99e8d` + `81f2f21` + `0f16ad7`) — dual-path canary architecture: canary catalog with Gemma/Nano/Qwen + `auto` selector, popup radio UI with live availability badges, verdict payload stamps the actual canary id, mid-session fallback toast, per-tab toolbar icon state with colour-coded verdict variants, canary-themed SVG + 20 generated PNGs.
 - **4E–4G** — Chromium-family compatibility audit, Track B resumption (B5 + B7 report), image-injection multimodal probe. Scheduled.
 
-**Accepted-but-unreviewed enhancement backlog** — captured in `docs/backlog/phase4-enhancement-requests.md` and tracked as a Phase 8 candidate:
+**Accepted-but-unreviewed enhancement backlog** — tracked in GitHub issue [#6](https://github.com/JimmyCapps/zentropy/issues/6); design rationale captured in `docs/issues/6-phase4-enhancements.md`:
 - Delta-cache for page snapshots (IndexedDB + bfcache signal; speeds revisits and relieves the 4096-token context window).
 - Turboquant on WebGPU/Chrome (sub-4-bit weight quantisation; cuts Gemma-2-2b footprint roughly in half, frees memory for a larger KV cache).
 

--- a/docs/issues/6-phase4-enhancements.md
+++ b/docs/issues/6-phase4-enhancements.md
@@ -1,5 +1,7 @@
 # Phase 4 Enhancement Requests — Phase 8 Candidates
 
+> **Tracked in [#6](https://github.com/JimmyCapps/zentropy/issues/6) — see issue for current status.** This document holds the design rationale and architectural sketches that don't fit cleanly in an issue body. Issue #6 is the canonical place for status, prioritisation, and discussion. Per the convention in `CONTRIBUTING.md` §Issue-tracked design docs.
+
 Two enhancement ideas captured during Phase 4 Stage 4D, not in scope for
 Phase 4 but worth tracking for Phase 8 or dedicated follow-on work.
 


### PR DESCRIPTION
## Summary

- Per #33 decision (Option B): GitHub issues are canonical for backlog items, status, prioritisation, and discussion.
- Per-issue documents at `docs/issues/<N>-<slug>.md` hold rich design content (architectural sketches, trade-off tables) that doesn't fit in an issue body.
- Applies the convention to the existing backlog: `docs/backlog/phase4-enhancement-requests.md` → `docs/issues/6-phase4-enhancements.md`.

Closes #33

## Approach

**Why this convention.** Issue #6 already tracks the two Phase 4 enhancement candidates (delta-cache + turboquant). The markdown backlog file held the rich design rationale (architectural sketches, Cloudflare/IndexedDB trade-off tables, paths-to-adopt analysis) that's hard to read inside a GitHub issue comment. Without an explicit relationship, the two could drift independently — exactly the drift #33 was filed to fix.

**The new shape.** GitHub stays the entry point for everything coordination-related. The per-issue doc is just the design appendix that's too long for an issue body.

**File naming.** `docs/issues/<issue-number>-<short-slug>.md`. Examples:
- `docs/issues/6-phase4-enhancements.md` (this PR)
- `docs/issues/9-image-injection-probe.md` (future, when #9's design needs sketching)

**When NOT to create one** — codified in CONTRIBUTING.md so future contributors don't reflexively write a doc per issue:
- Design fits in 2-3 paragraphs → keep in issue body.
- Doc would just restate what the issue already says → keep in issue body.

## Impact

- 1 file renamed (`docs/backlog/...` → `docs/issues/6-phase4-enhancements.md`); empty `docs/backlog/` directory removed.
- README.md inbound link updated: now points at issue #6 first, the per-issue doc second.
- The per-issue doc gets a header admonition explicitly stating: \"Tracked in #6 — see issue for current status.\"
- CONTRIBUTING.md gains a new \"Issue-tracked design docs\" section.

No content lost — the moved file is byte-identical apart from the new header admonition.

## Test plan

- [x] `git push` pre-push hook green (typecheck + test + build)
- [x] No code changes — CI runs for consistency
- [x] No remaining `docs/backlog` references in any tracked file (`grep -rn docs/backlog --include='*.md' --include='*.ts'` returns empty)
- [x] Convention codified in CONTRIBUTING.md so future contributors don't have to derive it
- [ ] CI green on the PR

## Risk / rollback

Zero runtime risk. Rollback: `git revert` restores `docs/backlog/`. The renamed file is preserved as a rename in git history so blame doesn't reset.

## Coordination notes

PR #35 also touches `README.md` (different lines: 24 path leak + 33 chunk-size + tech-stack section). I checked the diff — no overlap with the line this PR touches (line 20). Both can squash-merge in any order.