### PR TITLE
feat(phase4-#49): WebGPU adapter introspection at engine init

### DIFF
--- a/src/offscreen/engine.ts
+++ b/src/offscreen/engine.ts
@@ -12,6 +12,7 @@ import {
 } from '@/shared/constants.js';
 import { createLogger } from '@/shared/logger.js';
 import { resolveNanoCreateParams, type NanoParamBounds } from './engine-params.js';
+import { probeWebGPUAdapter, type AdapterIntrospection } from './webgpu-introspection.js';
 
 // Phase 4 Stage 4D.1 — dual-path engine.
 //
@@ -98,6 +99,13 @@ function getNanoApi(): NanoLanguageModel | null {
 let engine: CompletionEngine | null = null;
 let loadedModelId: string | null = null;
 let loadedCanaryId: CanaryId | null = null;
+/**
+ * WebGPU adapter introspection result cached at engine-init time.
+ * Issue #49. Null until initEngine() runs. Downstream callers
+ * (orchestrator diagnostics, Phase 4E reach audit) read via
+ * `getWebGPUAdapterMode()`.
+ */
+let webgpuAdapter: AdapterIntrospection | null = null;
 // Phase 4 Stage 4B.3 — single-flight promise for engine initialisation.
 // Concurrent callers of initEngine() during the load window must all await
 // the SAME in-flight promise. Previously each caller re-entered the function
@@ -327,6 +335,14 @@ async function createNanoEngineAdapter(modelId: string): Promise<CompletionEngin
   };
 }
 
