### PR TITLE
chore(graph): overlay cleanup post-PR-merge cascade

### DIFF
--- a/docs/issue-graph.md
+++ b/docs/issue-graph.md
@@ -1,8 +1,6 @@
 # Issue graph overlay
 
-_Agent-maintained. Last synced: 2026-04-23T08:05:00.297Z_
-
-**In progress:** #2 (branch refactor/unified-harness-console — unified hash-routed Test Console covering S1–S4 of the manual test plan. Directly supports closing #2 Stage B5 (Claude/ChatGPT/Gemini matrices) and #14 Nano replicate sweep. Adds SW externally_connectable handler for contention-aware amber Start.)
+_Agent-maintained. Last synced: 2026-04-23T10:44:04.501Z_
 
 **Clusters:** chat-agentic, classifier, determillm-gates, determillm-tracking, dialect, future-feature, hunters, infrastructure, nano, phase-3, phase-4, phase-5, phase-6+, phase-8-candidate, phase-8-engine, project-determillm, project-honeyllm, upstream
 
@@ -34,14 +32,14 @@ note: Phase 3 Track B Stage B5-B7 coordination + the upstream MLC web-llm race-c
 
 ```issue-graph
 cluster: classifier
-members: [15, 83, 84, 92]
-note: Classifier lineage: v1 substring (byte-locked) → v2 JSON-aware (shipped via closed #13) → v3 refusal-with-quoted-URL disambiguation (#83). Mini-sweep #15 for FP tuning. Test-tooling drift #84 (Gemini timeout) tracks here because it affects classifier-run reliability. #92 fixes bare-substring URL FP in the harness S3-matrix classifier (separate from byte-locked v1 in nano-sweep.ts).
+members: [15, 83, 84]
+note: Classifier lineage: v1 substring (byte-locked) → v2 JSON-aware (shipped via closed #13) → v3 refusal-with-quoted-URL disambiguation (#83). Mini-sweep #15 for FP tuning. Test-tooling drift #84 (Gemini timeout) tracks here because it affects classifier-run reliability. Harness S3-matrix bare-substring URL FP fix shipped via closed #92 (PR #98, 2026-04-23).
 ```
 
 ```issue-graph
 cluster: phase-8-engine
-members: [6, 14, 17, 18, 25, 51, 86, 93, 94, 95, 96, 97]
-note: Phase 8 engine polish: delta-cache + turboquant (#6), Nano replicates (#14), engine-health probe (#17), chunk concurrency revisit (#18), tokeniser-aware chunking (#25), site-structure registry (#51), file:// content-script exclusion (#86). Harness hygiene surfaced by 2026-04-23 behavioural testing: Web Locks API for cross-tab sweep race (#93), persistence observability + Zod (#94), contention banner inFlightCount (#95), SUSPICIOUS vs COMPROMISED chip rendering (#96), pendingChip helper + currentRoute JSDoc (#97).
+members: [6, 14, 17, 18, 25, 51, 86, 93, 94, 95, 96]
+note: Phase 8 engine polish: delta-cache + turboquant (#6), Nano replicates (#14), engine-health probe (#17), chunk concurrency revisit (#18), tokeniser-aware chunking (#25), site-structure registry (#51), file:// content-script exclusion (#86). Harness hygiene surfaced by 2026-04-23 behavioural testing: Web Locks API for cross-tab sweep race (#93), persistence observability + Zod (#94), contention banner inFlightCount (#95), SUSPICIOUS vs COMPROMISED chip rendering (#96). pendingChip helper + currentRoute JSDoc shipped via closed #97 (PR #99, 2026-04-23).
 ```
 
 ```issue-graph
@@ -105,8 +103,8 @@ note: PR #89 merged — loopback http delivery + content-script early-return on 
 ```
 
 ```issue-graph
-status: in-progress
+status: touched
 issue: 2
-started: 2026-04-22T00:25:00Z
-note: branch refactor/unified-harness-console — unified hash-routed Test Console covering S1–S4 of the manual test plan. Directly supports closing #2 Stage B5 (Claude/ChatGPT/Gemini matrices) and #14 Nano replicate sweep. Adds SW externally_connectable handler for contention-aware amber Start.
+completed: 2026-04-23T08:30:00Z
+note: PRs #90, #91, #98, #99 shipped harness-layer support for S3 matrix testing (Test Console, sweep resume, classifier fix, pendingChip helper). #2 was auto-closed by PR #98's Development-panel linkage and manually reopened — remaining scope is the B5 manual agent-mode testing + B7 regression report, pending $20 AUD budget and user time at agent UIs. Next session: guided manual testing walkthrough.
 ```

