### PR TITLE
fix(harness-#95): align pingExtension with SW pong contract

### DIFF
--- a/harnesses/index.js
+++ b/harnesses/index.js
@@ -140,17 +140,19 @@ function isSweepLocked(kind) {
   }
   return false;
 }
-var UNAVAILABLE = { available: false, analysing: false, inFlightCount: 0, inFlightTabIds: [] };
+function unavailable() {
+  return { available: false, analysing: false, inFlightCount: 0, inFlightTabIds: [] };
+}
 async function pingExtension() {
   const runtime = globalThis.chrome;
   if (runtime?.runtime?.sendMessage === void 0) {
-    return UNAVAILABLE;
+    return unavailable();
   }
   try {
     const response = await runtime.runtime.sendMessage(EXTENSION_ID_HINT, { type: "HONEYLLM_STATUS_PING" });
-    if (response === null || typeof response !== "object") return UNAVAILABLE;
+    if (response === null || typeof response !== "object") return unavailable();
     const r = response;
-    if (r.type !== "HONEYLLM_STATUS_PONG") return UNAVAILABLE;
+    if (r.type !== "HONEYLLM_STATUS_PONG") return unavailable();
     const inFlightCount = typeof r.inFlightCount === "number" && Number.isFinite(r.inFlightCount) ? r.inFlightCount : 0;
     const inFlightTabIds = Array.isArray(r.inFlightTabIds) ? r.inFlightTabIds.filter((n) => typeof n === "number" && Number.isFinite(n)) : [];
     return {
@@ -160,7 +162,7 @@ async function pingExtension() {
       inFlightTabIds
     };
   } catch {
-    return UNAVAILABLE;
+    return unavailable();
   }
 }
 function currentRoute(defaultId) {

--- a/harnesses/index.js
+++ b/harnesses/index.js
@@ -140,24 +140,27 @@ function isSweepLocked(kind) {
   }
   return false;
 }
+var UNAVAILABLE = { available: false, analysing: false, inFlightCount: 0, inFlightTabIds: [] };
 async function pingExtension() {
   const runtime = globalThis.chrome;
   if (runtime?.runtime?.sendMessage === void 0) {
-    return { available: false, analysing: false, url: null };
+    return UNAVAILABLE;
   }
   try {
     const response = await runtime.runtime.sendMessage(EXTENSION_ID_HINT, { type: "HONEYLLM_STATUS_PING" });
-    if (response !== null && typeof response === "object" && "analysing" in response) {
-      const r = response;
-      return {
-        available: true,
-        analysing: r.analysing === true,
-        url: typeof r.url === "string" ? r.url : null
-      };
-    }
-    return { available: true, analysing: false, url: null };
+    if (response === null || typeof response !== "object") return UNAVAILABLE;
+    const r = response;
+    if (r.type !== "HONEYLLM_STATUS_PONG") return UNAVAILABLE;
+    const inFlightCount = typeof r.inFlightCount === "number" && Number.isFinite(r.inFlightCount) ? r.inFlightCount : 0;
+    const inFlightTabIds = Array.isArray(r.inFlightTabIds) ? r.inFlightTabIds.filter((n) => typeof n === "number" && Number.isFinite(n)) : [];
+    return {
+      available: true,
+      analysing: r.analysing === true,
+      inFlightCount,
+      inFlightTabIds
+    };
   } catch {
-    return { available: false, analysing: false, url: null };
+    return UNAVAILABLE;
   }
 }
 function currentRoute(defaultId) {
@@ -703,7 +706,8 @@ async function refreshEngineStrip() {
   const extChip = document.getElementById("nano-ext");
   const navExt = document.getElementById("nav-extension");
   const status = await pingExtension();
-  const extText = !status.available ? "Extension: unreachable" : status.analysing ? `Extension: analysing${status.url !== null ? " page" : ""}` : "Extension: idle";
+  const pageWord = status.inFlightCount === 1 ? "page" : "pages";
+  const extText = !status.available ? "Extension: unreachable" : status.analysing ? `Extension: analysing ${status.inFlightCount} ${pageWord}` : "Extension: idle";
   const extCls = !status.available ? "absent" : status.analysing ? "busy" : "live";
   if (extChip !== null) {
     extChip.textContent = extText;
@@ -713,19 +717,24 @@ async function refreshEngineStrip() {
     navExt.textContent = !status.available ? "ext: unreach" : status.analysing ? "ext: busy" : "ext: idle";
     navExt.className = `nav-pill ${!status.available ? "err" : status.analysing ? "warn" : "ok"}`;
   }
-  updateContentionBanner(status.available && status.analysing);
+  updateContentionBanner(status);
 }
-function updateContentionBanner(extBusy) {
+function updateContentionBanner(status) {
   const banner = document.getElementById("nano-warn");
   const reason = document.getElementById("nano-warn-reason");
   const locked = isSweepLocked("nano");
+  const extBusy = status.available && status.analysing;
   const anyContention = locked || extBusy;
   if (banner === null) return;
   banner.style.display = anyContention ? "block" : "none";
   if (reason !== null) {
     const reasons = [];
     if (locked) reasons.push("another sweep is in progress (possibly in a different tab).");
-    if (extBusy) reasons.push("the HoneyLLM extension is currently analysing a page.");
+    if (extBusy) {
+      const pageWord = status.inFlightCount === 1 ? "page" : "pages";
+      const tabList = status.inFlightTabIds.length > 0 ? ` (tabs ${status.inFlightTabIds.join(", ")})` : "";
+      reasons.push(`the HoneyLLM extension is currently analysing ${status.inFlightCount} ${pageWord}${tabList}.`);
+    }
     reason.textContent = reasons.join(" ");
   }
   const startBtn = document.getElementById("start-btn");

--- a/harnesses/index.ts
+++ b/harnesses/index.ts
@@ -30,6 +30,7 @@ import {
   type AgentOutcome,
   type ChipResult,
   type ChipKind,
+  type ExtensionStatus,
 } from './lib/harness-state.js';
 
 import {
@@ -428,10 +429,11 @@ async function refreshEngineStrip(): Promise<void> {
   const extChip = document.getElementById('nano-ext');
   const navExt = document.getElementById('nav-extension');
   const status = await pingExtension();
+  const pageWord = status.inFlightCount === 1 ? 'page' : 'pages';
   const extText = !status.available
     ? 'Extension: unreachable'
     : status.analysing
-      ? `Extension: analysing${status.url !== null ? ' page' : ''}`
+      ? `Extension: analysing ${status.inFlightCount} ${pageWord}`
       : 'Extension: idle';
   const extCls = !status.available ? 'absent' : status.analysing ? 'busy' : 'live';
   if (extChip !== null) {
@@ -442,20 +444,25 @@ async function refreshEngineStrip(): Promise<void> {
     navExt.textContent = !status.available ? 'ext: unreach' : status.analysing ? 'ext: busy' : 'ext: idle';
     navExt.className = `nav-pill ${!status.available ? 'err' : status.analysing ? 'warn' : 'ok'}`;
   }
-  updateContentionBanner(status.available && status.analysing);
+  updateContentionBanner(status);
 }
 
-function updateContentionBanner(extBusy: boolean): void {
+function updateContentionBanner(status: ExtensionStatus): void {
   const banner = document.getElementById('nano-warn');
   const reason = document.getElementById('nano-warn-reason');
   const locked = isSweepLocked('nano');
+  const extBusy = status.available && status.analysing;
   const anyContention = locked || extBusy;
   if (banner === null) return;
   banner.style.display = anyContention ? 'block' : 'none';
   if (reason !== null) {
     const reasons: string[] = [];
     if (locked) reasons.push('another sweep is in progress (possibly in a different tab).');
-    if (extBusy) reasons.push('the HoneyLLM extension is currently analysing a page.');
+    if (extBusy) {
+      const pageWord = status.inFlightCount === 1 ? 'page' : 'pages';
+      const tabList = status.inFlightTabIds.length > 0 ? ` (tabs ${status.inFlightTabIds.join(', ')})` : '';
+      reasons.push(`the HoneyLLM extension is currently analysing ${status.inFlightCount} ${pageWord}${tabList}.`);
+    }
     reason.textContent = reasons.join(' ');
   }
   const startBtn = document.getElementById('start-btn') as HTMLButtonElement | null;

--- a/harnesses/lib/harness-state.ts
+++ b/harnesses/lib/harness-state.ts
@@ -226,27 +226,34 @@ export function isSweepLocked(kind: 'nano' | 'summarizer'): boolean {
 export interface ExtensionStatus {
   readonly available: boolean;
   readonly analysing: boolean;
-  readonly url: string | null;
+  readonly inFlightCount: number;
+  readonly inFlightTabIds: readonly number[];
 }
+
+const UNAVAILABLE: ExtensionStatus = { available: false, analysing: false, inFlightCount: 0, inFlightTabIds: [] };
 
 export async function pingExtension(): Promise<ExtensionStatus> {
   const runtime = (globalThis as { chrome?: { runtime?: { sendMessage?: (id: string, msg: unknown) => Promise<unknown> } } }).chrome;
   if (runtime?.runtime?.sendMessage === undefined) {
-    return { available: false, analysing: false, url: null };
+    return UNAVAILABLE;
   }
   try {
     const response = await runtime.runtime.sendMessage(EXTENSION_ID_HINT, { type: 'HONEYLLM_STATUS_PING' });
-    if (response !== null && typeof response === 'object' && 'analysing' in response) {
-      const r = response as { analysing?: unknown; url?: unknown };
-      return {
-        available: true,
-        analysing: r.analysing === true,
-        url: typeof r.url === 'string' ? r.url : null,
-      };
-    }
-    return { available: true, analysing: false, url: null };
+    if (response === null || typeof response !== 'object') return UNAVAILABLE;
+    const r = response as { type?: unknown; analysing?: unknown; inFlightCount?: unknown; inFlightTabIds?: unknown };
+    if (r.type !== 'HONEYLLM_STATUS_PONG') return UNAVAILABLE;
+    const inFlightCount = typeof r.inFlightCount === 'number' && Number.isFinite(r.inFlightCount) ? r.inFlightCount : 0;
+    const inFlightTabIds = Array.isArray(r.inFlightTabIds)
+      ? r.inFlightTabIds.filter((n): n is number => typeof n === 'number' && Number.isFinite(n))
+      : [];
+    return {
+      available: true,
+      analysing: r.analysing === true,
+      inFlightCount,
+      inFlightTabIds,
+    };
   } catch {
-    return { available: false, analysing: false, url: null };
+    return UNAVAILABLE;
   }
 }
 

--- a/harnesses/lib/harness-state.ts
+++ b/harnesses/lib/harness-state.ts
@@ -230,18 +230,20 @@ export interface ExtensionStatus {
   readonly inFlightTabIds: readonly number[];
 }
 
-const UNAVAILABLE: ExtensionStatus = { available: false, analysing: false, inFlightCount: 0, inFlightTabIds: [] };
+function unavailable(): ExtensionStatus {
+  return { available: false, analysing: false, inFlightCount: 0, inFlightTabIds: [] };
+}
 
 export async function pingExtension(): Promise<ExtensionStatus> {
   const runtime = (globalThis as { chrome?: { runtime?: { sendMessage?: (id: string, msg: unknown) => Promise<unknown> } } }).chrome;
   if (runtime?.runtime?.sendMessage === undefined) {
-    return UNAVAILABLE;
+    return unavailable();
   }
   try {
     const response = await runtime.runtime.sendMessage(EXTENSION_ID_HINT, { type: 'HONEYLLM_STATUS_PING' });
-    if (response === null || typeof response !== 'object') return UNAVAILABLE;
+    if (response === null || typeof response !== 'object') return unavailable();
     const r = response as { type?: unknown; analysing?: unknown; inFlightCount?: unknown; inFlightTabIds?: unknown };
-    if (r.type !== 'HONEYLLM_STATUS_PONG') return UNAVAILABLE;
+    if (r.type !== 'HONEYLLM_STATUS_PONG') return unavailable();
     const inFlightCount = typeof r.inFlightCount === 'number' && Number.isFinite(r.inFlightCount) ? r.inFlightCount : 0;
     const inFlightTabIds = Array.isArray(r.inFlightTabIds)
       ? r.inFlightTabIds.filter((n): n is number => typeof n === 'number' && Number.isFinite(n))
@@ -253,7 +255,7 @@ export async function pingExtension(): Promise<ExtensionStatus> {
       inFlightTabIds,
     };
   } catch {
-    return UNAVAILABLE;
+    return unavailable();
   }
 }
 


### PR DESCRIPTION
Closes #95.

## Summary

The service worker already sends `{type, analysing, inFlightCount, inFlightTabIds}` but `pingExtension()` modelled `{analysing, url}` — so the harness silently dropped the actionable fields and branched on a `url` field the SW never populated.

## Changes

**`harnesses/lib/harness-state.ts`**
- `ExtensionStatus`: drop never-populated `url`, add `inFlightCount: number` and `inFlightTabIds: readonly number[]`.
- `pingExtension`: verify `type === 'HONEYLLM_STATUS_PONG'` before trusting any field, narrow `inFlightCount` with `Number.isFinite`, filter `inFlightTabIds` to numeric entries.
- Error path returns a fresh object per call rather than a shared singleton, so a careless runtime mutation can't pollute state across calls.

**`harnesses/index.ts`**
- Engine chip reads `Extension: analysing 3 pages` instead of the generic `Extension: analysing page`.
- Contention banner names the tab IDs: `the HoneyLLM extension is currently analysing 3 pages (tabs 12, 34, 56).`

## Behaviour change to note

Previously, a response with `analysing` but no `type` field returned `{available: true, analysing: false}` and rendered as "Extension: idle". Under the stricter parser, any shape that fails `type === 'HONEYLLM_STATUS_PONG'` renders as "Extension: unreachable". This is what the issue asks for — testers who hit "unreachable" after pulling will correctly reload the extension rather than wondering why the chip flipped.

## Verification

Exercised with a mock `chrome.runtime.sendMessage` across 12 scenarios, all pass: no runtime, throw, null response, non-object response, wrong/missing type, idle pong, busy pong with tabs, filtered non-numeric tabIds, non-number/NaN inFlightCount coerced to 0, non-strict analysing stays false.

- typecheck clean, harness:build clean, 396/396 tests pass.

## Test plan

- [x] Typecheck + unit tests + harness build
- [x] Mock-based contract verification (12 scenarios)
- [ ] Manual: with extension installed, analyse two pages in different tabs, confirm the contention banner names both tab IDs and the engine chip shows "analysing 2 pages"