### PR TITLE
refactor(harness-#97): pendingChip() helper + currentRoute JSDoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ test-data/repos/
 # Local Claude Code workspace (session-specific, not shared)
 .claude/
 
+# Session exploration scratch (converted to issues/PRs at session end)
+.session-findings/
+
 # Playwright persistent profiles used by Phase 2/3 baseline runners
 .playwright-profile-*/
 

--- a/docs/issue-graph.md
+++ b/docs/issue-graph.md
@@ -1,8 +1,8 @@
 # Issue graph overlay
 
-_Agent-maintained. Last synced: 2026-04-21T22:28:16.233Z_
+_Agent-maintained. Last synced: 2026-04-23T08:05:00.297Z_
 
-**In progress:** #86 (branch fix/issue-86-harness-local-http — restoring http delivery via scripts/serve-harnesses.ts (loopback 127.0.0.1:8765) + content-script early-return on that host. Not closing #86 (manifest-level file:// exclude remains a separate design decision).)
+**In progress:** #2 (branch refactor/unified-harness-console — unified hash-routed Test Console covering S1–S4 of the manual test plan. Directly supports closing #2 Stage B5 (Claude/ChatGPT/Gemini matrices) and #14 Nano replicate sweep. Adds SW externally_connectable handler for contention-aware amber Start.)
 
 **Clusters:** chat-agentic, classifier, determillm-gates, determillm-tracking, dialect, future-feature, hunters, infrastructure, nano, phase-3, phase-4, phase-5, phase-6+, phase-8-candidate, phase-8-engine, project-determillm, project-honeyllm, upstream
 
@@ -34,14 +34,14 @@ note: Phase 3 Track B Stage B5-B7 coordination + the upstream MLC web-llm race-c
 
 ```issue-graph
 cluster: classifier
-members: [15, 83, 84]
-note: Classifier lineage: v1 substring (byte-locked) → v2 JSON-aware (shipped via closed #13) → v3 refusal-with-quoted-URL disambiguation (#83). Mini-sweep #15 for FP tuning. Test-tooling drift #84 (Gemini timeout) tracks here because it affects classifier-run reliability.
+members: [15, 83, 84, 92]
+note: Classifier lineage: v1 substring (byte-locked) → v2 JSON-aware (shipped via closed #13) → v3 refusal-with-quoted-URL disambiguation (#83). Mini-sweep #15 for FP tuning. Test-tooling drift #84 (Gemini timeout) tracks here because it affects classifier-run reliability. #92 fixes bare-substring URL FP in the harness S3-matrix classifier (separate from byte-locked v1 in nano-sweep.ts).
 ```
 
 ```issue-graph
 cluster: phase-8-engine
-members: [6, 14, 17, 18, 25, 51, 86]
-note: Phase 8 engine polish: delta-cache + turboquant (#6), Nano replicates (#14), engine-health probe (#17), chunk concurrency revisit (#18), tokeniser-aware chunking (#25), site-structure registry (#51), file:// content-script exclusion (#86).
+members: [6, 14, 17, 18, 25, 51, 86, 93, 94, 95, 96, 97]
+note: Phase 8 engine polish: delta-cache + turboquant (#6), Nano replicates (#14), engine-health probe (#17), chunk concurrency revisit (#18), tokeniser-aware chunking (#25), site-structure registry (#51), file:// content-script exclusion (#86). Harness hygiene surfaced by 2026-04-23 behavioural testing: Web Locks API for cross-tab sweep race (#93), persistence observability + Zod (#94), contention banner inFlightCount (#95), SUSPICIOUS vs COMPROMISED chip rendering (#96), pendingChip helper + currentRoute JSDoc (#97).
 ```
 
 ```issue-graph

--- a/harnesses/index.js
+++ b/harnesses/index.js
@@ -82,6 +82,13 @@ function classifyChip(fixture, reachable, bytes, scan, httpStatus, errorText) {
     title: "Spider stayed quiet on a clean fixture \u2014 expected outcome."
   };
 }
+function pendingChip() {
+  return {
+    kind: "pending",
+    text: "not checked",
+    title: "Fixture has not been checked yet in this session."
+  };
+}
 function classifyAgentResponse(response) {
   const lower = response.toLowerCase();
   return {
@@ -847,7 +854,8 @@ function buildFixtureTable(tbodyId, prefix) {
       attrs: { href: `${FIXTURE_HOST}${fx.path}`, target: "_blank", rel: "noopener" }
     }));
     fixtureCell.appendChild(el("div", { className: "ref", text: `expect ${fx.expected}: ${fx.description}` }));
-    const chip = el("span", { className: "spider-chip pending", text: "not checked" });
+    const chip = el("span");
+    paintChip(chip, pendingChip());
     fixtureCell.appendChild(chip);
     PREVIEW_REGISTRY.push({ path: fx.path, fixture: fx, fp, chip });
     const checkBtn = el("button", { className: "secondary tiny", text: "Check" });
@@ -944,8 +952,7 @@ function recomputeSectionStatus(prefix) {
 async function previewRow(fp) {
   const row = PREVIEW_REGISTRY.find((r) => r.fp === fp);
   if (row === void 0) return;
-  row.chip.className = "spider-chip pending";
-  row.chip.textContent = "checking\u2026";
+  paintChip(row.chip, { kind: "pending", text: "checking\u2026", title: "Fetching fixture to run Spider scan." });
   try {
     const res = await fetch(`${FIXTURE_HOST}${row.path}`);
     if (!res.ok) throw new Error(`HTTP ${res.status}`);

--- a/harnesses/index.ts
+++ b/harnesses/index.ts
@@ -15,6 +15,7 @@ import {
   saveState,
   spiderScan,
   classifyChip,
+  pendingChip,
   classifyAgentResponse,
   deriveAgentOutcome,
   acquireSweepLock,
@@ -600,7 +601,8 @@ function buildFixtureTable(tbodyId: string, prefix: string): void {
       attrs: { href: `${FIXTURE_HOST}${fx.path}`, target: '_blank', rel: 'noopener' },
     }));
     fixtureCell.appendChild(el('div', { className: 'ref', text: `expect ${fx.expected}: ${fx.description}` }));
-    const chip = el('span', { className: 'spider-chip pending', text: 'not checked' });
+    const chip = el('span');
+    paintChip(chip, pendingChip());
     fixtureCell.appendChild(chip);
     PREVIEW_REGISTRY.push({ path: fx.path, fixture: fx, fp, chip });
     const checkBtn = el('button', { className: 'secondary tiny', text: 'Check' });
@@ -704,8 +706,7 @@ function recomputeSectionStatus(prefix: string): void {
 async function previewRow(fp: string): Promise<void> {
   const row = PREVIEW_REGISTRY.find((r) => r.fp === fp);
   if (row === undefined) return;
-  row.chip.className = 'spider-chip pending';
-  row.chip.textContent = 'checking…';
+  paintChip(row.chip, { kind: 'pending', text: 'checking…', title: 'Fetching fixture to run Spider scan.' });
   try {
     const res = await fetch(`${FIXTURE_HOST}${row.path}`);
     if (!res.ok) throw new Error(`HTTP ${res.status}`);

--- a/harnesses/issue-graph/data.json
+++ b/harnesses/issue-graph/data.json
@@ -1,6 +1,107 @@
 {
-  "syncedAt": "2026-04-21T22:28:16.233Z",
+  "syncedAt": "2026-04-23T08:05:00.297Z",
   "nodes": [
+    {
+      "number": 97,
+      "kind": "issue",
+      "title": "refactor(harness): honest ChipKind via pendingChip() helper + currentRoute JSDoc",
+      "state": "open",
+      "labels": [
+        "phase-8-candidate",
+        "finding",
+        "project-honeyllm"
+      ],
+      "clusters": [
+        "phase-8-candidate",
+        "project-honeyllm",
+        "phase-8-engine"
+      ]
+    },
+    {
+      "number": 96,
+      "kind": "issue",
+      "title": "feat(harness): distinguish SUSPICIOUS vs COMPROMISED chip rendering",
+      "state": "open",
+      "labels": [
+        "enhancement",
+        "phase-8-candidate",
+        "finding",
+        "project-honeyllm"
+      ],
+      "clusters": [
+        "phase-8-candidate",
+        "project-honeyllm",
+        "phase-8-engine"
+      ]
+    },
+    {
+      "number": 95,
+      "kind": "issue",
+      "title": "feat(harness): surface inFlightCount in contention banner; drop unused url field from pingExtension",
+      "state": "open",
+      "labels": [
+        "enhancement",
+        "phase-8-candidate",
+        "finding",
+        "project-honeyllm"
+      ],
+      "clusters": [
+        "phase-8-candidate",
+        "project-honeyllm",
+        "phase-8-engine"
+      ]
+    },
+    {
+      "number": 94,
+      "kind": "issue",
+      "title": "fix(harness): persistence layer silently swallows save failures (quota, BigInt, Map/Set, circular)",
+      "state": "open",
+      "labels": [
+        "bug",
+        "phase-8-candidate",
+        "finding",
+        "project-honeyllm"
+      ],
+      "clusters": [
+        "phase-8-candidate",
+        "project-honeyllm",
+        "phase-8-engine"
+      ]
+    },
+    {
+      "number": 93,
+      "kind": "issue",
+      "title": "fix(harness): cross-tab sweep-lock race — localStorage has no CAS",
+      "state": "open",
+      "labels": [
+        "bug",
+        "phase-8-candidate",
+        "finding",
+        "project-honeyllm"
+      ],
+      "clusters": [
+        "phase-8-candidate",
+        "project-honeyllm",
+        "phase-8-engine"
+      ]
+    },
+    {
+      "number": 92,
+      "kind": "issue",
+      "title": "fix(harness): substring FP in agent classifier URL check — bare 'ngrok' matches 'mongrok'/'ngrokker'",
+      "state": "open",
+      "labels": [
+        "bug",
+        "phase-8-candidate",
+        "finding",
+        "project-honeyllm"
+      ],
+      "clusters": [
+        "phase-8-candidate",
+        "project-honeyllm",
+        "classifier"
+      ]
+    },
     {
       "number": 87,
       "kind": "issue",
@@ -31,10 +132,10 @@
       ],
       "overlayStatus": {
         "kind": "status",
-        "status": "in-progress",
+        "status": "touched",
         "issue": 86,
-        "started": "2026-04-22T00:00:00Z",
-        "note": "branch fix/issue-86-harness-local-http — restoring http delivery via scripts/serve-harnesses.ts (loopback 127.0.0.1:8765) + content-script early-return on that host. Not closing #86 (manifest-level file:// exclude remains a separate design decision)."
+        "completed": "2026-04-22T00:15:00Z",
+        "note": "PR #89 merged — loopback http delivery + content-script early-return on 127.0.0.1:8765. #86 remains open for the manifest-level file:// exclude decision."
       }
     },
     {
@@ -894,7 +995,46 @@
         "phase-3",
         "project-honeyllm",
         "infrastructure"
-      ]
+      ],
+      "overlayStatus": {
+        "kind": "status",
+        "status": "in-progress",
+        "issue": 2,
+        "started": "2026-04-22T00:25:00Z",
+        "note": "branch refactor/unified-harness-console — unified hash-routed Test Console covering S1–S4 of the manual test plan. Directly supports closing #2 Stage B5 (Claude/ChatGPT/Gemini matrices) and #14 Nano replicate sweep. Adds SW externally_connectable handler for contention-aware amber Start."
+      }
+    },
+    {
+      "number": 99,
+      "kind": "pr",
+      "title": "refactor(harness-#97): pendingChip() helper + currentRoute JSDoc",
+      "state": "open",
+      "labels": [],
+      "clusters": []
+    },
+    {
+      "number": 98,
+      "kind": "pr",
+      "title": "fix(harness-#92): word-boundary URL matching in classifyAgentResponse",
+      "state": "open",
+      "labels": [],
+      "clusters": []
+    },
+    {
+      "number": 91,
+      "kind": "pr",
+      "title": "fix(harness): wire Resume-from-cell offsets into runSweep",
+      "state": "merged",
+      "labels": [],
+      "clusters": []
+    },
+    {
+      "number": 90,
+      "kind": "pr",
+      "title": "refactor(#2,#14): unified hash-routed Test Console for manual testing",
+      "state": "merged",
+      "labels": [],
+      "clusters": []
     },
     {
       "number": 89,
@@ -1147,6 +1287,41 @@
       "from": 86,
       "to": 14,
       "note": "File:// content-script exclusion (#86) blocks Nano replicate-sampling (#14) — harness can't run while extension auto-analyses the same page."
+    },
+    {
+      "type": "references",
+      "from": 96,
+      "to": 3
+    },
+    {
+      "type": "references",
+      "from": 96,
+      "to": 75
+    },
+    {
+      "type": "references",
+      "from": 96,
+      "to": 2
+    },
+    {
+      "type": "references",
+      "from": 95,
+      "to": 2
+    },
+    {
+      "type": "references",
+      "from": 93,
+      "to": 14
+    },
+    {
+      "type": "references",
+      "from": 92,
+      "to": 2
+    },
+    {
+      "type": "references",
+      "from": 92,
+      "to": 83
     },
     {
       "type": "references",
@@ -1992,6 +2167,51 @@
       "type": "references",
       "from": 5,
       "to": 4
+    },
+    {
+      "type": "references",
+      "from": 99,
+      "to": 97
+    },
+    {
+      "type": "references",
+      "from": 98,
+      "to": 2
+    },
+    {
+      "type": "references",
+      "from": 98,
+      "to": 92
+    },
+    {
+      "type": "references",
+      "from": 91,
+      "to": 90
+    },
+    {
+      "type": "references",
+      "from": 90,
+      "to": 89
+    },
+    {
+      "type": "references",
+      "from": 90,
+      "to": 8
+    },
+    {
+      "type": "references",
+      "from": 90,
+      "to": 14
+    },
+    {
+      "type": "references",
+      "from": 90,
+      "to": 2
+    },
+    {
+      "type": "references",
+      "from": 90,
+      "to": 86
     },
     {
       "type": "references",

--- a/harnesses/lib/harness-state.ts
+++ b/harnesses/lib/harness-state.ts
@@ -135,6 +135,14 @@ export function classifyChip(fixture: Fixture, reachable: boolean, bytes: number
   };
 }
 
+export function pendingChip(): ChipResult {
+  return {
+    kind: 'pending',
+    text: 'not checked',
+    title: 'Fixture has not been checked yet in this session.',
+  };
+}
+
 // ---------- Agent response classifier ----------
 
 export interface AgentClassification {
@@ -249,6 +257,13 @@ export interface RouteDef {
   readonly label: string;
 }
 
+/**
+ * Returns the raw hash payload (everything after `#` or `#/`), or `defaultId`
+ * when the hash is empty. Only a single leading `/` is stripped — this parser
+ * does not split, decode, or whitelist the result. Consumers are responsible
+ * for validating the returned id against an allowed set and handling fallback
+ * for unknown routes.
+ */
 export function currentRoute(defaultId: string): string {
   const raw = window.location.hash.replace(/^#\/?/, '');
   return raw.length > 0 ? raw : defaultId;


### PR DESCRIPTION
## Summary

- **F3** — Adds `pendingChip()` helper so `ChipKind` is honest. Previously the `'pending'` variant was declared in the type but never produced by `classifyChip()`; callers built "pending" chips via raw CSS class strings, bypassing the type system. Refactored the two call sites in `harnesses/index.ts` to use `paintChip(chip, pendingChip())` — all chip rendering now flows through the same type-safe path.

- **HR-1** — Adds JSDoc to `currentRoute()` documenting that it returns the raw hash payload and that consumers are responsible for whitelist validation. The current consumer at `harnesses/index.ts:68` does this correctly (validates against `ROUTE_IDS`, falls back to `'s1'`), but the expectation wasn't written down.

- Adds `.session-findings/` to `.gitignore` so exploratory-session scratch doesn't leak.

## Why

Both findings came out of the 2026-04-23 behavioural-testing session:
- Chip classification probe (13 cases, 13 pass) surfaced the dead `'pending'` kind.
- Hash router probe (31 cases, 31 pass) surfaced five edge cases where `currentRoute` returns surprising strings (`'foo/bar'`, `'/double'`, `'s1?x=1'`, `'s1%20test'`, `' s1'`) — all correctly handled by the consumer's whitelist, so no bug, but worth documenting.

## Scope

Pure hygiene. No behaviour change. Two raw-CSS-string call sites become typed. One function gets a comment.

## Verification

- `npm run typecheck`: clean
- `npm test`: 396/396 pass
- `npm run harness:build`: clean

## Test plan

- [ ] Manual: visit `http://127.0.0.1:8765/#/s3-claude`, confirm the "not checked" chips render identically to pre-refactor (same CSS class `spider-chip pending`, same text, same hover title).
- [ ] Manual: click Check on a fixture, confirm the `checking…` text appears briefly with `pending` styling before resolving.

## Issue linkage

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)