### PR TITLE
feat(#20): per-origin scan policy — deny-list + user overrides

### DIFF
--- a/src/policy/origin-policy.test.ts
+++ b/src/policy/origin-policy.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveOriginPolicy,
+  extractHost,
+  describeDecision,
+  DEFAULT_DENY_LIST,
+  type OverrideMap,
+} from './origin-policy.js';
+
+describe('extractHost', () => {
+  it('returns the hostname from a full URL', () => {
+    expect(extractHost('https://mail.google.com/inbox')).toBe('mail.google.com');
+  });
+
+  it('lowercases the host', () => {
+    expect(extractHost('https://Mail.Google.COM/')).toBe('mail.google.com');
+  });
+
+  it('strips port from a bare host', () => {
+    expect(extractHost('localhost:3000')).toBe('localhost');
+  });
+
+  it('accepts a bare host verbatim (except case)', () => {
+    expect(extractHost('example.com')).toBe('example.com');
+    expect(extractHost('EXAMPLE.COM')).toBe('example.com');
+  });
+
+  it('returns null for empty or whitespace-only input', () => {
+    expect(extractHost('')).toBeNull();
+    expect(extractHost('   ')).toBeNull();
+  });
+
+  it('returns null for unparseable URL with scheme', () => {
+    expect(extractHost('https://')).toBeNull();
+  });
+
+  it('handles tolerant URL parser quirks (https:///path → "path")', () => {
+    // Node's URL treats https:///path as https://path/. Not our problem to
+    // second-guess: the parser says this is a hostname, we return it.
+    expect(extractHost('https:///path')).toBe('path');
+  });
+
+  it('handles chrome:// URLs', () => {
+    expect(extractHost('chrome://extensions/')).toBe('extensions');
+  });
+});
+
+describe('resolveOriginPolicy — default deny-list', () => {
+  it('skips Gmail by exact match', () => {
+    const decision = resolveOriginPolicy('mail.google.com');
+    expect(decision.action).toBe('skip');
+    expect(decision.reason).toBe('deny_list_match');
+    expect(decision.matchedRule).toBe('Gmail');
+  });
+
+  it('skips a subdomain of a subdomain-rule host', () => {
+    const decision = resolveOriginPolicy('support.1password.com');
+    expect(decision.action).toBe('skip');
+    expect(decision.matchedRule).toBe('1Password');
+  });
+
+  it('skips the exact parent of a subdomain rule (e.g. chase.com itself)', () => {
+    const decision = resolveOriginPolicy('chase.com');
+    expect(decision.action).toBe('skip');
+    expect(decision.matchedRule).toBe('Chase');
+  });
+
+  it('skips via suffix rule', () => {
+    const decision = resolveOriginPolicy('account.proton.me');
+    expect(decision.action).toBe('skip');
+    expect(decision.reason).toBe('deny_list_match');
+  });
+
+  it('scans origins not in the deny-list', () => {
+    const decision = resolveOriginPolicy('example.com');
+    expect(decision.action).toBe('scan');
+    expect(decision.reason).toBe('default_scan');
+    expect(decision.matchedRule).toBeNull();
+  });
+
+  it('is case-insensitive on the input origin', () => {
+    const decision = resolveOriginPolicy('Mail.Google.COM');
+    expect(decision.action).toBe('skip');
+    expect(decision.matchedRule).toBe('Gmail');
+  });
+
+  it('accepts a full URL and extracts the host', () => {
+    const decision = resolveOriginPolicy('https://mail.google.com/mail/u/0/#inbox');
+    expect(decision.action).toBe('skip');
+  });
+
+  it('does NOT match a subdomain rule on an unrelated lookalike', () => {
+    // 'notchase.com' ends with 'chase.com' textually but is a different
+    // registrable domain — subdomain rule should not match.
+    const decision = resolveOriginPolicy('notchase.com');
+    expect(decision.action).toBe('scan');
+  });
+});
+
+describe('resolveOriginPolicy — user overrides', () => {
+  it('user "skip" beats default scan', () => {
+    const overrides: OverrideMap = { 'example.com': 'skip' };
+    const decision = resolveOriginPolicy('example.com', overrides);
+    expect(decision.action).toBe('skip');
+    expect(decision.reason).toBe('user_override_skip');
+  });
+
+  it('user "scan" beats deny-list match', () => {
+    const overrides: OverrideMap = { 'mail.google.com': 'scan' };
+    const decision = resolveOriginPolicy('mail.google.com', overrides);
+    expect(decision.action).toBe('scan');
+    expect(decision.reason).toBe('user_override_scan');
+    expect(decision.matchedRule).toBeNull();
+  });
+
+  it('override is keyed by exact host; does not apply to subdomains', () => {
+    const overrides: OverrideMap = { '1password.com': 'scan' };
+    // Override applies to 1password.com itself, but support.1password.com
+    // still matches the deny-list subdomain rule.
+    const decision = resolveOriginPolicy('support.1password.com', overrides);
+    expect(decision.action).toBe('skip');
+    expect(decision.reason).toBe('deny_list_match');
+  });
+
+  it('override lookup is case-insensitive', () => {
+    const overrides: OverrideMap = { 'example.com': 'skip' };
+    const decision = resolveOriginPolicy('EXAMPLE.COM', overrides);
+    expect(decision.action).toBe('skip');
+    expect(decision.reason).toBe('user_override_skip');
+  });
+});
+
+describe('resolveOriginPolicy — edge cases', () => {
+  it('empty origin resolves to default scan (fail-open)', () => {
+    const decision = resolveOriginPolicy('');
+    expect(decision.action).toBe('scan');
+    expect(decision.reason).toBe('default_scan');
+  });
+
+  it('custom empty deny-list means no origin is skipped by default', () => {
+    const decision = resolveOriginPolicy('mail.google.com', {}, []);
+    expect(decision.action).toBe('scan');
+    expect(decision.reason).toBe('default_scan');
+  });
+
+  it('localhost scans by default', () => {
+    const decision = resolveOriginPolicy('localhost');
+    expect(decision.action).toBe('scan');
+  });
+
+  it('chrome-extension URLs extract hostname and scan by default', () => {
+    const decision = resolveOriginPolicy('chrome-extension://abc123/popup.html');
+    expect(decision.action).toBe('scan');
+  });
+});
+
+describe('describeDecision', () => {
+  it('describes user-override scan', () => {
+    const decision = resolveOriginPolicy('mail.google.com', {
+      'mail.google.com': 'scan',
+    });
+    expect(describeDecision(decision)).toContain('you enabled');
+  });
+
+  it('describes user-override skip', () => {
+    const decision = resolveOriginPolicy('example.com', {
+      'example.com': 'skip',
+    });
+    expect(describeDecision(decision)).toContain('you disabled');
+  });
+
+  it('describes deny-list match with the matched rule label', () => {
+    const decision = resolveOriginPolicy('mail.google.com');
+    expect(describeDecision(decision)).toContain('Gmail');
+  });
+
+  it('describes default scan', () => {
+    const decision = resolveOriginPolicy('example.com');
+    expect(describeDecision(decision)).toBe('Scanning');
+  });
+});
+
+describe('DEFAULT_DENY_LIST integrity', () => {
+  it('has at least one entry (sanity check that we didn\'t ship an empty list)', () => {
+    expect(DEFAULT_DENY_LIST.length).toBeGreaterThan(0);
+  });
+
+  it('every entry has a non-empty label', () => {
+    for (const rule of DEFAULT_DENY_LIST) {
+      expect(rule.label.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every exact and suffix rule has a non-empty host/suffix', () => {
+    for (const rule of DEFAULT_DENY_LIST) {
+      if (rule.kind === 'exact') expect(rule.host.length).toBeGreaterThan(0);
+      if (rule.kind === 'suffix') expect(rule.suffix.length).toBeGreaterThan(0);
+      if (rule.kind === 'subdomain') expect(rule.parent.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/src/policy/origin-policy.ts
+++ b/src/policy/origin-policy.ts
@@ -1,0 +1,215 @@
+/**
+ * Per-origin scan policy (issue #20).
+ *
+ * Resolves the scan decision for a given page origin before any ingestion or
+ * probe work happens. The policy layer is pure and chrome-free so it can be
+ * unit-tested without the extension loaded.
+ *
+ * Resolution order (highest precedence first):
+ *   1. Explicit user override in `overrides` (`scan` or `skip`).
+ *   2. Built-in deny-list match (returns `skip`).
+ *   3. Default (returns `scan`).
+ *
+ * "Origin" here is the hostname portion (e.g. `mail.google.com`), not the
+ * full URL origin with scheme. This matches `PageSnapshot.metadata.origin`
+ * shape in practice — callers that receive full URLs should strip to host
+ * before passing in.
+ */
+
+export type ScanAction = 'scan' | 'skip';
+
+/**
+ * Decision returned by the resolver. `reason` distinguishes why a decision
+ * was reached, so the popup can show the user whether their override is
+ * active vs. a built-in rule is matching.
+ */
+export interface ScanDecision {
+  readonly action: ScanAction;
+  readonly reason:
+    | 'user_override_scan'
+    | 'user_override_skip'
+    | 'deny_list_match'
+    | 'default_scan';
+  /**
+   * When `reason` is `deny_list_match`, names the matching rule so the popup
+   * can surface "skipped because this looks like a banking domain". Null for
+   * other reasons.
+   */
+  readonly matchedRule: string | null;
+}
+
+type DenyRule =
+  | { readonly kind: 'exact'; readonly host: string; readonly label: string }
+  | { readonly kind: 'suffix'; readonly suffix: string; readonly label: string }
+  | { readonly kind: 'subdomain'; readonly parent: string; readonly label: string };
+
+/**
+ * Conservative default deny-list. Kept deliberately small — false-positive
+ * skips (scanning was actually desired) are high-friction to recover from
+ * since the user has to notice scanning isn't happening and toggle it on.
+ *
+ * Selection criteria:
+ *   - Overwhelmingly sensitive content.
+ *   - Low chance of a legitimate "I want HoneyLLM to scan this" scenario.
+ *   - Recognisable hostname pattern (don't rely on TLS cert metadata or
+ *     hand-curated lists of every bank in every region).
+ *
+ * Explicitly NOT included:
+ *   - Banking by TLD (`*.bank`): exists but rarely used; falls through to
+ *     explicit origins below. Users in regions with other conventions can
+ *     add their banks via the override UI.
+ *   - `*.gov` / `*.health`: too broad — includes public-information sites
+ *     (`nhs.uk/conditions/*`, `usa.gov/*`) that are reasonable to scan.
+ *     Users who need them can add explicit skips.
+ *
+ * Rationale for each entry is captured in the `label`.
+ */
+export const DEFAULT_DENY_LIST: readonly DenyRule[] = [
+  // Email — private correspondence.
+  { kind: 'exact', host: 'mail.google.com', label: 'Gmail' },
+  { kind: 'exact', host: 'outlook.live.com', label: 'Outlook (personal)' },
+  { kind: 'exact', host: 'outlook.office365.com', label: 'Outlook (work)' },
+  { kind: 'exact', host: 'outlook.office.com', label: 'Outlook (work alt)' },
+  { kind: 'suffix', suffix: '.proton.me', label: 'Proton Mail' },
+  { kind: 'exact', host: 'mail.proton.me', label: 'Proton Mail' },
+  { kind: 'exact', host: 'app.fastmail.com', label: 'Fastmail' },
+
+  // Password managers.
+  { kind: 'exact', host: 'vault.bitwarden.com', label: 'Bitwarden vault' },
+  { kind: 'subdomain', parent: '1password.com', label: '1Password' },
+  { kind: 'subdomain', parent: 'lastpass.com', label: 'LastPass' },
+  { kind: 'exact', host: 'app.dashlane.com', label: 'Dashlane' },
+
+  // Major banking origins (sample — users extend via override UI).
+  { kind: 'subdomain', parent: 'chase.com', label: 'Chase' },
+  { kind: 'subdomain', parent: 'bankofamerica.com', label: 'Bank of America' },
+  { kind: 'subdomain', parent: 'wellsfargo.com', label: 'Wells Fargo' },
+  { kind: 'subdomain', parent: 'barclays.co.uk', label: 'Barclays' },
+  { kind: 'subdomain', parent: 'hsbc.com', label: 'HSBC' },
+  { kind: 'subdomain', parent: 'commbank.com.au', label: 'Commonwealth Bank' },
+  { kind: 'subdomain', parent: 'anz.com.au', label: 'ANZ' },
+  { kind: 'subdomain', parent: 'westpac.com.au', label: 'Westpac' },
+  { kind: 'subdomain', parent: 'nab.com.au', label: 'NAB' },
+
+  // Health portals with obvious patterns.
+  { kind: 'subdomain', parent: 'myhealthrecord.gov.au', label: 'My Health Record (AU)' },
+  { kind: 'subdomain', parent: 'mymedicare.gov', label: 'Medicare (US)' },
+  { kind: 'subdomain', parent: 'nhs.uk', label: 'NHS login area' },
+
+  // Government auth portals (login-only; public-info *.gov sites excluded
+  // on purpose — too broad).
+  { kind: 'subdomain', parent: 'my.gov.au', label: 'myGov (AU)' },
+  { kind: 'subdomain', parent: 'login.gov', label: 'login.gov (US)' },
+];
+
+/**
+ * User-defined overrides, keyed by exact hostname. Values override the
+ * deny-list; `scan` forces scanning even if a rule matches, `skip` forces
+ * skipping even if nothing matches.
+ */
+export type OverrideMap = Readonly<Record<string, ScanAction>>;
+
+/**
+ * Case-insensitive, handles leading dot on suffix rules, handles exact
+ * subdomain parent match too (so `parent: 'chase.com'` matches both
+ * `chase.com` and `banking.chase.com`).
+ */
+function hostMatchesRule(host: string, rule: DenyRule): boolean {
+  const normalised = host.toLowerCase();
+  switch (rule.kind) {
+    case 'exact':
+      return normalised === rule.host.toLowerCase();
+    case 'suffix':
+      return normalised.endsWith(rule.suffix.toLowerCase());
+    case 'subdomain': {
+      const parent = rule.parent.toLowerCase();
+      return normalised === parent || normalised.endsWith(`.${parent}`);
+    }
+  }
+}
+
+function findMatchingRule(host: string, rules: readonly DenyRule[]): DenyRule | null {
+  for (const rule of rules) {
+    if (hostMatchesRule(host, rule)) return rule;
+  }
+  return null;
+}
+
+/**
+ * Resolve whether a given origin should be scanned.
+ *
+ * `origin` accepts either a bare hostname (`example.com`) or a full URL;
+ * URLs have scheme + path + query stripped. Unparseable or empty values
+ * resolve to `scan` / `default_scan` — failing open is the safer default
+ * because a missing origin usually means a local-file or internal URL
+ * where scan/skip is academic.
+ */
+export function resolveOriginPolicy(
+  origin: string,
+  overrides: OverrideMap = {},
+  denyList: readonly DenyRule[] = DEFAULT_DENY_LIST,
+): ScanDecision {
+  const host = extractHost(origin);
+  if (host === null) {
+    return { action: 'scan', reason: 'default_scan', matchedRule: null };
+  }
+
+  const override = overrides[host.toLowerCase()];
+  if (override === 'scan') {
+    return { action: 'scan', reason: 'user_override_scan', matchedRule: null };
+  }
+  if (override === 'skip') {
+    return { action: 'skip', reason: 'user_override_skip', matchedRule: null };
+  }
+
+  const matched = findMatchingRule(host, denyList);
+  if (matched !== null) {
+    return {
+      action: 'skip',
+      reason: 'deny_list_match',
+      matchedRule: matched.label,
+    };
+  }
+
+  return { action: 'scan', reason: 'default_scan', matchedRule: null };
+}
+
+/**
+ * Extract the hostname from either a bare host or a full URL. Returns null
+ * for genuinely empty input so the caller can short-circuit — we never
+ * return a malformed host string that could hash-collide with a legitimate
+ * one in the override map.
+ */
+export function extractHost(value: string): string | null {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return null;
+  if (!trimmed.includes('://')) {
+    // Already a bare host; strip port if present.
+    return trimmed.split(':')[0]!.toLowerCase();
+  }
+  try {
+    const url = new URL(trimmed);
+    return url.hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Convenience for the popup: gives the human-readable label of the current
+ * policy state. Consumed by the "This site" card.
+ */
+export function describeDecision(decision: ScanDecision): string {
+  switch (decision.reason) {
+    case 'user_override_scan':
+      return 'Scanning (you enabled it for this site)';
+    case 'user_override_skip':
+      return 'Not scanning (you disabled it for this site)';
+    case 'deny_list_match':
+      return decision.matchedRule !== null
+        ? `Not scanning (default: ${decision.matchedRule})`
+        : 'Not scanning (default)';
+    case 'default_scan':
+      return 'Scanning';
+  }
+}

--- a/src/policy/origin-storage.test.ts
+++ b/src/policy/origin-storage.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { getOverrides, setOverride, clearOverride } from './origin-storage.js';
+import { STORAGE_KEY_ORIGIN_OVERRIDES } from '@/shared/constants.js';
+
+interface ChromeStub {
+  storage: {
+    sync: {
+      get: (key: string) => Promise<Record<string, unknown>>;
+      set: (items: Record<string, unknown>) => Promise<void>;
+    };
+  };
+}
+
+function stubChrome(initial: Record<string, unknown> = {}): {
+  readStore: () => Record<string, unknown>;
+} {
+  const store: Record<string, unknown> = { ...initial };
+  const chromeStub: ChromeStub = {
+    storage: {
+      sync: {
+        get: async (key) => (key in store ? { [key]: store[key] } : {}),
+        set: async (items) => {
+          Object.assign(store, items);
+        },
+      },
+    },
+  };
+  vi.stubGlobal('chrome', chromeStub);
+  return { readStore: () => store };
+}
+
+describe('origin-storage', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('getOverrides', () => {
+    it('returns empty object when key is absent', async () => {
+      stubChrome();
+      expect(await getOverrides()).toEqual({});
+    });
+
+    it('returns stored overrides', async () => {
+      stubChrome({
+        [STORAGE_KEY_ORIGIN_OVERRIDES]: {
+          'example.com': 'skip',
+          'mail.google.com': 'scan',
+        },
+      });
+      expect(await getOverrides()).toEqual({
+        'example.com': 'skip',
+        'mail.google.com': 'scan',
+      });
+    });
+
+    it('filters garbage values (only "scan" and "skip" are accepted)', async () => {
+      stubChrome({
+        [STORAGE_KEY_ORIGIN_OVERRIDES]: {
+          'valid.com': 'skip',
+          'nonsense.com': 'maybe',
+          'numeric.com': 1,
+          'nested.com': { obj: true },
+        },
+      });
+      expect(await getOverrides()).toEqual({ 'valid.com': 'skip' });
+    });
+
+    it('normalises keys to lowercase', async () => {
+      stubChrome({
+        [STORAGE_KEY_ORIGIN_OVERRIDES]: { 'Example.COM': 'skip' },
+      });
+      expect(await getOverrides()).toEqual({ 'example.com': 'skip' });
+    });
+
+    it('returns empty when stored value is not an object', async () => {
+      stubChrome({ [STORAGE_KEY_ORIGIN_OVERRIDES]: 'not-an-object' });
+      expect(await getOverrides()).toEqual({});
+    });
+
+    it('returns empty when stored value is null', async () => {
+      stubChrome({ [STORAGE_KEY_ORIGIN_OVERRIDES]: null });
+      expect(await getOverrides()).toEqual({});
+    });
+  });
+
+  describe('setOverride', () => {
+    it('writes a new override under the lowercased host', async () => {
+      const { readStore } = stubChrome();
+      await setOverride('Example.COM', 'skip');
+      expect(readStore()[STORAGE_KEY_ORIGIN_OVERRIDES]).toEqual({
+        'example.com': 'skip',
+      });
+    });
+
+    it('preserves existing overrides when adding a new one', async () => {
+      const { readStore } = stubChrome({
+        [STORAGE_KEY_ORIGIN_OVERRIDES]: { 'a.com': 'skip' },
+      });
+      await setOverride('b.com', 'scan');
+      expect(readStore()[STORAGE_KEY_ORIGIN_OVERRIDES]).toEqual({
+        'a.com': 'skip',
+        'b.com': 'scan',
+      });
+    });
+
+    it('overwrites an existing override for the same host', async () => {
+      const { readStore } = stubChrome({
+        [STORAGE_KEY_ORIGIN_OVERRIDES]: { 'example.com': 'skip' },
+      });
+      await setOverride('example.com', 'scan');
+      expect(readStore()[STORAGE_KEY_ORIGIN_OVERRIDES]).toEqual({
+        'example.com': 'scan',
+      });
+    });
+
+    it('extracts hostname from a full URL', async () => {
+      const { readStore } = stubChrome();
+      await setOverride('https://mail.google.com/mail/u/0/#inbox', 'scan');
+      expect(readStore()[STORAGE_KEY_ORIGIN_OVERRIDES]).toEqual({
+        'mail.google.com': 'scan',
+      });
+    });
+
+    it('silently ignores unparseable origins', async () => {
+      const { readStore } = stubChrome();
+      await setOverride('', 'skip');
+      expect(readStore()[STORAGE_KEY_ORIGIN_OVERRIDES]).toBeUndefined();
+    });
+  });
+
+  describe('clearOverride', () => {
+    it('removes a stored override', async () => {
+      const { readStore } = stubChrome({
+        [STORAGE_KEY_ORIGIN_OVERRIDES]: {
+          'a.com': 'skip',
+          'b.com': 'scan',
+        },
+      });
+      await clearOverride('a.com');
+      expect(readStore()[STORAGE_KEY_ORIGIN_OVERRIDES]).toEqual({ 'b.com': 'scan' });
+    });
+
+    it('is a no-op when the origin has no override', async () => {
+      const { readStore } = stubChrome({
+        [STORAGE_KEY_ORIGIN_OVERRIDES]: { 'a.com': 'skip' },
+      });
+      await clearOverride('nonexistent.com');
+      expect(readStore()[STORAGE_KEY_ORIGIN_OVERRIDES]).toEqual({ 'a.com': 'skip' });
+    });
+
+    it('accepts a full URL', async () => {
+      const { readStore } = stubChrome({
+        [STORAGE_KEY_ORIGIN_OVERRIDES]: { 'mail.google.com': 'scan' },
+      });
+      await clearOverride('https://mail.google.com/foo');
+      expect(readStore()[STORAGE_KEY_ORIGIN_OVERRIDES]).toEqual({});
+    });
+
+    it('silently ignores unparseable origins', async () => {
+      const { readStore } = stubChrome({
+        [STORAGE_KEY_ORIGIN_OVERRIDES]: { 'a.com': 'skip' },
+      });
+      await clearOverride('');
+      expect(readStore()[STORAGE_KEY_ORIGIN_OVERRIDES]).toEqual({ 'a.com': 'skip' });
+    });
+  });
+});

--- a/src/policy/origin-storage.ts
+++ b/src/policy/origin-storage.ts
@@ -1,0 +1,54 @@
+/**
+ * chrome.storage.sync wrapper for per-origin scan overrides (issue #20).
+ *
+ * Thin layer that isolates chrome.* calls so origin-policy.ts stays pure
+ * and unit-testable. All functions normalise the hostname to lowercase
+ * before reading/writing so lookup is order-independent with the
+ * resolver in origin-policy.ts.
+ */
+import { STORAGE_KEY_ORIGIN_OVERRIDES } from '@/shared/constants.js';
+import type { OverrideMap, ScanAction } from './origin-policy.js';
+import { extractHost } from './origin-policy.js';
+import { createLogger } from '@/shared/logger.js';
+
+const log = createLogger('OriginStorage');
+
+export async function getOverrides(): Promise<OverrideMap> {
+  const result = await chrome.storage.sync.get(STORAGE_KEY_ORIGIN_OVERRIDES);
+  const raw = result[STORAGE_KEY_ORIGIN_OVERRIDES];
+  if (raw === undefined || raw === null || typeof raw !== 'object') {
+    return {};
+  }
+  // Defensive: coerce only valid entries so stale/garbage storage values
+  // can't poison the resolver.
+  const clean: Record<string, ScanAction> = {};
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (value === 'scan' || value === 'skip') {
+      clean[key.toLowerCase()] = value;
+    }
+  }
+  return clean;
+}
+
+export async function setOverride(origin: string, action: ScanAction): Promise<void> {
+  const host = extractHost(origin);
+  if (host === null) {
+    log.warn(`Ignoring setOverride for unparseable origin: ${origin}`);
+    return;
+  }
+  const current = await getOverrides();
+  const next: Record<string, ScanAction> = { ...current, [host]: action };
+  await chrome.storage.sync.set({ [STORAGE_KEY_ORIGIN_OVERRIDES]: next });
+  log.info(`Override set: ${host} → ${action}`);
+}
+
+export async function clearOverride(origin: string): Promise<void> {
+  const host = extractHost(origin);
+  if (host === null) return;
+  const current = await getOverrides();
+  if (!(host in current)) return;
+  const next: Record<string, ScanAction> = { ...current };
+  delete next[host];
+  await chrome.storage.sync.set({ [STORAGE_KEY_ORIGIN_OVERRIDES]: next });
+  log.info(`Override cleared: ${host}`);
+}

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -151,6 +151,46 @@
     .avail-unavailable { background: #3a1a1a; color: #f87171; border: 1px solid #5a2d2d; }
     .avail-loaded { background: #1a1a3a; color: #818cf8; border: 1px solid #2d2d5a; }
     .avail-checking { background: #262626; color: #9ca3af; border: 1px solid #404040; }
+    /* Issue #20 — per-site scan card. */
+    .site-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+      margin-bottom: 8px;
+    }
+    .site-host {
+      font-size: 13px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      color: #e0e0e0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      flex: 1;
+    }
+    .site-state {
+      font-size: 11px;
+      color: #9ca3af;
+      line-height: 1.4;
+    }
+    .scan-select {
+      background: #1f2937;
+      color: #e2e8f0;
+      border: 1px solid #374151;
+      border-radius: 6px;
+      font-size: 12px;
+      padding: 4px 6px;
+      cursor: pointer;
+    }
+    .scan-select:focus {
+      outline: none;
+      border-color: #60a5fa;
+    }
+    .skip-card {
+      background: #1e2330;
+      border: 1px solid #334155;
+    }
+    .skip-card h2 { color: #93c5fd; }
     .toast {
       position: fixed;
       bottom: 12px;
@@ -176,6 +216,19 @@
   <div id="loading">Analyzing page...</div>
 
   <div id="content" style="display: none;">
+    <div class="card" id="site-card" style="display: none;">
+      <h2>This site</h2>
+      <div class="site-row">
+        <span class="site-host" id="site-host">--</span>
+        <select class="scan-select" id="site-scan-select">
+          <option value="default">Default</option>
+          <option value="scan">Always scan</option>
+          <option value="skip">Never scan</option>
+        </select>
+      </div>
+      <div class="site-state" id="site-state">--</div>
+    </div>
+
     <div class="card error-card" id="error-card" style="display: none;">
       <h2>Analysis Status</h2>
       <div class="error-message" id="error-message"></div>

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -6,6 +6,17 @@ import {
   type CanaryId,
   type CanaryDefinition,
 } from '@/shared/constants.js';
+import {
+  resolveOriginPolicy,
+  describeDecision,
+  extractHost,
+  type ScanAction,
+} from '@/policy/origin-policy.js';
+import {
+  getOverrides,
+  setOverride,
+  clearOverride,
+} from '@/policy/origin-storage.js';
 
 interface StoredVerdict {
   status: string;
@@ -294,9 +305,13 @@ async function loadVerdict(): Promise<void> {
 
   // Phase 4 Stage 4A — surface analysisError so UNKNOWN verdicts (all probes
   // errored) and partial failures are visible instead of masquerading as CLEAN.
+  // Issue #20 — recognise the `origin_denied:` prefix so policy-skips don't
+  // read as engine failures. The per-site card already shows the skip reason
+  // in-context; here we just suppress the red "analysis incomplete" card.
   const errorCard = $('error-card');
   const errorMessageEl = $('error-message');
-  if (verdict.analysisError) {
+  const isOriginDenied = verdict.analysisError?.startsWith('origin_denied:') ?? false;
+  if (verdict.analysisError && !isOriginDenied) {
     errorCard.style.display = 'block';
     errorMessageEl.textContent = verdict.status === 'UNKNOWN'
       ? `Analysis incomplete: ${verdict.analysisError}`
@@ -343,7 +358,75 @@ async function loadVerdict(): Promise<void> {
   $('timestamp-info').textContent = `Last analyzed: ${date.toLocaleString()} | ${verdict.url}`;
 }
 
+/**
+ * Issue #20 — per-site scan card. Resolves the current tab's host against
+ * user overrides + the built-in deny-list, renders a three-way selector,
+ * and persists changes via origin-storage. Scan state takes effect on the
+ * tab's next PAGE_SNAPSHOT (reload, navigation, or keepalive wake) — a
+ * toast makes that clear so the user isn't surprised by the tab's current
+ * verdict not updating instantly.
+ */
+async function initSiteCard(): Promise<void> {
+  const card = $('site-card');
+  const hostEl = $('site-host');
+  const stateEl = $('site-state');
+  const select = $('site-scan-select') as HTMLSelectElement;
+
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  if (!tab?.url) {
+    return; // no active tab / internal page
+  }
+  const host = extractHost(tab.url);
+  if (host === null || host === '' || host === 'extensions' || host === 'newtab') {
+    // Internal Chrome pages (chrome://, newtab) have no meaningful origin
+    // policy. Keep the card hidden.
+    return;
+  }
+
+  card.style.display = 'block';
+  hostEl.textContent = host;
+
+  const overrides = await getOverrides();
+  const decision = resolveOriginPolicy(host, overrides);
+  stateEl.textContent = describeDecision(decision);
+
+  const current = overrides[host];
+  select.value = current ?? 'default';
+
+  select.addEventListener('change', () => {
+    void (async () => {
+      const choice = select.value as 'default' | ScanAction;
+      try {
+        if (choice === 'default') {
+          await clearOverride(host);
+          showToast('Using default policy — applies on next page load');
+        } else {
+          await setOverride(host, choice);
+          showToast(
+            choice === 'skip'
+              ? 'Never scanning this site — applies on next page load'
+              : 'Always scanning this site — applies on next page load',
+          );
+        }
+        // Re-describe so the user sees the updated state immediately even
+        // though the actual scan behaviour only changes on next navigation.
+        const refreshedOverrides = await getOverrides();
+        const refreshed = resolveOriginPolicy(host, refreshedOverrides);
+        stateEl.textContent = describeDecision(refreshed);
+      } catch (err) {
+        showToast('Failed to save site preference');
+        console.error('site override persist failed', err);
+      }
+    })();
+  });
+}
+
 void (async () => {
+  try {
+    await initSiteCard();
+  } catch (err) {
+    console.error('site card init failed', err);
+  }
   try {
     await initCanarySelector();
   } catch (err) {

--- a/src/service-worker/orchestrator.test.ts
+++ b/src/service-worker/orchestrator.test.ts
@@ -1,5 +1,26 @@
 import { describe, it, expect } from 'vitest';
-import { mergeErrors } from './orchestrator.js';
+import { mergeErrors, buildOriginSkippedVerdict } from './orchestrator.js';
+import type { PageSnapshot } from '@/types/snapshot.js';
+
+function snapshotFixture(overrides: Partial<PageSnapshot['metadata']> = {}): PageSnapshot {
+  return {
+    visibleText: '',
+    hiddenText: '',
+    scriptFingerprints: [],
+    metadata: {
+      title: 'Test',
+      url: 'https://example.com/',
+      origin: 'example.com',
+      description: '',
+      ogTags: new Map<string, string>(),
+      cspMeta: null,
+      lang: 'en',
+      ...overrides,
+    },
+    extractedAt: 1_700_000_000_000,
+    charCount: 0,
+  };
+}
 
 describe('mergeErrors (Phase 4 Stage 4B)', () => {
   it('returns null when both inputs are null', () => {
@@ -20,5 +41,79 @@ describe('mergeErrors (Phase 4 Stage 4B)', () => {
     expect(
       mergeErrors('partial probe failure: summarization', 'chunk_count_capped (6 chunks → kept first 4)'),
     ).toBe('partial probe failure: summarization; chunk_count_capped (6 chunks → kept first 4)');
+  });
+});
+
+describe('buildOriginSkippedVerdict (issue #20)', () => {
+  it('produces UNKNOWN status with zero confidence and zero score', () => {
+    const verdict = buildOriginSkippedVerdict(
+      snapshotFixture({ url: 'https://mail.google.com/inbox' }),
+      'Gmail',
+      'deny_list_match',
+    );
+    expect(verdict.status).toBe('UNKNOWN');
+    expect(verdict.confidence).toBe(0);
+    expect(verdict.totalScore).toBe(0);
+  });
+
+  it('stamps analysisError with origin_denied prefix + rule label for deny-list match', () => {
+    const verdict = buildOriginSkippedVerdict(
+      snapshotFixture({ url: 'https://mail.google.com/' }),
+      'Gmail',
+      'deny_list_match',
+    );
+    expect(verdict.analysisError).toBe('origin_denied: default deny-list (Gmail)');
+  });
+
+  it('stamps analysisError without rule label when matchedRule is null', () => {
+    const verdict = buildOriginSkippedVerdict(
+      snapshotFixture(),
+      null,
+      'deny_list_match',
+    );
+    expect(verdict.analysisError).toBe('origin_denied: default deny-list');
+  });
+
+  it('stamps analysisError with "user override" marker for user-skip', () => {
+    const verdict = buildOriginSkippedVerdict(
+      snapshotFixture(),
+      null,
+      'user_override_skip',
+    );
+    expect(verdict.analysisError).toBe('origin_denied: user override');
+  });
+
+  it('carries the snapshot URL through to the verdict', () => {
+    const verdict = buildOriginSkippedVerdict(
+      snapshotFixture({ url: 'https://mail.google.com/mail/u/0/#inbox' }),
+      'Gmail',
+      'deny_list_match',
+    );
+    expect(verdict.url).toBe('https://mail.google.com/mail/u/0/#inbox');
+  });
+
+  it('has empty probeResults and default-false behavioralFlags', () => {
+    const verdict = buildOriginSkippedVerdict(
+      snapshotFixture(),
+      'Gmail',
+      'deny_list_match',
+    );
+    expect(verdict.probeResults).toEqual([]);
+    expect(verdict.behavioralFlags).toEqual({
+      roleDrift: false,
+      exfiltrationIntent: false,
+      instructionFollowing: false,
+      hiddenContentAwareness: false,
+    });
+    expect(verdict.mitigationsApplied).toEqual([]);
+  });
+
+  it('leaves canaryId null (no canary was consulted)', () => {
+    const verdict = buildOriginSkippedVerdict(
+      snapshotFixture(),
+      'Gmail',
+      'deny_list_match',
+    );
+    expect(verdict.canaryId).toBeNull();
   });
 });

--- a/src/service-worker/orchestrator.ts
+++ b/src/service-worker/orchestrator.ts
@@ -8,6 +8,8 @@ import { connectOffscreenPort } from './keepalive.js';
 import { analyzeBehavior } from '@/analysis/behavioral-analyzer.js';
 import { evaluatePolicy } from '@/policy/engine.js';
 import { persistVerdict } from '@/policy/storage.js';
+import { resolveOriginPolicy } from '@/policy/origin-policy.js';
+import { getOverrides } from '@/policy/origin-storage.js';
 
 const log = createLogger('Orchestrator');
 
@@ -53,10 +55,67 @@ function buildAnalysisText(snapshot: PageSnapshot): string {
   return parts.filter(Boolean).join('\n');
 }
 
+/**
+ * Build the synthetic "skipped by policy" verdict (issue #20). No probes run,
+ * no offscreen document is touched. The verdict shape remains compatible with
+ * the existing pipeline (toolbar icon, persisted storage, popup read path)
+ * but carries a prefix on `analysisError` that the popup can detect to
+ * distinguish policy-skip from engine-failure UNKNOWN.
+ */
+export function buildOriginSkippedVerdict(
+  snapshot: PageSnapshot,
+  matchedRule: string | null,
+  reason: 'user_override_skip' | 'deny_list_match',
+): SecurityVerdict {
+  const errorSuffix = reason === 'user_override_skip'
+    ? 'user override'
+    : matchedRule !== null
+      ? `default deny-list (${matchedRule})`
+      : 'default deny-list';
+  return {
+    status: 'UNKNOWN',
+    confidence: 0,
+    totalScore: 0,
+    probeResults: [],
+    behavioralFlags: {
+      roleDrift: false,
+      exfiltrationIntent: false,
+      instructionFollowing: false,
+      hiddenContentAwareness: false,
+    },
+    mitigationsApplied: [],
+    timestamp: Date.now(),
+    url: snapshot.metadata.url,
+    analysisError: `origin_denied: ${errorSuffix}`,
+    canaryId: null,
+  };
+}
+
 export async function analyzeSnapshot(
   tabId: number,
   snapshot: PageSnapshot,
 ): Promise<SecurityVerdict> {
+  // Issue #20 — short-circuit before any ingestion or offscreen work if the
+  // origin is on the deny-list or explicitly skipped by the user. Persisting
+  // the synthetic verdict means the popup + toolbar icon still have a signal
+  // for the tab; they can detect the `origin_denied:` prefix on
+  // analysisError to render the right UI state.
+  const overrides = await getOverrides();
+  const policy = resolveOriginPolicy(snapshot.metadata.origin, overrides);
+  if (policy.action === 'skip') {
+    log.info(
+      `Skipping analysis for ${snapshot.metadata.url} (${policy.reason}${policy.matchedRule ? `: ${policy.matchedRule}` : ''})`,
+    );
+    // `user_override_skip` and `deny_list_match` are the only two reasons
+    // that resolve to 'skip'; the type system guarantees this but narrow
+    // explicitly so buildOriginSkippedVerdict gets the right literal type.
+    const reason =
+      policy.reason === 'user_override_skip' ? 'user_override_skip' : 'deny_list_match';
+    const verdict = buildOriginSkippedVerdict(snapshot, policy.matchedRule, reason);
+    await persistVerdict(verdict);
+    return verdict;
+  }
+
   log.info(`Starting analysis for ${snapshot.metadata.url}`);
 
   await ensureOffscreenDocument();

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -173,6 +173,14 @@ export const STORAGE_KEY_CANARY = 'honeyllm:canary';
  * or when the engine selector runs.
  */
 export const STORAGE_KEY_NANO_AVAILABILITY = 'honeyllm:nano-availability';
+/**
+ * Issue #20 — per-origin scan overrides. Stored in chrome.storage.sync so
+ * user's skip/scan preferences follow across devices. Value shape:
+ * `Record<hostname, 'scan' | 'skip'>`. Keyed by hostname (lowercased).
+ * Absent key means "no override" — resolution falls through to the built-in
+ * deny-list.
+ */
+export const STORAGE_KEY_ORIGIN_OVERRIDES = 'honeyllm:origin-overrides';
 
 // Test-only gate. When `chrome.storage.local[STORAGE_KEY_TEST_MODE]` is
 // strictly `true`, Phase 3 Track A handlers (`RUN_PROBES_DIRECT` in offscreen,


### PR DESCRIPTION
## Summary

- Adds a per-origin scan gate so sensitive sites (Gmail, banking, health portals, password managers) are skipped before any ingestion or probe work runs.
- Users can override per-origin from a new \"This site\" card in the popup — three-way choice: Default / Always scan / Never scan.
- Fixes #12 out of the box: \`mail.google.com\` is in the ship deny-list, so Gmail content never reaches the probe pipeline on a fresh install.

Closes #20
Closes #12

## Approach

**Three layers, each isolated for testability:**

1. \`src/policy/origin-policy.ts\` — pure resolver. Takes \`(origin, overrides)\`, returns \`{action, reason, matchedRule}\`. No chrome APIs. Three rule shapes: exact host, suffix match (e.g. \`.proton.me\`), subdomain tree (e.g. any \`*.chase.com\`). User override beats deny-list beats default.
2. \`src/policy/origin-storage.ts\` — chrome.storage.sync wrapper. Filters garbage values on read so corrupt sync state can't poison the resolver.
3. \`src/service-worker/orchestrator.ts\` — short-circuits \`analyzeSnapshot\` at the top when policy says skip. Synthesises an \`UNKNOWN\` verdict with \`analysisError: 'origin_denied: <reason>'\`.

**Why \`UNKNOWN\` + \`analysisError\` prefix instead of a new \`SKIPPED\` status.** Adding \`SKIPPED\` to \`SecurityStatus\` would ripple through the toolbar icon, content-script verdict handlers, \`AISecurityReport\`, and every callsite that switches on status. The prefix convention gives the popup everything it needs to distinguish policy-skip from engine-failure UNKNOWN without touching the type surface.

**Default deny-list choices.** Kept deliberately small — false-positive skips (scanning was actually desired) are high-friction to recover from. Selection criteria: overwhelmingly sensitive content, low chance of legitimate \"scan this\" scenarios, recognisable hostname pattern.

Explicitly *excluded*:
- \`*.gov\` / \`*.health\` (too broad — includes public-info sites like \`nhs.uk/conditions/*\`, \`usa.gov/*\`).
- Banks by TLD (\`*.bank\` exists but is rarely used).

Users in regions with other conventions add their banks via the override UI.

## Impact

### Files changed

| Category | Files |
|---|---|
| New pure modules | \`src/policy/origin-policy.{ts,test.ts}\` — 31 tests |
| New storage wrapper | \`src/policy/origin-storage.{ts,test.ts}\` — 15 tests |
| Orchestrator hook | \`src/service-worker/orchestrator.{ts,test.ts}\` — 7 new tests for \`buildOriginSkippedVerdict\` |
| Popup UI | \`src/popup/popup.html\` + \`popup.ts\` — new \"This site\" card |
| Constant | \`src/shared/constants.ts\` — \`STORAGE_KEY_ORIGIN_OVERRIDES\` |

### Test count

253 → 309 (+53 new tests across policy, storage, and orchestrator).

### User-visible changes

- Popup has a new \"This site\" card at the top showing the current host + three-way selector + state description.
- Sensitive sites auto-skip analysis on first install. Default deny-list covers: Gmail, Outlook, Proton Mail, Fastmail, Bitwarden, 1Password, LastPass, Dashlane, Chase, BoA, Wells Fargo, Barclays, HSBC, CommBank, ANZ, Westpac, NAB, My Health Record (AU), Medicare (US), NHS, myGov (AU), login.gov.
- Skipped pages still get a persisted verdict (\`UNKNOWN\` + \`origin_denied:\` marker) so the popup and toolbar icon have state for the tab.

### Not in scope

- No \"all overrides\" settings panel (list every per-origin preference with a clear button). Deferred until the need emerges — the per-site selector covers the 95% flow.
- No broader allow-list pattern (e.g. \"scan this whole subdomain tree\"). Current design is exact-host override — can revisit if users start wanting bulk operations.

## Test plan

- [x] \`npm run typecheck\` green
- [x] \`npm test\` green (309/309)
- [x] \`npm run build\` green
- [x] Pre-push hook green
- [ ] CI green on the PR
- [ ] **Manual verification** (deferred — user has the extension disabled):
  - Gmail tab → popup shows \"Not scanning (default: Gmail)\", toolbar icon UNKNOWN.
  - Set \"Always scan\" on Gmail → reload → verdict produced, icon reflects result.
  - Set \"Never scan\" on a normally-scanned site (example.com) → reload → skip path hit, no probes run.
  - Toggle back to \"Default\" → clears the override, deny-list result resumes.

## Risk / rollback

Low risk for default-scanning users (everyone not on the deny-list). Medium for users with sensitive sites in the deny-list — they lose scan coverage on those origins by default, which is exactly the point of this PR but represents a behaviour change.

Rollback: \`git revert\` restores the old behaviour. No schema / data migrations, no persisted state that would outlive the revert (overrides live in \`chrome.storage.sync\` under a new key; stale keys are harmless).

## Coordination notes

- Introduces a new \`docs/issues/\` pattern (convention from #33). This PR doesn't create one — the design fits in the PR body. If #20's scope grows to include the settings panel, that follow-up PR will spawn \`docs/issues/20-origin-deny-list.md\`.
- Touches popup, which was recently iterated in #22 / #23 / #28 / #29. No merge conflicts expected.