### PR TITLE
feat(phase4-#59): stamp webgpuAdapterMode on SecurityVerdict

### DIFF
--- a/docs/phase4/compat-audit-methodology.md
+++ b/docs/phase4/compat-audit-methodology.md
@@ -41,7 +41,7 @@ For each browser, capture four signal types:
 |---|---|---|---|
 | `LanguageModel` presence | `typeof window.LanguageModel !== 'undefined'` evaluated **inside the offscreen document** | `present` / `absent` | The Prompt API surface for Chrome's built-in Gemini Nano. Must be tested in the offscreen doc, not the page — extension contexts are where Chrome exposes it. |
 | `LanguageModel.availability()` | `await LanguageModel.availability()` (only if `LanguageModel` is present) | `'available'` / `'downloadable'` / `'downloading'` / `'unavailable'` / `<error>` | Nano has an EPP gate plus a per-profile component download. `'unavailable'` on Chrome Stable usually means the profile isn't EPP-enrolled. |
-| WebGPU adapter mode | `getWebGPUAdapterInfo()` exported from `src/offscreen/engine.ts` (introduced by [PR #56](https://github.com/JimmyCapps/zentropy/pull/56), closes [#49](https://github.com/JimmyCapps/zentropy/issues/49)) | `'core'` / `'compatibility'` / `'none'` / `'unknown'` | The shape is `AdapterIntrospection { mode, info }` from `src/offscreen/webgpu-introspection.ts`. The downstream `SecurityVerdict.webgpuAdapterMode` field is **TBD on merge of #56 follow-up** (#56 itself defers verdict-stamping). For the audit, read the engine-init log line `WebGPU adapter mode: <mode>` from the offscreen DevTools console. |
+| WebGPU adapter mode | Read `SecurityVerdict.webgpuAdapterMode` from the persisted verdict (popup or `chrome.storage.local`). Fallback: `getWebGPUAdapterInfo()` in the offscreen console, or the engine-init log line `WebGPU adapter mode: <mode>`. | `'core'` / `'compatibility'` / `'none'` / `'unknown'` | The field lands on every verdict produced by a scan that consulted the offscreen engine (introspection shape is `AdapterIntrospection { mode, info }` from `src/offscreen/webgpu-introspection.ts`). Verdicts produced via the origin-denied skip path have `webgpuAdapterMode: null` because no engine work ran. |
 | Verdict on canary fixture | Open `test-pages/phase4/nano-harness.html` (manual Nano sweep) and `test-pages/clean/simple-article.html` (full-extension MLC path); read the persisted verdict from `chrome.storage` via the popup or service worker console | `CLEAN` / `SUSPICIOUS` / `COMPROMISED` / `UNKNOWN` / `<error>` | A non-`UNKNOWN` verdict on a real injection page demonstrates the full pipeline ran. `UNKNOWN` with `analysisError` set means the engine layer failed — diagnose using the WebGPU adapter mode and `LanguageModel.availability()` columns. |
 
 ## 4. Pass / partial / fail criteria per browser
@@ -108,15 +108,20 @@ early and let them run in parallel.
 
 ### 5.3 Capture WebGPU adapter mode
 
-1. In the offscreen DevTools console (after PR #56 merges and is on `main`):
+1. After the scan completes (§5.4), open the persisted verdict from
+   `chrome.storage.local` — the popup surfaces `webgpuAdapterMode`, or read
+   it directly in the service-worker console:
    ```js
-   // Imported at module top in src/offscreen/engine.ts
+   const { honeyllm } = await chrome.storage.local.get(null);
+   Object.values(honeyllm).map(v => v.webgpuAdapterMode);
+   ```
+   Fallbacks if the scan errored before a verdict persisted: in the
+   offscreen DevTools console run
+   ```js
    const info = (await import('./engine.js')).getWebGPUAdapterInfo();
    info?.mode  // 'core' | 'compatibility' | 'none' | 'unknown'
    ```
-   *Until #56 merges*, capture the value by reading the engine-init log line
-   `WebGPU adapter mode: <mode>` directly from the offscreen console output
-   on first probe run.
+   or read the engine-init log line `WebGPU adapter mode: <mode>`.
 2. Record the mode. If `'compatibility'`, MLC is expected to fail — note
    that for the verdict column.
 3. If `'none'`, the browser has no WebGPU at all — unusual for modern
@@ -152,10 +157,10 @@ the steps above and overwrite if any cell is `?` or appears stale.
 |---|---|---|
 | Browser | Chrome | — |
 | Channel / Version | Stable / `?` (record the exact version when re-running) | unknown until run |
-| Extension ID (this profile) | `immjocpajnooomnmdgecldcfimembndj` | CLAUDE.md §Chrome Stable unpacked extension ID; project memory `project_chrome_extension_id.md`. Treat as stable until the user signals a reload changed it. |
+| Extension ID (this profile) | Read from `chrome://extensions/` after `Load unpacked` — rotates on each reload | The ID is per-`Load unpacked` operation, so recording a literal here would go stale. Capture at audit time and note in the row's Notes column if needed. |
 | `LanguageModel` presence | `present` | Inferred: the `test-pages/phase4/nano-harness.html` flow exists and is documented as working on the user's EPP-enrolled profile (`docs/testing/phase4/mlc-root-cause.md`, `test-pages/phase4/README.md`). Re-confirm with `typeof LanguageModel`. |
 | `LanguageModel.availability()` | `'available'` (on EPP-enrolled profile with both flags enabled and component downloaded) | `test-pages/phase4/README.md` §"One-time prep" — the flow assumes `await LanguageModel.availability()` returns `'available'` before sweep. On a non-EPP profile this is `'unavailable'`. |
-| WebGPU adapter mode | `?` (likely `'core'` on Apple Silicon Macs; record from offscreen console once PR #56 is on `main`) | PR #56 has not landed on `main` as of branch creation. Apple Silicon Macs are not in the cohort that compat-mode targets (D3D11.1- on Windows, Vulkan 1.1- on Android), so `'core'` is the expected value. |
+| WebGPU adapter mode | `?` (likely `'core'` on Apple Silicon Macs; read `SecurityVerdict.webgpuAdapterMode` from the persisted verdict) | Apple Silicon Macs are not in the cohort that compat-mode targets (D3D11.1- on Windows, Vulkan 1.1- on Android), so `'core'` is the expected value. |
 | Verdict on `simple-article.html` (clean fixture) | Likely `CLEAN` with `confidence ~0.93` | `docs/testing/phase4/mlc-root-cause.md` §"Verification outcome" recorded `CLEAN, confidence 0.93` on the wikipedia-sourdough clean fixture post-4B.3 fix. The `simple-article.html` fixture is similarly clean. |
 | Verdict on a real injection fixture | `?` (run `test-pages/clean/security-blog.html` or any of the affected-set fixtures; expect `SUSPICIOUS` or `COMPROMISED`) | The MDN fixture in the same Track B verification produced `SUSPICIOUS, confidence 0.67` — that's the shape we expect from a non-clean page. |
 | Roll-up | **Pass** (assumed, pending verification) | Both engines available + non-UNKNOWN verdict expected. |
@@ -185,10 +190,11 @@ inline below as a working scratchpad.
 - **Tracking issue:** [#8 Phase 4 Stage 4E — Chromium-family browser compatibility audit](https://github.com/JimmyCapps/zentropy/issues/8)
 - **WebGPU introspection (gives us the adapter-mode column):**
   - Issue: [#49 feat: WebGPU adapter introspection at engine init](https://github.com/JimmyCapps/zentropy/issues/49)
-  - PR: [#56 feat(phase4-#49): WebGPU adapter introspection at engine init](https://github.com/JimmyCapps/zentropy/pull/56)
-  - Module: `src/offscreen/webgpu-introspection.ts` (post-merge)
-  - Engine getter: `getWebGPUAdapterInfo()` in `src/offscreen/engine.ts` (post-merge)
-  - Verdict-field stamping (`SecurityVerdict.webgpuAdapterMode`) — **TBD on follow-up to #56**; PR #56 explicitly defers this.
+  - Introspection PR: [#56 feat(phase4-#49): WebGPU adapter introspection at engine init](https://github.com/JimmyCapps/zentropy/pull/56)
+  - Verdict-stamping follow-up: [#59 feat(phase4): stamp webgpuAdapterMode on SecurityVerdict](https://github.com/JimmyCapps/zentropy/issues/59)
+  - Module: `src/offscreen/webgpu-introspection.ts`
+  - Engine getter: `getWebGPUAdapterInfo()` in `src/offscreen/engine.ts`
+  - Verdict field: `SecurityVerdict.webgpuAdapterMode` in `src/types/verdict.ts`
 - **Manual Nano harness (used for the verdict column when `LanguageModel` is `'available'`):** `test-pages/phase4/README.md`
 - **Phase 4 plan and hard rules:** `docs/testing/PHASE4_PROMPT.md` §Stage 4E (referenced in issue #8)
 - **Final deliverable doc (the populated matrix):** `docs/testing/PHASE4_BROWSER_COMPATIBILITY.md` — to be created when audit data is collected.

--- a/src/content/signaling/window-globals.ts
+++ b/src/content/signaling/window-globals.ts
@@ -35,6 +35,7 @@ function buildReport(verdict: SecurityVerdict): AISecurityReport {
     mitigationsApplied: [...verdict.mitigationsApplied],
     analysisError: verdict.analysisError,
     canaryId: verdict.canaryId,
+    webgpuAdapterMode: verdict.webgpuAdapterMode,
   };
 }
 

--- a/src/offscreen/index.ts
+++ b/src/offscreen/index.ts
@@ -5,7 +5,7 @@ import type {
 } from '@/types/messages.js';
 import { createLogger } from '@/shared/logger.js';
 import { isTestModeEnabled } from '@/shared/test-mode.js';
-import { initEngine, generateCompletion, getLoadedModelId, getLoadedCanaryId } from './engine.js';
+import { initEngine, generateCompletion, getLoadedModelId, getLoadedCanaryId, getWebGPUAdapterInfo } from './engine.js';
 import { runProbes } from './probe-runner.js';
 import { runDirectProbe, type DirectProbeDeps } from './direct-probe.js';
 
@@ -115,6 +115,7 @@ chrome.runtime.onMessage.addListener((message: HoneyLLMMessage, _sender, sendRes
           chunkIndex,
           results,
           canaryId: getLoadedCanaryId(),
+          webgpuAdapterMode: getWebGPUAdapterInfo()?.mode ?? null,
         };
         chrome.runtime.sendMessage(response);
       })
@@ -134,6 +135,7 @@ chrome.runtime.onMessage.addListener((message: HoneyLLMMessage, _sender, sendRes
             { probeName: 'adversarial_compliance', passed: false, flags: [], rawOutput: '', score: 0, errorMessage },
           ],
           canaryId: getLoadedCanaryId(),
+          webgpuAdapterMode: getWebGPUAdapterInfo()?.mode ?? null,
         };
         chrome.runtime.sendMessage(response);
       });

--- a/src/policy/engine.test.ts
+++ b/src/policy/engine.test.ts
@@ -155,4 +155,51 @@ describe('evaluatePolicy', () => {
       expect(verdict.canaryId).toBe('chrome-builtin-gemini-nano');
     });
   });
+
+  // Issue #59 — webgpuAdapterMode wiring.
+  describe('webgpuAdapterMode propagation', () => {
+    it('defaults webgpuAdapterMode to null when not supplied', () => {
+      const verdict = evaluatePolicy([], CLEAN_FLAGS, 'https://a.com');
+      expect(verdict.webgpuAdapterMode).toBeNull();
+    });
+
+    it('passes through the supplied adapter mode on score-derived verdicts', () => {
+      const results = [makeResult({ probeName: 'summarization', passed: true })];
+      const verdict = evaluatePolicy(
+        results,
+        CLEAN_FLAGS,
+        'https://a.com',
+        null,
+        'gemma-2-2b-mlc',
+        'core',
+      );
+      expect(verdict.status).toBe('CLEAN');
+      expect(verdict.webgpuAdapterMode).toBe('core');
+    });
+
+    it('passes through the supplied adapter mode on UNKNOWN verdicts', () => {
+      const results = [
+        makeResult({ probeName: 'summarization', errorMessage: 'engine timeout' }),
+        makeResult({ probeName: 'instruction_detection', errorMessage: 'engine timeout' }),
+      ];
+      const verdict = evaluatePolicy(
+        results,
+        CLEAN_FLAGS,
+        'https://a.com',
+        null,
+        'chrome-builtin-gemini-nano',
+        'compatibility',
+      );
+      expect(verdict.status).toBe('UNKNOWN');
+      expect(verdict.webgpuAdapterMode).toBe('compatibility');
+    });
+
+    it('accepts all four adapter-mode literals', () => {
+      const modes = ['core', 'compatibility', 'none', 'unknown'] as const;
+      for (const mode of modes) {
+        const verdict = evaluatePolicy([], CLEAN_FLAGS, 'https://a.com', null, null, mode);
+        expect(verdict.webgpuAdapterMode).toBe(mode);
+      }
+    });
+  });
 });

--- a/src/policy/engine.ts
+++ b/src/policy/engine.ts
@@ -1,4 +1,4 @@
-import type { ProbeResult, BehavioralFlags, SecurityVerdict, SecurityStatus } from '@/types/verdict.js';
+import type { ProbeResult, BehavioralFlags, SecurityVerdict, SecurityStatus, WebGPUAdapterMode } from '@/types/verdict.js';
 import { THRESHOLD_SUSPICIOUS, THRESHOLD_COMPROMISED } from '@/shared/constants.js';
 import { computeScore } from './rules.js';
 
@@ -30,6 +30,7 @@ export function evaluatePolicy(
   url: string,
   analysisError: string | null = null,
   canaryId: string | null = null,
+  webgpuAdapterMode: WebGPUAdapterMode | null = null,
 ): SecurityVerdict {
   // Phase 4 Stage 4A — error-aware branching.
   //
@@ -59,6 +60,7 @@ export function evaluatePolicy(
       url,
       analysisError: aggregateError,
       canaryId,
+      webgpuAdapterMode,
     };
   }
 
@@ -77,5 +79,6 @@ export function evaluatePolicy(
     url,
     analysisError: aggregateError,
     canaryId,
+    webgpuAdapterMode,
   };
 }

--- a/src/service-worker/orchestrator.ts
+++ b/src/service-worker/orchestrator.ts
@@ -1,5 +1,5 @@
 import type { PageSnapshot } from '@/types/snapshot.js';
-import type { ProbeResult, SecurityVerdict } from '@/types/verdict.js';
+import type { ProbeResult, SecurityVerdict, WebGPUAdapterMode } from '@/types/verdict.js';
 import type { RunProbesMessage, ProbeResultsMessage } from '@/types/messages.js';
 import { MAX_CHUNK_CHARS, MAX_CHUNKS_PER_PAGE } from '@/shared/constants.js';
 import { createLogger } from '@/shared/logger.js';
@@ -121,6 +121,7 @@ export function buildOriginSkippedVerdict(
     url: snapshot.metadata.url,
     analysisError: `origin_denied: ${errorSuffix}`,
     canaryId: null,
+    webgpuAdapterMode: null,
   };
 }
 
@@ -218,6 +219,7 @@ export async function analyzeSnapshot(
     // eliminating the multi-chunk variant of the false-negative bug.
     const allChunkResults: (readonly ProbeResult[])[] = [];
     let canaryId: string | null = null;
+    let webgpuAdapterMode: WebGPUAdapterMode | null = null;
     for (let index = 0; index < chunks.length; index += 1) {
       // Issue #11 — check the signal before dispatching each chunk. A new
       // PAGE_SNAPSHOT arriving mid-analysis flips this flag; reject rather
@@ -230,7 +232,7 @@ export async function analyzeSnapshot(
         throw new AnalysisAbortedError(reason);
       }
       const chunk = chunks[index]!;
-      const { results, canaryId: chunkCanaryId } = await runChunkProbes({
+      const { results, canaryId: chunkCanaryId, webgpuAdapterMode: chunkAdapterMode } = await runChunkProbes({
         tabId,
         chunk,
         chunkIndex: index,
@@ -245,6 +247,12 @@ export async function analyzeSnapshot(
       if (canaryId === null && chunkCanaryId !== null) {
         canaryId = chunkCanaryId;
       }
+      // Issue #59 — same first-non-null merge for adapter mode. All chunks
+      // share the same WebGPU introspection result since initEngine() runs
+      // once per offscreen lifetime.
+      if (webgpuAdapterMode === null && chunkAdapterMode !== null) {
+        webgpuAdapterMode = chunkAdapterMode;
+      }
     }
 
     const mergedResults = mergeProbeResults(allChunkResults);
@@ -253,7 +261,14 @@ export async function analyzeSnapshot(
       capped ? `chunk_count_capped (${allChunks.length} chunks → kept first ${MAX_CHUNKS_PER_PAGE})` : null,
     );
     const behavioralFlags = analyzeBehavior(mergedResults);
-    const verdict = evaluatePolicy(mergedResults, behavioralFlags, snapshot.metadata.url, aggregateError, canaryId);
+    const verdict = evaluatePolicy(
+      mergedResults,
+      behavioralFlags,
+      snapshot.metadata.url,
+      aggregateError,
+      canaryId,
+      webgpuAdapterMode,
+    );
 
     await persistVerdict(verdict);
 
@@ -278,6 +293,7 @@ interface RunChunkArgs {
 interface ChunkProbeResult {
   readonly results: readonly ProbeResult[];
   readonly canaryId: string | null;
+  readonly webgpuAdapterMode: WebGPUAdapterMode | null;
 }
 
 function runChunkProbes(args: RunChunkArgs): Promise<ChunkProbeResult> {
@@ -289,7 +305,11 @@ function runChunkProbes(args: RunChunkArgs): Promise<ChunkProbeResult> {
         message.chunkIndex === args.chunkIndex
       ) {
         chrome.runtime.onMessage.removeListener(handler);
-        resolve({ results: message.results, canaryId: message.canaryId ?? null });
+        resolve({
+          results: message.results,
+          canaryId: message.canaryId ?? null,
+          webgpuAdapterMode: message.webgpuAdapterMode ?? null,
+        });
       }
     };
     chrome.runtime.onMessage.addListener(handler);

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -1,5 +1,5 @@
 import type { PageSnapshot } from './snapshot.js';
-import type { ProbeResult, SecurityVerdict } from './verdict.js';
+import type { ProbeResult, SecurityVerdict, WebGPUAdapterMode } from './verdict.js';
 
 export type MessageType =
   | 'PAGE_SNAPSHOT'
@@ -47,6 +47,9 @@ export interface ProbeResultsMessage extends BaseMessage {
   // Null if the offscreen couldn't determine the canary (shouldn't happen
   // in practice; kept nullable for legacy/error paths).
   readonly canaryId: string | null;
+  // Issue #59 — WebGPU adapter mode from the most recent initEngine() call.
+  // Null when introspection hasn't run yet or navigator.gpu was unavailable.
+  readonly webgpuAdapterMode: WebGPUAdapterMode | null;
 }
 
 export interface VerdictMessage extends BaseMessage {

--- a/src/types/verdict.ts
+++ b/src/types/verdict.ts
@@ -1,5 +1,11 @@
 export type SecurityStatus = 'CLEAN' | 'SUSPICIOUS' | 'COMPROMISED' | 'UNKNOWN';
 
+// Phase 4 Stage 4E — mirrors AdapterMode in src/offscreen/webgpu-introspection.ts.
+// Kept as a type-only duplicate here so src/types/ stays dependency-free
+// (offscreen/ pulls @mlc-ai/web-llm, which doesn't load in consumers that only
+// need the verdict shape, e.g. content/popup).
+export type WebGPUAdapterMode = 'core' | 'compatibility' | 'none' | 'unknown';
+
 export interface ProbeResult {
   readonly probeName: string;
   readonly passed: boolean;
@@ -43,6 +49,12 @@ export interface SecurityVerdict {
   // the selector fell back to Gemma). Null on verdicts produced before 4D.3,
   // or when the engine's canary id wasn't available at verdict time.
   readonly canaryId: string | null;
+  // Issue #59 — WebGPU adapter mode observed at engine init, forwarded here
+  // so #8's Chromium-family audit can tabulate verdicts per adapter class
+  // without a console scrape. Null on verdicts produced before #59, on the
+  // Nano-only path where no WebGPU probe ran, or when the introspection
+  // result wasn't available at verdict-assembly time.
+  readonly webgpuAdapterMode: WebGPUAdapterMode | null;
 }
 
 export interface AISecurityReport {
@@ -68,4 +80,6 @@ export interface AISecurityReport {
   // Phase 4 Stage 4D.3 — mirrors SecurityVerdict.canaryId so page scripts can
   // see which on-device canary produced the analysis.
   readonly canaryId: string | null;
+  // Issue #59 — mirrors SecurityVerdict.webgpuAdapterMode for page scripts.
+  readonly webgpuAdapterMode: WebGPUAdapterMode | null;
 }


### PR DESCRIPTION
## Summary

Turns the schema change deferred by PR #56 into real structured data. `SecurityVerdict.webgpuAdapterMode` now lands on every verdict that consulted the offscreen engine, so #8's Chromium-family audit rows no longer require a console scrape.

Closes #59

## Approach

**Why a type-only duplicate in `src/types/verdict.ts`.** The introspection lives in `src/offscreen/webgpu-introspection.ts`, but offscreen transitively pulls `@mlc-ai/web-llm`. Consumers that only need verdict shapes (content/popup) shouldn't have to. Added `WebGPUAdapterMode` as a type-only alias matching the four literals from `AdapterMode`. Kept in sync by convention; both live side-by-side in \`src/types/\` comments.

**First-non-null merge across chunks.** Same pattern used for `canaryId`: chunks in a single analysis share the same offscreen engine so they should always report the same mode. Defensive merge just in case.

**Field is read at response time, not at module load.** `getWebGPUAdapterInfo()?.mode ?? null` is evaluated on each `PROBE_RESULTS` send, so a late introspection result (e.g. engine initialised after the first chunk was queued) still lands on subsequent messages.

**Origin-denied skip path gets `null`.** When the deny-list short-circuits before any engine work, there's no introspection to record; surfaces as \`null\` like pre-existing verdicts.

## Methodology doc

Replaces the TBD with the real field. Source order in §5.3 is now: verdict field (primary) → storage scrape → `getWebGPUAdapterInfo()` in offscreen console → engine-init log line. The Chrome Stable worked-example row loses its literal extension ID (was drift-prone; rotates on every \`Load unpacked\`).

## Impact

| Change | Before | After |
|---|---|---|
| `SecurityVerdict.webgpuAdapterMode` | absent | `'core' | 'compatibility' | 'none' | 'unknown' | null` |
| `AISecurityReport.webgpuAdapterMode` | absent | mirrors verdict |
| `PROBE_RESULTS` message | no adapter signal | carries mode |
| Methodology doc | TBD + console scrape | points at verdict field |

Additive only. No behavioural change — nothing reads the new field yet beyond \`__AI_SECURITY_REPORT__\`.

## Test plan

- [x] 4 new tests locking \`webgpuAdapterMode\` propagation in \`evaluatePolicy\` (default null, score-derived, UNKNOWN, all four literals)
- [x] \`npm run typecheck\` green
- [x] \`npm test\` green (335 → 339)
- [x] \`npm run build\` green
- [ ] CI green
- [ ] **Manual verification** (user): after build + reload, scan any page, open persisted storage in the popup or SW console, confirm \`webgpuAdapterMode\` is populated with one of the four literals (likely \`'core'\` on your dev machine).

## Risk / rollback

Low. Purely additive schema + propagation. No scoring logic depends on the field. \`git revert\` cleanly if the field shape needs to change before consumers adopt it.

## Cross-refs

- #49 / PR #56 — upstream introspection
- #57 — audit methodology consuming this field
- #8 — audit population that benefits from this landing