--- a/harnesses/issue-graph/data.json
+++ b/harnesses/issue-graph/data.json
@@ -1,11 +1,11 @@
 {
-  "syncedAt": "2026-04-23T08:05:00.297Z",
+  "syncedAt": "2026-04-23T10:44:04.501Z",
   "nodes": [
     {
       "number": 97,
       "kind": "issue",
       "title": "refactor(harness): honest ChipKind via pendingChip() helper + currentRoute JSDoc",
-      "state": "open",
+      "state": "closed",
       "labels": [
         "phase-8-candidate",
         "finding",
@@ -13,8 +13,7 @@
       ],
       "clusters": [
         "phase-8-candidate",
-        "project-honeyllm",
-        "phase-8-engine"
+        "project-honeyllm"
       ]
     },
     {
@@ -89,7 +88,7 @@
       "number": 92,
       "kind": "issue",
       "title": "fix(harness): substring FP in agent classifier URL check — bare 'ngrok' matches 'mongrok'/'ngrokker'",
-      "state": "open",
+      "state": "closed",
       "labels": [
         "bug",
         "phase-8-candidate",
@@ -98,8 +97,7 @@
       ],
       "clusters": [
         "phase-8-candidate",
-        "project-honeyllm",
-        "classifier"
+        "project-honeyllm"
       ]
     },
     {
@@ -998,17 +996,17 @@
       ],
       "overlayStatus": {
         "kind": "status",
-        "status": "in-progress",
+        "status": "touched",
         "issue": 2,
-        "started": "2026-04-22T00:25:00Z",
-        "note": "branch refactor/unified-harness-console — unified hash-routed Test Console covering S1–S4 of the manual test plan. Directly supports closing #2 Stage B5 (Claude/ChatGPT/Gemini matrices) and #14 Nano replicate sweep. Adds SW externally_connectable handler for contention-aware amber Start."
+        "completed": "2026-04-23T08:30:00Z",
+        "note": "PRs #90, #91, #98, #99 shipped harness-layer support for S3 matrix testing (Test Console, sweep resume, classifier fix, pendingChip helper). #2 was auto-closed by PR #98's Development-panel linkage and manually reopened — remaining scope is the B5 manual agent-mode testing + B7 regression report, pending $20 AUD budget and user time at agent UIs. Next session: guided manual testing walkthrough."
       }
     },
     {
       "number": 99,
       "kind": "pr",
       "title": "refactor(harness-#97): pendingChip() helper + currentRoute JSDoc",
-      "state": "open",
+      "state": "merged",
       "labels": [],
       "clusters": []
     },
@@ -1016,7 +1014,7 @@
       "number": 98,
       "kind": "pr",
       "title": "fix(harness-#92): word-boundary URL matching in classifyAgentResponse",
-      "state": "open",
+      "state": "merged",
       "labels": [],
       "clusters": []
     },


### PR DESCRIPTION
## Summary

Post-merge housekeeping for the 2026-04-23 PR batch. Resolves graph:sync drift warnings for the two recently-closed issues and replaces a stale in-progress block.

## Changes

- Remove #92 from `classifier` cluster members (closed via PR #98)
- Remove #97 from `phase-8-engine` cluster members (closed via PR #99)
- Both closures documented in the cluster note as historical references
- Replace stale `status: in-progress, issue: 2` block with `status: touched` completion entry documenting the four supporting PRs (#90, #91, #98, #99) and the remaining scope (B5 manual testing + B7 regression report)

## Why #2's status block is "touched" not "closed"

#2 was auto-closed by PR #98's Development-panel linkage on merge (despite the PR body's explicit "does not close #2" parenthetical). I manually reopened it because the remaining scope — B5 agent-mode testing at Claude.ai / ChatGPT / Gemini + B7 regression report — has not been performed yet. Next-session guided manual testing is what will close it properly.

## Process note — root-cause of the auto-close

PR #98's body contained a `## Issue linkage` section with both `Closes #92` and `Refs #2 (... this PR does not close #2)`. GitHub's auto-close keyword matcher only triggers on `Closes/Fixes/Resolves`, so that part was fine. But the **Development panel sidebar** on the issue page links PRs to issues based on all mentions in title/body/branch, and on merge it auto-closed everything it had linked — ignoring the parenthetical intent.

**Future-PR discipline:** avoid dedicated `## Issue linkage` sections when the PR references multiple issues with different close semantics. Put a single `Closes #N` on its own line at end of body; mention related-but-not-closing issues in narrative prose within the body text. Documented in the commit message.

## Verification

- `npm run graph:sync` → `41 open, 30 closed, 28 merged, 286 edges, 0 drift warnings`
- No code changes; documentation/overlay only

## Test plan

- [x] graph:sync reports 0 drift
- [ ] CI `graph-drift` check passes

## Issue linkage

None. (Deliberately avoiding a Closes/Refs section here — this PR exists to fix the overlay after the previous PRs' merge cascade and doesn't need issue linkage of its own.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)