### PR TITLE
chore(phase4-#50): params() clamp + debug-surface doc line

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,10 @@ The offscreen doc is created on first `PAGE_SNAPSHOT` after a reload, not eagerl
 
 `immjocpajnooomnmdgecldcfimembndj` — use verbatim in `chrome-extension://` URLs until the user signals a reload changed it.
 
+### Debugging Nano probes
+
+`chrome://on-device-internals/` → Event Logs tab is Chrome's canonical debug surface for the Prompt API / Gemini Nano. Shows the literal prompt tokens that reached the model, including the system-prompt wrapper and any prefix handling. First stop when a Nano probe returns unexpected output.
+
 ### Audit-trail discipline
 
 When committing phase test results, commit **full per-probe result directories** as evidence. Gitignore only partial / wiped dumps that were superseded by a summary JSON. Before first `git add`, run `npm audit` + a broad secret grep — AIza keys are 39 chars, so regex must be ≥20 char suffix to catch them.

--- a/src/offscreen/engine-params.test.ts
+++ b/src/offscreen/engine-params.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveNanoCreateParams,
+  PREFERRED_NANO_TEMPERATURE,
+  PREFERRED_NANO_TOP_K,
+  type NanoParamBounds,
+} from './engine-params.js';
+
+describe('resolveNanoCreateParams (issue #50 item 1)', () => {
+  it('returns preferred values when bounds is null', () => {
+    const result = resolveNanoCreateParams(null);
+    expect(result.temperature).toBe(PREFERRED_NANO_TEMPERATURE);
+    expect(result.topK).toBe(PREFERRED_NANO_TOP_K);
+  });
+
+  it('passes preferred values through when bounds are generous', () => {
+    const bounds: NanoParamBounds = {
+      defaultTopK: 3,
+      maxTopK: 128,
+      defaultTemperature: 1.0,
+      maxTemperature: 2.0,
+    };
+    const result = resolveNanoCreateParams(bounds);
+    expect(result.temperature).toBe(PREFERRED_NANO_TEMPERATURE);
+    expect(result.topK).toBe(PREFERRED_NANO_TOP_K);
+  });
+
+  it('clamps topK down when maxTopK is tighter than preferred', () => {
+    const bounds: NanoParamBounds = {
+      defaultTopK: 1,
+      maxTopK: 2,
+      defaultTemperature: 0.5,
+      maxTemperature: 1.0,
+    };
+    const result = resolveNanoCreateParams(bounds);
+    expect(result.topK).toBe(2);
+  });
+
+  it('clamps temperature down when maxTemperature is tighter than preferred', () => {
+    // Contrived but locks the clamp behaviour: maxTemperature below our
+    // preferred 0.1 would force temperature to maxTemperature.
+    const bounds: NanoParamBounds = {
+      defaultTopK: 3,
+      maxTopK: 8,
+      defaultTemperature: 0.05,
+      maxTemperature: 0.05,
+    };
+    const result = resolveNanoCreateParams(bounds);
+    expect(result.temperature).toBe(0.05);
+  });
+
+  it('clamps both when both bounds are tighter', () => {
+    const bounds: NanoParamBounds = {
+      defaultTopK: 1,
+      maxTopK: 1,
+      defaultTemperature: 0.05,
+      maxTemperature: 0.05,
+    };
+    const result = resolveNanoCreateParams(bounds);
+    expect(result.topK).toBe(1);
+    expect(result.temperature).toBe(0.05);
+  });
+
+  it('does not inflate values above preferred even if bounds allow it', () => {
+    // Regression guard: Math.min with a larger upper bound should still
+    // return the preferred (lower) value.
+    const bounds: NanoParamBounds = {
+      defaultTopK: 40,
+      maxTopK: 128,
+      defaultTemperature: 1.0,
+      maxTemperature: 2.0,
+    };
+    const result = resolveNanoCreateParams(bounds);
+    expect(result.topK).toBeLessThanOrEqual(PREFERRED_NANO_TOP_K);
+    expect(result.temperature).toBeLessThanOrEqual(PREFERRED_NANO_TEMPERATURE);
+  });
+});

