### PR TITLE
feat(harness-#96): distinguish SUSPICIOUS from COMPROMISED in chip rendering

### DIFF
--- a/harnesses/index.js
+++ b/harnesses/index.js
@@ -54,22 +54,35 @@ function classifyChip(fixture, reachable, bytes, scan, httpStatus, errorText) {
       title: "Fixture could not be fetched \u2014 check fixture host availability."
     };
   }
-  const injectedExpected = fixture.expected !== "CLEAN";
-  if (injectedExpected && scan.matched) {
+  if (fixture.expected === "COMPROMISED" && scan.matched) {
     return {
       kind: "ok",
       text: `flagged \u2713 (${scan.label})`,
-      title: `Spider correctly flagged injected fixture. Matched: ${scan.label}`
+      title: `Spider correctly flagged COMPROMISED fixture. Matched: ${scan.label}`
     };
   }
-  if (injectedExpected && !scan.matched) {
+  if (fixture.expected === "COMPROMISED" && !scan.matched) {
     return {
       kind: "fail",
-      text: `FN \u2014 Spider missed injection`,
-      title: "False negative: Spider did not flag a fixture marked as injected/borderline. Investigate pattern coverage."
+      text: "FN \u2014 Spider missed injection",
+      title: "False negative on COMPROMISED fixture: Spider did not flag a strong adversarial signal. Investigate pattern coverage."
     };
   }
-  if (!injectedExpected && scan.matched) {
+  if (fixture.expected === "SUSPICIOUS" && scan.matched) {
+    return {
+      kind: "warn",
+      text: `flagged (weak) \u2713 (${scan.label})`,
+      title: `Spider flagged SUSPICIOUS fixture as expected \u2014 weak adversarial signal. Matched: ${scan.label}`
+    };
+  }
+  if (fixture.expected === "SUSPICIOUS" && !scan.matched) {
+    return {
+      kind: "warn",
+      text: "FN (weak) \u2014 Spider missed SUSPICIOUS fixture",
+      title: "Weak false negative: Spider did not flag a SUSPICIOUS fixture. Less critical than a COMPROMISED miss, but worth tracking."
+    };
+  }
+  if (fixture.expected === "CLEAN" && scan.matched) {
     return {
       kind: "fail",
       text: `FP \u2014 Spider flagged clean fixture (${scan.label})`,

--- a/harnesses/lib/harness-state.ts
+++ b/harnesses/lib/harness-state.ts
@@ -88,7 +88,7 @@ export function spiderScan(text: string): SpiderScan {
 
 // ---------- Expectation-matching chip ----------
 
-export type ChipKind = 'ok' | 'fail' | 'unreachable' | 'pending';
+export type ChipKind = 'ok' | 'warn' | 'fail' | 'unreachable' | 'pending';
 
 export interface ChipResult {
   readonly kind: ChipKind;
@@ -105,23 +105,35 @@ export function classifyChip(fixture: Fixture, reachable: boolean, bytes: number
     };
   }
 
-  const injectedExpected = fixture.expected !== 'CLEAN';
-
-  if (injectedExpected && scan.matched) {
+  if (fixture.expected === 'COMPROMISED' && scan.matched) {
     return {
       kind: 'ok',
       text: `flagged ✓ (${scan.label})`,
-      title: `Spider correctly flagged injected fixture. Matched: ${scan.label}`,
+      title: `Spider correctly flagged COMPROMISED fixture. Matched: ${scan.label}`,
     };
   }
-  if (injectedExpected && !scan.matched) {
+  if (fixture.expected === 'COMPROMISED' && !scan.matched) {
     return {
       kind: 'fail',
-      text: `FN — Spider missed injection`,
-      title: 'False negative: Spider did not flag a fixture marked as injected/borderline. Investigate pattern coverage.',
+      text: 'FN — Spider missed injection',
+      title: 'False negative on COMPROMISED fixture: Spider did not flag a strong adversarial signal. Investigate pattern coverage.',
     };
   }
-  if (!injectedExpected && scan.matched) {
+  if (fixture.expected === 'SUSPICIOUS' && scan.matched) {
+    return {
+      kind: 'warn',
+      text: `flagged (weak) ✓ (${scan.label})`,
+      title: `Spider flagged SUSPICIOUS fixture as expected — weak adversarial signal. Matched: ${scan.label}`,
+    };
+  }
+  if (fixture.expected === 'SUSPICIOUS' && !scan.matched) {
+    return {
+      kind: 'warn',
+      text: 'FN (weak) — Spider missed SUSPICIOUS fixture',
+      title: 'Weak false negative: Spider did not flag a SUSPICIOUS fixture. Less critical than a COMPROMISED miss, but worth tracking.',
+    };
+  }
+  if (fixture.expected === 'CLEAN' && scan.matched) {
     return {
       kind: 'fail',
       text: `FP — Spider flagged clean fixture (${scan.label})`,

--- a/harnesses/lib/harness.css
+++ b/harnesses/lib/harness.css
@@ -200,6 +200,7 @@ th { color: #6b7280; text-transform: uppercase; letter-spacing: 0.4px; font-size
   font-weight: 600;
 }
 .spider-chip.ok { background: #1a3a1a; color: #4ade80; }
+.spider-chip.warn { background: #3a2a10; color: #fb923c; }
 .spider-chip.fail { background: #3a1a1a; color: #f87171; }
 .spider-chip.unreachable { background: #3a2a1a; color: #facc15; }
 .spider-chip.pending { background: #2a2a2a; color: #9ca3af; }


### PR DESCRIPTION
Closes #96.

## Summary

`classifyChip` in `harnesses/lib/harness-state.ts` collapsed SUSPICIOUS and COMPROMISED into one "injected" bucket, so the chip could not tell testers which kind of signal was being detected or missed. Split into three-way expectation handling and added a `warn` ChipKind for the SUSPICIOUS-expected cases.

## Rendering matrix

| Fixture expected | Spider matched | Kind | Colour | Text |
|---|---|---|---|---|
| CLEAN | no | ok | green (unchanged) | `clean ✓ (200, Nb)` |
| CLEAN | yes | fail | red (unchanged) | `FP — Spider flagged clean fixture` |
| SUSPICIOUS | yes | **warn** | **orange (new)** | `flagged (weak) ✓` |
| SUSPICIOUS | no | **warn** | **orange (new)** | `FN (weak) — Spider missed SUSPICIOUS fixture` |
| COMPROMISED | yes | ok | green (unchanged) | `flagged ✓` |
| COMPROMISED | no | fail | red (unchanged) | `FN — Spider missed injection` |

Orange (`#fb923c`) chosen over amber (`#facc15`, already used by `unreachable`) so semantic warnings stay visually distinct from infrastructure issues.

## Out of scope

Per the issue body's scope split:
- Rubric definition — what "weaker" means in aggregate scoring — tracked in #3 Phase 5 Hunters §5C.
- Education-aware downgrade — depends on Education signal from #75.

This PR is the self-contained harness presentation change.

## Verification

Exercised with a local mock script across all 3×2 fixture/scan combinations plus unreachable. All 7 scenarios pass:

| # | Scenario | Result |
|---|---|---|
| 1 | COMPROMISED + hit | ok (green) ✓ |
| 2 | COMPROMISED + miss | fail (red) ✓ |
| 3 | SUSPICIOUS + hit | warn (orange) ✓ |
| 4 | SUSPICIOUS + miss | warn (orange) ✓ |
| 5 | CLEAN + hit | fail (red) ✓ |
| 6 | CLEAN + miss | ok (green) ✓ |
| 7 | unreachable | unreachable (amber) ✓ |

- `npm run typecheck` clean
- `npm test` → 396/396 pass
- `npm run harness:build` clean (index.js rebuilt)
- `npm run build` clean

## Test plan

- [x] Typecheck + unit tests + harness build + extension build
- [x] Mock-based behaviour verification (7 scenarios)
- [ ] Manual: `npm run harness`, open S3 Claude matrix, click Check on `/borderline/security-advisory` (SUSPICIOUS) and on `/injected/hidden-div-basic` (COMPROMISED), confirm the former renders orange and the latter renders green.