### PR TITLE
feat(phase4-#46): availability() options parity + download-progress monitor

### DIFF
--- a/src/offscreen/engine-constants.test.ts
+++ b/src/offscreen/engine-constants.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { NANO_CAPABILITY_OPTIONS } from './engine-constants.js';
+
+/**
+ * Regression guard for issue #46. The capability-options constant is the
+ * single source of truth passed to BOTH `LanguageModel.availability()` and
+ * `LanguageModel.create()`. Chrome rejects create() with NotSupportedError
+ * if the two calls diverge on modality/language, so these tests lock the
+ * contract shape.
+ *
+ * We don't exercise the adapter end-to-end here — `createNanoEngineAdapter`
+ * is module-private (can't mock `window.LanguageModel` without an export
+ * seam). The sibling PR for #41 made the same call. These tests pin the
+ * observable surface instead.
+ */
+describe('NANO_CAPABILITY_OPTIONS (issue #46)', () => {
+  it('declares both expectedInputs and expectedOutputs', () => {
+    expect(NANO_CAPABILITY_OPTIONS.expectedInputs).toBeDefined();
+    expect(NANO_CAPABILITY_OPTIONS.expectedOutputs).toBeDefined();
+  });
+
+  it('uses matching language arrays on both sides (avoids create() NotSupportedError)', () => {
+    const inputs = NANO_CAPABILITY_OPTIONS.expectedInputs ?? [];
+    const outputs = NANO_CAPABILITY_OPTIONS.expectedOutputs ?? [];
+    expect(inputs).toHaveLength(1);
+    expect(outputs).toHaveLength(1);
+    expect(inputs[0]!.languages).toEqual(outputs[0]!.languages);
+  });
+
+  it('declares text modality on both sides', () => {
+    const inputs = NANO_CAPABILITY_OPTIONS.expectedInputs ?? [];
+    const outputs = NANO_CAPABILITY_OPTIONS.expectedOutputs ?? [];
+    expect(inputs[0]!.type).toBe('text');
+    expect(outputs[0]!.type).toBe('text');
+  });
+
+  it('currently ships English-only (expand via #48 Language Detector)', () => {
+    const inputs = NANO_CAPABILITY_OPTIONS.expectedInputs ?? [];
+    expect(inputs[0]!.languages).toEqual(['en']);
+  });
+});

--- a/src/offscreen/engine-constants.ts
+++ b/src/offscreen/engine-constants.ts
@@ -1,0 +1,26 @@
+/**
+ * Engine constants split out so tests can import them without pulling the
+ * full `engine.ts` module (which transitively imports `@mlc-ai/web-llm` and
+ * can't load in a Node test environment).
+ */
+
+/**
+ * Shared shape for options passed to both `LanguageModel.availability()`
+ * and `LanguageModel.create()`. Declaring them once and spreading into
+ * both call sites is the contract that prevents the availability-vs-create
+ * NotSupportedError drift described in Chrome's
+ * `inform-users-of-model-download` guide.
+ */
+export interface NanoCapabilityOptions {
+  readonly expectedInputs?: ReadonlyArray<{ type: 'text'; languages?: readonly string[] }>;
+  readonly expectedOutputs?: ReadonlyArray<{ type: 'text'; languages?: readonly string[] }>;
+}
+
+/**
+ * Single source of truth passed to both `availability()` and `create()`.
+ * English-only as of issue #46; #48 will widen to detected page language.
+ */
+export const NANO_CAPABILITY_OPTIONS: NanoCapabilityOptions = {
+  expectedInputs: [{ type: 'text', languages: ['en'] }],
+  expectedOutputs: [{ type: 'text', languages: ['en'] }],
+};

--- a/src/offscreen/engine.ts
+++ b/src/offscreen/engine.ts
@@ -39,17 +39,37 @@ interface NanoSession {
   destroy(): void;
 }
 
-interface NanoCreateOptions {
+import { NANO_CAPABILITY_OPTIONS, type NanoCapabilityOptions } from './engine-constants.js';
+
+/**
+ * `downloadprogress` event + monitor callback shape. When Nano's underlying
+ * model isn't resident on-device yet, the first `create()` call triggers
+ * a download (potentially multi-GB). Chrome surfaces progress via the
+ * monitor callback; we forward each event as an ENGINE_STATUS message so
+ * the popup can render a download state instead of a silent "loading…".
+ * Issue #46.
+ */
+interface NanoMonitorEvent {
+  readonly loaded: number;
+}
+interface NanoMonitor {
+  addEventListener(
+    event: 'downloadprogress',
+    handler: (e: NanoMonitorEvent) => void,
+  ): void;
+}
+
+interface NanoCreateOptions extends NanoCapabilityOptions {
   readonly initialPrompts?: ReadonlyArray<{ role: 'system' | 'user' | 'assistant'; content: string }>;
   readonly temperature?: number;
   readonly topK?: number;
-  readonly expectedOutputs?: ReadonlyArray<{ type: 'text'; languages?: readonly string[] }>;
+  readonly monitor?: (m: NanoMonitor) => void;
 }
 
 type NanoAvailability = 'unavailable' | 'downloadable' | 'downloading' | 'available';
 
 interface NanoLanguageModel {
-  availability(): Promise<NanoAvailability>;
+  availability(options?: NanoCapabilityOptions): Promise<NanoAvailability>;
   create(options?: NanoCreateOptions): Promise<NanoSession>;
 }
 
@@ -57,6 +77,7 @@ function getNanoApi(): NanoLanguageModel | null {
   const lm = (globalThis as unknown as { LanguageModel?: NanoLanguageModel }).LanguageModel;
   return lm ?? null;
 }
+
 
 let engine: CompletionEngine | null = null;
 let loadedModelId: string | null = null;
@@ -146,7 +167,11 @@ async function isCanaryAvailable(canary: CanaryDefinition): Promise<boolean> {
     const api = getNanoApi();
     if (api === null) return false;
     try {
-      const avail = await api.availability();
+      // Issue #46 — pass the same options we'll use in create(). Without
+      // the expectedInputs/Outputs hints, availability can return
+      // 'available' while create() throws NotSupportedError on a language
+      // or modality mismatch.
+      const avail = await api.availability(NANO_CAPABILITY_OPTIONS);
       return avail === 'available';
     } catch {
       return false;
@@ -218,37 +243,47 @@ async function createMlcEngineAdapter(modelId: string): Promise<CompletionEngine
  * validated by the Stage 4C manual harness. Sessions are cheap to create
  * and per-call isolation avoids cross-probe prompt leakage.
  *
- * `expectedOutputs: [{ type: 'text', languages: ['en'] }]` silences the
- * "No output language was specified" Chrome warning and gives the model
- * a hint about expected output shape.
+ * Issue #46 — availability() + create() receive matching
+ * `NANO_CAPABILITY_OPTIONS` so Chrome can't report 'available' for a
+ * language/modality set that create() then rejects. The download progress
+ * monitor forwards each event as an ENGINE_STATUS message so the popup
+ * sees "Downloading... 42%" instead of a silent "loading".
  */
 async function createNanoEngineAdapter(modelId: string): Promise<CompletionEngine> {
   const api = getNanoApi();
   if (api === null) {
     throw new Error('Nano adapter requested but window.LanguageModel is absent');
   }
-  const avail = await api.availability();
-  if (avail !== 'available') {
+  const avail = await api.availability(NANO_CAPABILITY_OPTIONS);
+  if (avail === 'unavailable') {
     throw new Error(`Nano adapter requested but availability=${avail}`);
   }
   loadedModelId = modelId;
-  // Emit a single "ready" progress event so the SW and popup status
-  // displays stay consistent with the MLC path.
-  chrome.runtime.sendMessage({
-    type: 'ENGINE_STATUS',
-    status: 'loading',
-    progress: 1,
-    modelId,
-  });
-  log.info(`Nano adapter initialised for ${modelId}`);
+  log.info(
+    `Nano adapter initialising for ${modelId} (availability=${avail})`,
+  );
   return {
     id: modelId,
     async generate(systemPrompt: string, userMessage: string): Promise<string> {
       const session = await api.create({
+        ...NANO_CAPABILITY_OPTIONS,
         initialPrompts: [{ role: 'system', content: systemPrompt }],
         temperature: 0.1,
         topK: 3,
-        expectedOutputs: [{ type: 'text', languages: ['en'] }],
+        monitor: (m) => {
+          m.addEventListener('downloadprogress', (e) => {
+            // Forward model download progress to the popup. Chrome emits
+            // this on the first create() call when the underlying model
+            // isn't resident yet; subsequent create()s on the same device
+            // don't emit any events and take the warm path.
+            chrome.runtime.sendMessage({
+              type: 'ENGINE_STATUS',
+              status: e.loaded >= 1 ? 'ready' : 'loading',
+              progress: e.loaded,
+              modelId,
+            });
+          });
+        },
       });
       try {
         return await session.prompt(userMessage);


### PR DESCRIPTION
## Summary

- Pass `NANO_CAPABILITY_OPTIONS` to both `LanguageModel.availability()` and `LanguageModel.create()` so Chrome can't report 'available' for a language/modality set that create() then rejects with NotSupportedError (per Chrome's `inform-users-of-model-download` explicit requirement).
- Add `expectedInputs` alongside the pre-existing `expectedOutputs` — availability had no hints at all before.
- Wire `monitor(m) → downloadprogress` events to the existing `ENGINE_STATUS` channel so the popup sees download state instead of a silent \"loading\".

Closes #46

## Approach

**Single source of truth.** `NANO_CAPABILITY_OPTIONS` lives in a new `engine-constants.ts` module. Both `availability()` callers (`isCanaryAvailable`, `createNanoEngineAdapter`) spread the same constant. Impossible for the two to drift.

**Why the separate constants module.** Importing `engine.ts` from a test pulls `@mlc-ai/web-llm` transitively, which doesn't load in Node (`require is not defined in ES module scope`). Splitting the constants out gives us a testable export seam without an adapter-refactor.

**Availability gating loosened.** Previously `createNanoEngineAdapter` threw on any availability != 'available'. Now it only throws on 'unavailable' — 'downloadable' and 'downloading' let create() proceed and the monitor hooks up. Chrome's create() handles the download path itself; we were rejecting it before it could run.

**Download monitor replaces the hardcoded ready signal.** The old code emitted a single `ENGINE_STATUS { status: 'loading', progress: 1 }` before returning. The monitor now emits real progress events. `initEngine` emits the final `'ready'` after the adapter returns regardless, so the UX contract is preserved.

## Impact

| Change | Before | After |
|---|---|---|
| `availability()` call shape | `api.availability()` (no options) | `api.availability(NANO_CAPABILITY_OPTIONS)` |
| `create()` options | `expectedOutputs` only | `expectedInputs` + `expectedOutputs` (matching) |
| Download progress to popup | Silent hardcoded `progress: 1` | Real `downloadprogress` events forwarded |
| Availability 'downloading' | Threw (bug — blocked download path) | Proceeds to create() which handles download |
| Tests | 309 | 313 (+4 new) |

Pure-logic tests in `engine-constants.test.ts` lock the capability-options shape: both-sides parity, text modality, English-only, matching language arrays.

## Coordination with PR #42 (#41)

PR #42 (sibling session) adds `outputLanguage: 'en'` to the same `create()` call at line 255. Different lines, different field, different concern. **Orthogonal — no merge conflict either direction.**

Suggested merge order: #42 first (smaller, already approved), then this PR rebases with a no-op. If this lands first, #42 rebases cleanly and both live together in the same create() options object.

## Test plan

- [x] `npm run typecheck` green
- [x] `npm test` green (313/313)
- [x] `npm run build` green
- [x] Pre-push hook green
- [ ] CI green on the PR
- [ ] **Manual verification** (deferred — user has extension disabled):
  - Load extension under Nano canary; visit any scannable page; open offscreen DevTools console.
  - Confirm the pre-existing \"No output language was specified\" warning is still silenced by PR #42 (if merged first) — this PR doesn't interact with that.
  - On a fresh Chrome profile that needs the Nano model download: confirm `ENGINE_STATUS { progress: 0.x }` messages appear in the SW console before the final `'ready'`.
  - If model is already cached: confirm no regression — probes run normally, `'ready'` fires.

## Risk / rollback

Low. All changes are additive or defensive. `git revert` restores the old behaviour; the only persisted state this touches is the popup's transient ENGINE_STATUS display (no storage writes).

Related:
- #43 (research umbrella)
- #41 / PR #42 (sibling session)
- #48 (Language Detector — will widen NANO_CAPABILITY_OPTIONS to detected page language)