### PR TITLE
fix(phase4-#41): specify outputLanguage on Nano session.create

### DIFF
--- a/src/offscreen/engine.ts
+++ b/src/offscreen/engine.ts
@@ -44,6 +44,7 @@ interface NanoCreateOptions {
   readonly temperature?: number;
   readonly topK?: number;
   readonly expectedOutputs?: ReadonlyArray<{ type: 'text'; languages?: readonly string[] }>;
+  readonly outputLanguage?: string;
 }
 
 type NanoAvailability = 'unavailable' | 'downloadable' | 'downloading' | 'available';
@@ -218,9 +219,12 @@ async function createMlcEngineAdapter(modelId: string): Promise<CompletionEngine
  * validated by the Stage 4C manual harness. Sessions are cheap to create
  * and per-call isolation avoids cross-probe prompt leakage.
  *
- * `expectedOutputs: [{ type: 'text', languages: ['en'] }]` silences the
- * "No output language was specified" Chrome warning and gives the model
- * a hint about expected output shape.
+ * `outputLanguage: 'en'` is required by Chrome's updated Prompt API to
+ * silence the "No output language was specified" warning that fires from
+ * every `session.prompt(...)` call (see #41). `expectedOutputs.languages`
+ * is retained alongside it as an additional hint about output shape; the
+ * warning persists if `outputLanguage` is omitted even when
+ * `expectedOutputs.languages` is set.
  */
 async function createNanoEngineAdapter(modelId: string): Promise<CompletionEngine> {
   const api = getNanoApi();
@@ -248,6 +252,7 @@ async function createNanoEngineAdapter(modelId: string): Promise<CompletionEngin
         initialPrompts: [{ role: 'system', content: systemPrompt }],
         temperature: 0.1,
         topK: 3,
+        outputLanguage: 'en',
         expectedOutputs: [{ type: 'text', languages: ['en'] }],
       });
       try {


### PR DESCRIPTION
## Summary

- Adds `outputLanguage: 'en'` to `LanguageModel.create()` in the Nano adapter so Chrome's per-prompt warning stops firing.
- Updates the `NanoCreateOptions` structural type to declare the new field.
- Refreshes the docstring above `createNanoEngineAdapter` to explain why both `outputLanguage` and `expectedOutputs.languages` are now passed.

Closes #41

## Approach

Per the issue, the warning fires from every `session.prompt()` call even though `expectedOutputs.languages: ['en']` is set. Chrome's updated Prompt API treats `outputLanguage` as the authoritative output-language hint and only silences the warning when that field is present. `expectedOutputs.languages` is retained alongside it as a defensive secondary hint about output shape — they're not equivalent and the redundancy is cheap.

Scope kept to `src/offscreen/engine.ts:247-252` per the issue. The other call sites (`src/tests/phase3/builtin-probe.ts:52`, `src/tests/phase3/builtin-probe.test.ts:438`, `test-pages/phase4/nano-harness.ts:309`) are test/dev harnesses that don't run during real scans, and the issue scoped the finding to the production probe path. Happy to expand if you'd prefer a sweep — separate PR makes the rationale easier to audit.

No regression test added: `createNanoEngineAdapter` is module-private and would need to be exported (or refactored behind a test seam) to assert `api.create({...})` call shape. Adding either felt out of proportion to a one-line config fix. Manual verification at the offscreen DevTools console is the pragmatic regression signal.

## Impact

- Console noise gone — one Chrome warning per `session.prompt()` call previously, zero after this change.
- No behavioural change to probe verdicts, scoring, or runtime perf.
- No schema changes.

## Test plan

- [ ] \`npm run typecheck\` green (no \`any\`, structural type extended cleanly)
- [ ] \`npm test\` green (no test files touched)
- [ ] \`npm run build\` green
- [ ] Manual verification: load \`dist/\` as unpacked extension, force canary to \`chrome-builtin-gemini-nano\` via the popup radio, visit any page, open offscreen DevTools console, confirm the "No output language was specified" warning no longer fires.

I cannot run the local commands from my sandbox — I'd appreciate someone running the manual smoke from a real Chrome with Nano available, since the Phase 4C affected-baseline harness is the only path that actually exercises this code.

## Risk / rollback

Low risk, single-file change. \`outputLanguage\` is an optional structural-type field and an additive property on the create options object — older Chrome versions that don't recognise it should ignore it (the existing \`expectedOutputs.languages\` hint remains as fallback). Revert via \`git revert\` if Chrome ever changes the field name.