### PR TITLE
chore(#87): Pages 404.html so missing paths return HTTP 404

### DIFF
--- a/test-pages/404.html
+++ b/test-pages/404.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="robots" content="noindex, noarchive, nofollow">
+  <title>Not found — HoneyLLM Research Fixtures</title>
+</head>
+<body style="background:#0f0f0f; color:#e0e0e0; margin:0; font-family:-apple-system,BlinkMacSystemFont,sans-serif;">
+  <div style="padding: 24px; max-width: 1100px; margin: 0 auto;">
+    <h1>404 — Not found</h1>
+    <p>The path you requested does not exist in this fixture catalog.</p>
+    <p>Available roots: <a href="/" style="color:#93c5fd;">/</a> · <a href="/manifest.json" style="color:#93c5fd;">/manifest.json</a> · <a href="/manifest-dialect.json" style="color:#93c5fd;">/manifest-dialect.json</a></p>
+    <p style="color:#666; font-size:12px; margin-top:16px;">If you were looking for a test harness or tooling page, those live in the repo under <code>harnesses/</code> and are run locally — they are not published here.</p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Adds \`test-pages/404.html\` so Cloudflare Pages returns HTTP 404 for missing paths instead of HTTP 200 with the fixtures index as SPA fallback.
- Closes #87.

## Why

After PR #82 moved harness / issue-graph / generator files out of the deploy tree and I tore down + rebuilt the Pages project, curl-probing the deprecated URLs returned HTTP 200:

\`\`\`
200  /manual-test-harness
200  /nano-harness
200  /issue-graph
200  /generate.ts
200  /this-path-does-not-exist-random-abcdef
\`\`\`

\`grep\`-against the responses confirms zero harness content — security-wise the teardown succeeded. The 200 is just Cloudflare's default 'SPA fallback' serving index.html for unknown paths. That's misleading for anyone checking the deprecated URLs.

## Fix

Per Cloudflare Pages docs (\`pages/configuration/serving-pages\`): adding a top-level \`404.html\` makes Pages serve it with HTTP 404 for missing paths.

\`_redirects\` won't work — docs explicitly rule out 404 as a rewrite status code (\`pages/configuration/redirects\`: 'Rewrites (other status codes) ❌ — /blog/\\\* /blog/404.html 404 — Not supported').

## Test plan

- [x] Author \`test-pages/404.html\`
- [ ] Cloudflare Pages auto-deploys on merge
- [ ] After deploy: re-run curl probes and confirm 404 on deprecated paths, 200 on legitimate fixture paths