+/**
+ * Return the WebGPU adapter introspection result from the last initEngine()
+ * call, or null if initEngine() hasn't run yet. Issue #49.
+ */
+export function getWebGPUAdapterInfo(): AdapterIntrospection | null {
+  return webgpuAdapter;
+}
+
 export async function initEngine(): Promise<CompletionEngine> {
   if (engine !== null) return engine;
   if (initPromise !== null) return initPromise;
@@ -337,6 +353,28 @@ export async function initEngine(): Promise<CompletionEngine> {
   // circuit via the `engine !== null` check; on failure it's also cleared
   // so a subsequent call can retry.
   initPromise = (async () => {
+    // Issue #49 — pre-flight WebGPU adapter introspection. Runs before
+    // canary selection so MLC-path canaries can be skipped in principle
+    // when the device only exposes a compatibility-mode adapter (@mlc-ai
+    // /web-llm assumes Core WebGPU). Today we only log the mode; future
+    // work (after upstream MLC supports compat mode, see #16) may
+    // actually prefer Nano on compat-only devices.
+    const gpu = (globalThis as unknown as { navigator?: { gpu?: Parameters<typeof probeWebGPUAdapter>[0] } })
+      .navigator?.gpu ?? null;
+    webgpuAdapter = await probeWebGPUAdapter(gpu);
+    if (webgpuAdapter.mode === 'compatibility') {
+      log.warn(
+        `WebGPU adapter is compatibility-mode only — MLC canaries may fail. ` +
+        `Nano canary (Chrome built-in) unaffected. ` +
+        `Adapter info: ${JSON.stringify(webgpuAdapter.info)}`,
+      );
+    } else {
+      log.info(
+        `WebGPU adapter mode: ${webgpuAdapter.mode}` +
+        (webgpuAdapter.info !== null ? ` (${JSON.stringify(webgpuAdapter.info)})` : ''),
+      );
+    }
+
     const userChoice = await getUserCanaryChoice();
     const canary = await resolveCanary(userChoice);
     loadedCanaryId = canary.id;

--- a/src/offscreen/webgpu-introspection.test.ts
+++ b/src/offscreen/webgpu-introspection.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi } from 'vitest';
+import { probeWebGPUAdapter } from './webgpu-introspection.js';
+
+function mockGpu(config: {
+  core?: 'null' | 'throw' | 'ok';
+  compat?: 'null' | 'throw' | 'ok';
+  legacy?: 'null' | 'throw' | 'ok';
+  coreInfo?: { vendor?: string; architecture?: string };
+  compatInfo?: { vendor?: string; architecture?: string };
+}) {
+  const requestAdapter = vi.fn(async (options?: { featureLevel?: 'core' | 'compatibility' }) => {
+    const level = options?.featureLevel;
+    if (level === 'core') {
+      if (config.core === 'throw') throw new Error('core throws');
+      if (config.core === 'null' || config.core === undefined) return null;
+      return { info: config.coreInfo };
+    }
+    if (level === 'compatibility') {
+      if (config.compat === 'throw') throw new Error('compat throws');
+      if (config.compat === 'null' || config.compat === undefined) return null;
+      return { info: config.compatInfo };
+    }
+    // Legacy (no featureLevel)
+    if (config.legacy === 'throw') throw new Error('legacy throws');
+    if (config.legacy === 'null' || config.legacy === undefined) return null;
+    return { info: undefined };
+  });
+  return { requestAdapter };
+}
+
+describe('probeWebGPUAdapter (issue #49)', () => {
+  it('returns "none" when gpu is undefined', async () => {
+    const result = await probeWebGPUAdapter(undefined);
+    expect(result.mode).toBe('none');
+    expect(result.info).toBeNull();
+  });
+
+  it('returns "none" when gpu is null', async () => {
+    const result = await probeWebGPUAdapter(null);
+    expect(result.mode).toBe('none');
+  });
+
+  it('returns "core" when requestAdapter({featureLevel: core}) succeeds', async () => {
+    const gpu = mockGpu({
+      core: 'ok',
+      coreInfo: { vendor: 'Apple', architecture: 'apple-m' },
+    });
+    const result = await probeWebGPUAdapter(gpu);
+    expect(result.mode).toBe('core');
+    expect(result.info).toEqual({ vendor: 'Apple', architecture: 'apple-m' });
+  });
+
+  it('falls through to "compatibility" when core returns null', async () => {
+    const gpu = mockGpu({
+      core: 'null',
+      compat: 'ok',
+      compatInfo: { vendor: 'Intel', architecture: 'gen9' },
+    });
+    const result = await probeWebGPUAdapter(gpu);
+    expect(result.mode).toBe('compatibility');
+    expect(result.info).toEqual({ vendor: 'Intel', architecture: 'gen9' });
+  });
+
+  it('falls through to "compatibility" when core throws', async () => {
+    const gpu = mockGpu({
+      core: 'throw',
+      compat: 'ok',
+      compatInfo: { vendor: 'AMD' },
+    });
+    const result = await probeWebGPUAdapter(gpu);
+    expect(result.mode).toBe('compatibility');
+    expect(result.info?.vendor).toBe('AMD');
+    expect(result.info?.architecture).toBeNull();
+  });
+
+  it('falls through to "core" (legacy no-featureLevel) when both core+compat return null', async () => {
+    const gpu = mockGpu({ core: 'null', compat: 'null', legacy: 'ok' });
+    const result = await probeWebGPUAdapter(gpu);
+    expect(result.mode).toBe('core');
+  });
+
+  it('returns "unknown" when every probe path fails / returns null', async () => {
+    const gpu = mockGpu({ core: 'null', compat: 'null', legacy: 'null' });
+    const result = await probeWebGPUAdapter(gpu);
+    expect(result.mode).toBe('unknown');
+    expect(result.info).toBeNull();
+  });
+
+  it('returns "unknown" when every probe path throws', async () => {
+    const gpu = mockGpu({ core: 'throw', compat: 'throw', legacy: 'throw' });
+    const result = await probeWebGPUAdapter(gpu);
+    expect(result.mode).toBe('unknown');
+  });
+
+  it('handles missing adapter.info gracefully', async () => {
+    const gpu = mockGpu({ core: 'ok' }); // no coreInfo
+    const result = await probeWebGPUAdapter(gpu);
+    expect(result.mode).toBe('core');
+    expect(result.info).toBeNull();
+  });
+
+  it('extracts partial adapter.info when some fields are missing', async () => {
+    const gpu = mockGpu({
+      core: 'ok',
+      coreInfo: { vendor: 'Apple' }, // no architecture
+    });
+    const result = await probeWebGPUAdapter(gpu);
+    expect(result.info).toEqual({ vendor: 'Apple', architecture: null });
+  });
+});

--- a/src/offscreen/webgpu-introspection.ts
+++ b/src/offscreen/webgpu-introspection.ts
@@ -1,0 +1,100 @@
+/**
+ * Pre-flight WebGPU adapter introspection (issue #49).
+ *
+ * `@mlc-ai/web-llm` assumes Core WebGPU. Chrome's WebGPU Compatibility
+ * Mode (shipped Chrome 139+, chromestatus feature 6436406437871616) is
+ * a strict subset that runs on older graphics APIs (OpenGL ES, D3D11) —
+ * ~31% of Chrome-on-Windows users and ~23% of Android users only get a
+ * compatibility-mode adapter. On those devices our MLC canaries fail
+ * with no clear signal to the user.
+ *
+ * This module queries the adapter at engine-init time and exposes the
+ * result as a structured `AdapterMode` that downstream diagnostics can
+ * stamp on verdicts and the Phase 4E reach audit can tabulate.
+ *
+ * Kept in its own module so the probe logic can be unit-tested with a
+ * mocked `navigator.gpu` without pulling the full engine module.
+ */
+
+export type AdapterMode =
+  | 'core'           // Core WebGPU — MLC canaries should work
+  | 'compatibility'  // Compat-mode only — MLC will fail; Nano may still work
+  | 'none'           // No WebGPU at all — MLC unavailable
+  | 'unknown';       // navigator.gpu exists but adapter query threw
+
+export interface AdapterIntrospection {
+  readonly mode: AdapterMode;
+  /**
+   * When `mode === 'core' | 'compatibility'`, the first few well-known
+   * fields from `GPUAdapter.info` (vendor, architecture). Null on
+   * `'none'` / `'unknown'`. Best-effort — `info` is a newer WebGPU
+   * addition and may be absent on older Chrome.
+   */
+  readonly info: {
+    readonly vendor: string | null;
+    readonly architecture: string | null;
+  } | null;
+}
+
+/**
+ * Minimal structural types for navigator.gpu so this module doesn't
+ * depend on the full WebGPU types being present in the test env.
+ */
+interface GPUAdapterInfoLike {
+  readonly vendor?: string;
+  readonly architecture?: string;
+}
+interface GPUAdapterLike {
+  readonly info?: GPUAdapterInfoLike;
+}
+interface GPULike {
+  requestAdapter(options?: { featureLevel?: 'core' | 'compatibility' }): Promise<GPUAdapterLike | null>;
+}
+
+export async function probeWebGPUAdapter(gpu: GPULike | undefined | null): Promise<AdapterIntrospection> {
+  if (gpu === undefined || gpu === null) {
+    return { mode: 'none', info: null };
+  }
+  // Try Core first — if it succeeds we know the device can run unrestricted
+  // MLC. If it returns null, fall through to Compat which accepts a
+  // wider device range (older GPUs, OpenGL ES backends).
+  try {
+    const core = await gpu.requestAdapter({ featureLevel: 'core' });
+    if (core !== null) {
+      return { mode: 'core', info: extractInfo(core) };
+    }
+  } catch {
+    // Some Chrome builds throw instead of returning null for unsupported
+    // featureLevel. Fall through to compat probe.
+  }
+  try {
+    const compat = await gpu.requestAdapter({ featureLevel: 'compatibility' });
+    if (compat !== null) {
+      return { mode: 'compatibility', info: extractInfo(compat) };
+    }
+  } catch {
+    // Same defensive handling — treat any error as "no compat adapter".
+  }
+  // Last-chance probe: `requestAdapter()` without featureLevel hint.
+  // Some older Chrome builds don't accept featureLevel at all and the
+  // calls above no-op. This path catches those and still produces a
+  // 'core' signal for devices that happen to support it via the legacy
+  // call shape.
+  try {
+    const legacy = await gpu.requestAdapter();
+    if (legacy !== null) {
+      return { mode: 'core', info: extractInfo(legacy) };
+    }
+  } catch {
+    // Give up — treat as no WebGPU.
+  }
+  return { mode: 'unknown', info: null };
+}
+
+function extractInfo(adapter: GPUAdapterLike): AdapterIntrospection['info'] {
+  if (adapter.info === undefined) return null;
+  return {
+    vendor: typeof adapter.info.vendor === 'string' ? adapter.info.vendor : null,
+    architecture: typeof adapter.info.architecture === 'string' ? adapter.info.architecture : null,
+  };
+}


### PR DESCRIPTION
## Summary

Adds pre-flight `navigator.gpu.requestAdapter()` introspection at engine-init time. Logs whether the device is Core / Compatibility / none and stores the result for downstream diagnostics.

Closes #49

## Why

WebGPU Compatibility Mode shipped in Chrome 139+. ~31% of Chrome-on-Windows users (per chromestatus feature 6436406437871616) and ~23% of Android users can only get a compatibility-mode adapter. `@mlc-ai/web-llm` assumes Core WebGPU, so our MLC canaries fail on those devices with no clear signal.

This PR does NOT fix MLC on compat-mode devices — that's upstream (see #16). It does give us the structured data to:
- Log a clear warning when MLC is doomed on a device
- Stamp adapter-mode on future verdict diagnostics (#8 Phase 4E reach audit needs this)
- Answer the next-tier question later (\"should we prefer Nano on compat-only devices?\")

## Design

- New `src/offscreen/webgpu-introspection.ts` — pure module, structural types, no deps. `probeWebGPUAdapter(gpu)` tries Core → Compat → legacy-no-featureLevel → 'unknown'. Each try/catch-wrapped since Chrome builds vary in how they handle unsupported `featureLevel` (some throw, some return null).
- Engine calls `probeWebGPUAdapter(navigator.gpu)` at top of `initEngine()`. Caches result; exposes via new `getWebGPUAdapterInfo()` getter.
- Compat-mode logs at WARN; everything else at INFO.

## Scope not included (deferred)

- Stamping `webgpuAdapterMode` on `SecurityVerdict`. Schema change; separate PR.
- Prefer-Nano-on-compat behaviour. Requires Nano availability guarantee we don't have on non-EPP.
- MLC skip-on-compat. Would give non-EPP compat-only users zero coverage.

## Tests

10 new tests: null/undefined gpu, core success, core→compat fallthrough (null and throw), compat→legacy fallthrough, every-path-fails (null and throw), missing adapter.info, partial adapter.info.

309 → 319. typecheck + build green.

## Test plan

- [x] typecheck / test / build green
- [ ] CI green
- [ ] **Manual verification** (deferred):
  - Load extension, visit a scannable page.
  - Confirm SW console shows `INFO WebGPU adapter mode: core (...)` on a modern device.
  - On a device/Chrome build that only supports compat: confirm `WARN WebGPU adapter is compatibility-mode only — MLC canaries may fail`.

## Risk / rollback

Low. Read-only probe; doesn't alter canary selection or engine creation. `git revert` if the probe ever produces false positives that confuse diagnostics.

Related: #8 (Phase 4E reach audit), #16 (upstream MLC compat question), #43 (research umbrella).