--- a/src/offscreen/engine-params.ts
+++ b/src/offscreen/engine-params.ts
@@ -1,0 +1,43 @@
+/**
+ * Nano param bounds + preferred-values resolver (issue #50 item 1).
+ *
+ * Split into its own module so tests can import it without pulling the
+ * full `engine.ts` (which transitively imports `@mlc-ai/web-llm` and
+ * explodes in Node).
+ *
+ * Chrome's Prompt API for Chrome Extensions exposes `LanguageModel.params()`
+ * which returns current-build bounds for `topK` and `temperature`. Without
+ * querying these and clamping our preferred values, a future Chrome release
+ * tightening `maxTopK` below our hardcoded 3 would make every `create()`
+ * call throw silently.
+ */
+
+export const PREFERRED_NANO_TEMPERATURE = 0.1;
+export const PREFERRED_NANO_TOP_K = 3;
+
+export interface NanoParamBounds {
+  readonly defaultTopK: number;
+  readonly maxTopK: number;
+  readonly defaultTemperature: number;
+  readonly maxTemperature: number;
+}
+
+export interface ResolvedNanoCreateParams {
+  readonly temperature: number;
+  readonly topK: number;
+}
+
+/**
+ * Clamp our preferred values against runtime bounds. When `bounds === null`
+ * (older Chrome or non-Extensions surface where `params()` is absent),
+ * pass preferred values through unmodified — nothing to clamp against.
+ */
+export function resolveNanoCreateParams(bounds: NanoParamBounds | null): ResolvedNanoCreateParams {
+  if (bounds === null) {
+    return { temperature: PREFERRED_NANO_TEMPERATURE, topK: PREFERRED_NANO_TOP_K };
+  }
+  return {
+    temperature: Math.min(PREFERRED_NANO_TEMPERATURE, bounds.maxTemperature),
+    topK: Math.min(PREFERRED_NANO_TOP_K, bounds.maxTopK),
+  };
+}

--- a/src/offscreen/engine.ts
+++ b/src/offscreen/engine.ts
@@ -11,6 +11,7 @@ import {
   type CanaryDefinition,
 } from '@/shared/constants.js';
 import { createLogger } from '@/shared/logger.js';
+import { resolveNanoCreateParams, type NanoParamBounds } from './engine-params.js';
 
 // Phase 4 Stage 4D.1 — dual-path engine.
 //
