### PR TITLE
docs(#34): qualify README memory requirement with claude-mem observations

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,11 @@ Then load the extension in Chrome:
 
 - Chrome 113+ (WebGPU support required)
 - GPU with WebGPU capability
-- ~2 GB free memory for model inference
+- Free memory for model inference — observed footprints from Phase 4 live-analysis sessions:
+  - **Gemma-2-2b** (primary canary): ~1.5 GB resident during warm inference.
+  - **Qwen2.5-0.5B** (fast-path fallback): smaller but un-measured at the time of writing.
+  - **Gemini Nano** (EPP-only): host-managed by Chrome; no extension-visible footprint to declare.
+  - System-level: sustained multi-tab sessions with Chrome orphan processes from prior runs pushed the test machine to 81% swap utilisation during Phase 4C, so plan for headroom beyond the model weights themselves. Re-measurement is deferred (#34) — numbers will firm up once Phase 4 is fully stable.
 
 ## Development
 


### PR DESCRIPTION
## Summary

- Per #34 decision (Option A with deferred re-measurement): replace the unqualified \"~2 GB\" claim with observed footprints from prior live-analysis sessions.
- Re-measurement is deferred until Phase 4 is fully stable — iterating now would invite more re-runs in the short term. Cross-links #34 inline so the deferred work is discoverable from the README itself.

Closes #34

## Approach

Sourced from claude-mem session history rather than a fresh measurement run:

| Canary | Observed footprint | Source |
|---|---|---|
| Gemma-2-2b (primary) | ~1.5 GB resident during warm inference | obs #2292 (Phase 4 enhancement session, 2026-04-17) |
| Qwen2.5-0.5B (fast-path) | smaller but un-measured | honest gap — avoided inventing a number |
| Gemini Nano (EPP-only) | host-managed by Chrome | no extension-visible footprint to declare |
| System-level | 81% swap utilisation during sustained multi-tab Phase 4C test sessions | obs #2206 |

The new wording acknowledges the per-canary variation the previous single \"~2 GB\" number obscured, and flags that real-world headroom exceeds model weights alone (Chrome orphans, other tabs, offscreen doc overhead).

## Impact

README-only change; 1 file, +5/-1 lines. PR #35 also touches README.md but at different lines (21/28/155/182) — no conflict with the line 109-111 edit here.

## Test plan

- [x] `git push` pre-push hook green (typecheck + test + build)
- [x] No code changes — CI runs for consistency
- [x] Cross-link to #34 resolves (the deferred-re-measurement follow-up stays discoverable)
- [ ] CI green on the PR

## Risk / rollback

Zero runtime risk. Rollback: `git revert`. Numbers are historical observations from committed claude-mem memory, not freshly derived, so they don't go stale in the normal \"code changed\" sense — only when Phase 4 stabilises and someone runs a fresh sweep.

## Coordination notes

Fourth and final PR in the #30 follow-up cycle:
- PR #36 closed #31 (session-launch prompts removed)
- PR #37 closed #32 (report-fork convention applied)
- PR #38 closed #33 (backlog migrated to GitHub canonical)
- This PR closes #34

All four touch docs only, no overlapping line ranges, squash-mergeable in any order.