### PR TITLE
fix(harness): wire Resume-from-cell offsets into runSweep

### DIFF
--- a/harnesses/index.js
+++ b/harnesses/index.js
@@ -257,8 +257,11 @@ async function runSweep(api, options) {
   const totalCells = PROBE_ORDER.length * INPUT_ORDER.length;
   const total = totalCells * options.replicates;
   const firstLoadRecorded = { value: false };
-  for (let replicate = 1; replicate <= options.replicates; replicate += 1) {
-    for (let cellIndex = 0; cellIndex < totalCells; cellIndex += 1) {
+  const startReplicate = options.startFromReplicate ?? 1;
+  const startCellIndex = options.startFromCellIndex ?? 0;
+  for (let replicate = startReplicate; replicate <= options.replicates; replicate += 1) {
+    const innerStart = replicate === startReplicate ? startCellIndex : 0;
+    for (let cellIndex = innerStart; cellIndex < totalCells; cellIndex += 1) {
       if (options.shouldAbort?.() === true) return results;
       const probe = PROBE_ORDER[Math.floor(cellIndex / INPUT_ORDER.length)];
       const input = INPUT_ORDER[cellIndex % INPUT_ORDER.length];
@@ -791,15 +794,29 @@ async function doSweep(resume) {
     persistSweepState();
   }
   sweepAborter = { abort: false };
+  const totalCells = PROBE_ORDER.length * INPUT_ORDER.length;
+  const plannedTotal = totalCells * replicates;
+  const resumeFrom = resume ? currentResults.length : 0;
+  if (resumeFrom >= plannedTotal) {
+    releaseSweepLock("nano");
+    if (startBtn !== null) startBtn.disabled = false;
+    const resumeBtn = document.getElementById("resume-btn");
+    if (resumeBtn !== null) resumeBtn.style.display = "none";
+    return;
+  }
+  const startFromReplicate = Math.floor(resumeFrom / totalCells) + 1;
+  const startFromCellIndex = resumeFrom % totalCells;
   try {
     await runSweep(api, {
       replicates,
+      startFromReplicate,
+      startFromCellIndex,
       onCellStart: (cellIndex) => renderCell(cellIndex, "running", null, ""),
       onProgress: (p) => {
         const r = p.lastCell;
         currentResults.push(r);
         renderCell(r.index, r.row.error_message !== null ? "error" : "done", r.row.inference_ms, r.row.output.length > 0 ? r.row.output : r.row.error_message ?? "");
-        setProgress(p.completed, p.total);
+        setProgress(currentResults.length, p.total);
         persistSweepState();
       },
       shouldAbort: () => sweepAborter.abort

--- a/harnesses/index.ts
+++ b/harnesses/index.ts
@@ -538,15 +538,30 @@ async function doSweep(resume: boolean): Promise<void> {
   }
   sweepAborter = { abort: false };
 
+  const totalCells = PROBE_ORDER.length * INPUT_ORDER.length;
+  const plannedTotal = totalCells * replicates;
+  const resumeFrom = resume ? currentResults.length : 0;
+  if (resumeFrom >= plannedTotal) {
+    releaseSweepLock('nano');
+    if (startBtn !== null) startBtn.disabled = false;
+    const resumeBtn = document.getElementById('resume-btn');
+    if (resumeBtn !== null) resumeBtn.style.display = 'none';
+    return;
+  }
+  const startFromReplicate = Math.floor(resumeFrom / totalCells) + 1;
+  const startFromCellIndex = resumeFrom % totalCells;
+
   try {
     await runSweep(api, {
       replicates,
+      startFromReplicate,
+      startFromCellIndex,
       onCellStart: (cellIndex) => renderCell(cellIndex, 'running', null, ''),
       onProgress: (p) => {
         const r = p.lastCell;
         currentResults.push(r);
         renderCell(r.index, r.row.error_message !== null ? 'error' : 'done', r.row.inference_ms, r.row.output.length > 0 ? r.row.output : (r.row.error_message ?? ''));
-        setProgress(p.completed, p.total);
+        setProgress(currentResults.length, p.total);
         persistSweepState();
       },
       shouldAbort: () => sweepAborter.abort,

--- a/harnesses/lib/nano-sweep.ts
+++ b/harnesses/lib/nano-sweep.ts
@@ -169,6 +169,10 @@ export interface SweepProgress {
 
 export interface SweepOptions {
   readonly replicates: number;
+  /** 1-indexed replicate to start at. Cells before this are skipped. Default 1. */
+  readonly startFromReplicate?: number;
+  /** 0-indexed cell within startFromReplicate. Later replicates start at 0. Default 0. */
+  readonly startFromCellIndex?: number;
   readonly onProgress?: (p: SweepProgress) => void;
   readonly onCellStart?: (cellIndex: number, replicate: number) => void;
   readonly shouldAbort?: () => boolean;
@@ -179,9 +183,12 @@ export async function runSweep(api: LanguageModelAPI, options: SweepOptions): Pr
   const totalCells = PROBE_ORDER.length * INPUT_ORDER.length;
   const total = totalCells * options.replicates;
   const firstLoadRecorded = { value: false };
+  const startReplicate = options.startFromReplicate ?? 1;
+  const startCellIndex = options.startFromCellIndex ?? 0;
 
-  for (let replicate = 1; replicate <= options.replicates; replicate += 1) {
-    for (let cellIndex = 0; cellIndex < totalCells; cellIndex += 1) {
+  for (let replicate = startReplicate; replicate <= options.replicates; replicate += 1) {
+    const innerStart = replicate === startReplicate ? startCellIndex : 0;
+    for (let cellIndex = innerStart; cellIndex < totalCells; cellIndex += 1) {
       if (options.shouldAbort?.() === true) return results;
 
       const probe = PROBE_ORDER[Math.floor(cellIndex / INPUT_ORDER.length)]!;


### PR DESCRIPTION
## Summary

- `runSweep` now accepts `startFromReplicate` / `startFromCellIndex` and honours them; the outer loop skips earlier replicates, the inner loop skips earlier cells only in the first replicate.
- `doSweep(resume=true)` derives the offsets from `currentResults.length`, early-bails when the stored run already covers the planned total (e.g. user lowered replicates after a big run), and passes `currentResults.length` to `setProgress` so the bar doesn't reset to 1/N on the first resumed cell.

## Why

Without this, `Resume from N` re-executed cells 1..N-1, pushed duplicates into `currentResults`, and displayed a progress bar that started at 1/total instead of N/total. The PR #90 test plan lists "reload mid-sweep and confirm Resume picks up from next cell" — that checkbox wouldn't have passed on manual run.

## Verification

Ran a mock `LanguageModel` against `runSweep` to confirm all four resume shapes:

| Scenario | Expected | Actual |
|---|---|---|
| fresh, replicates=1 | 27 cells, indices 0..26 | ✓ |
| resume mid-replicate (cell=14) | 13 cells, first idx 14 | ✓ |
| resume across replicates (40 done, replicates=3) | 41 cells, first (r2, i13) | ✓ |
| already past requested replicates | 0 cells | ✓ |

- `npm run typecheck` clean
- `npm run harness:build` clean (index.js 51.4kb)
- `npm test` → 396/396 pass

## Test plan

- [x] Typecheck + unit tests + harness build
- [ ] Manual: run `npm run harness`, start a sweep at replicates=5, reload mid-sweep, click Resume — expect work to pick up at the next cell, progress bar to continue from the prior count, no duplicate rows in the exported JSON
- [ ] Manual: let a sweep finish, lower replicates to 1, click Resume — expect the button to hide without re-running anything

Refs PR #90. Does not address the other review items (hardcoded extension ID, committed `.js` drift, classifier duplication, missing unit coverage) — those stay in the PR #90 discussion.