@@ -68,9 +69,24 @@ interface NanoCreateOptions extends NanoCapabilityOptions {
 
 type NanoAvailability = 'unavailable' | 'downloadable' | 'downloading' | 'available';
 
+/**
+ * Shape returned by `LanguageModel.params()`. Per Chrome's Prompt API
+ * docs this method is exposed only in the Prompt API for Chrome Extensions
+ * (which we are), not the base Web origin-trial surface. Gives us runtime
+ * bounds so `create({ topK, temperature })` can't exceed what the current
+ * Chrome build accepts. Issue #50 item 1.
+ */
+interface NanoParams {
+  readonly defaultTopK: number;
+  readonly maxTopK: number;
+  readonly defaultTemperature: number;
+  readonly maxTemperature: number;
+}
+
 interface NanoLanguageModel {
   availability(options?: NanoCapabilityOptions): Promise<NanoAvailability>;
   create(options?: NanoCreateOptions): Promise<NanoSession>;
+  params?(): Promise<NanoParams>;
 }
 
 function getNanoApi(): NanoLanguageModel | null {
@@ -258,6 +274,19 @@ async function createNanoEngineAdapter(modelId: string): Promise<CompletionEngin
   if (avail === 'unavailable') {
     throw new Error(`Nano adapter requested but availability=${avail}`);
   }
+  // Issue #50 item 1 — query runtime bounds for topK/temperature. Only
+  // the Prompt API for Chrome Extensions exposes params(); on the base
+  // surface it may be absent. Null result → resolver passes preferred
+  // values through unmodified.
+  let paramBounds: NanoParamBounds | null = null;
+  if (typeof api.params === 'function') {
+    try {
+      paramBounds = await api.params();
+    } catch (err) {
+      log.warn('LanguageModel.params() threw; using preferred values', err);
+    }
+  }
+  const createParams = resolveNanoCreateParams(paramBounds);
   loadedModelId = modelId;
   log.info(
     `Nano adapter initialising for ${modelId} (availability=${avail})`,
@@ -268,8 +297,8 @@ async function createNanoEngineAdapter(modelId: string): Promise<CompletionEngin
       const session = await api.create({
         ...NANO_CAPABILITY_OPTIONS,
         initialPrompts: [{ role: 'system', content: systemPrompt }],
-        temperature: 0.1,
-        topK: 3,
+        temperature: createParams.temperature,
+        topK: createParams.topK,
         monitor: (m) => {
           m.addEventListener('downloadprogress', (e) => {
             // Forward model download progress to the popup. Chrome emits


### PR DESCRIPTION
## Summary

Cleanup bundle from #50. Three concrete items + one deferred watch.

Closes #50

## Items

### 1. `LanguageModel.params()` clamp (code)

`createNanoEngineAdapter` queries `LanguageModel.params()` once at init and clamps our preferred `topK=3, temperature=0.1` against `maxTopK` / `maxTemperature`. Without this, if a future Chrome tightens either bound below our hardcoded value, every `create()` call throws silently.

Logic lives in a new `src/offscreen/engine-params.ts` module so tests can import it in Node (importing `engine.ts` directly pulls `@mlc-ai/web-llm`, which doesn't load in vitest). 6 new unit tests lock the clamp behaviour.

### 2. Expired `aiLanguageModelOriginTrial` permission (no-op)

Grep confirmed the permission is absent from `manifest.json`. Nothing to remove. Item resolved as \"not present\".

### 3. `chrome://on-device-internals` debug-surface doc (docs)

Added a new \"Debugging Nano probes\" subsection to `CLAUDE.md` under Domain invariants. One-sentence pointer to Chrome's canonical event-log surface — the first stop when probes misbehave.

### 4. Classifier API watch (deferred)

Chrome's Classifier API is only at Intent-to-Prototype on blink-dev. Nothing to do until the origin trial opens. Closing #50 with a note that this item becomes a fresh issue when the trial announces.

## Coordination with PR #53 (#46)

Both touch `src/offscreen/engine.ts` but different lines. #53 introduces `NANO_CAPABILITY_OPTIONS` (new import + spread into `create()`). This PR adds a separate import from `engine-params.ts` + a `params()` call block before `create()` + replaces the literal `temperature: 0.1, topK: 3` with `createParams.temperature, createParams.topK`. Merge either order — no overlapping line ranges.

## Test plan

- [x] typecheck / test / build green locally
- [x] 315 tests pass (309 on main + 6 new clamp tests)
- [x] Pre-push hook green
- [ ] CI green on the PR
- [ ] **Manual verification** (deferred — user has extension disabled):
  - On Nano canary, open SW console.
  - Confirm no \"exceeds maxTopK\" or similar `create()` errors.
  - If Chrome reports smaller bounds than our preferred, confirm the SW logs a clamp message rather than throwing.

## Risk / rollback

Low. `params()` call is try-catch-wrapped; unsupported-API fallback path returns preferred values unchanged (same as pre-change behaviour). Doc line is additive. `git revert` if needed.

Related: #43 umbrella, #41 / PR #42 (sibling, outputLanguage), #46 / PR #53 (sibling, capability options).