### PR TITLE
fix(harness-#94): surface persistence failures instead of silently swallowing

### DIFF
--- a/harnesses/index.js
+++ b/harnesses/index.js
@@ -18,16 +18,66 @@ function loadState() {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (raw === null) return {};
     const parsed = JSON.parse(raw);
-    if (parsed === null || typeof parsed !== "object") return {};
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return {};
     return parsed;
   } catch {
     return {};
   }
 }
+function validateSerializable(value, path = "$", visited = /* @__PURE__ */ new WeakSet()) {
+  if (value === null || value === void 0) return { valid: true };
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") return { valid: true };
+  if (typeof value === "bigint") {
+    return { valid: false, reason: "BigInt is not JSON-serializable", path };
+  }
+  if (typeof value === "function" || typeof value === "symbol") {
+    return { valid: false, reason: `${typeof value} is silently dropped by JSON.stringify`, path };
+  }
+  if (typeof value !== "object") {
+    return { valid: false, reason: `unhandled type: ${typeof value}`, path };
+  }
+  if (value instanceof Date) {
+    return { valid: false, reason: "Date silently becomes a string and loses type on round-trip", path };
+  }
+  if (value instanceof Map || value instanceof Set || value instanceof RegExp) {
+    return { valid: false, reason: `${value.constructor.name} silently becomes {} and loses data`, path };
+  }
+  if (visited.has(value)) {
+    return { valid: false, reason: "circular reference detected", path };
+  }
+  visited.add(value);
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i += 1) {
+      const child = validateSerializable(value[i], `${path}[${i}]`, visited);
+      if (!child.valid) return child;
+    }
+    return { valid: true };
+  }
+  for (const [k, v] of Object.entries(value)) {
+    const child = validateSerializable(v, `${path}.${k}`, visited);
+    if (!child.valid) return child;
+  }
+  return { valid: true };
+}
 function saveState(state2) {
+  const validation = validateSerializable(state2);
+  if (!validation.valid) {
+    console.error(`[harness-state] saveState rejected: ${validation.reason} (at ${validation.path})`);
+    return false;
+  }
+  let serialized;
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(state2));
-  } catch {
+    serialized = JSON.stringify(state2);
+  } catch (err) {
+    console.error("[harness-state] saveState: JSON.stringify threw", err);
+    return false;
+  }
+  try {
+    localStorage.setItem(STORAGE_KEY, serialized);
+    return true;
+  } catch (err) {
+    console.error("[harness-state] saveState: localStorage.setItem threw (likely QuotaExceededError)", err);
+    return false;
   }
 }
 var SPIDER_PATTERNS = [

--- a/harnesses/lib/harness-state.test.ts
+++ b/harnesses/lib/harness-state.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { loadState, saveState, STORAGE_KEY } from './harness-state.js';
+
+interface MockStorage {
+  store: Map<string, string>;
+  setShouldThrow: boolean;
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+  clear(): void;
+}
+
+function makeMockStorage(): MockStorage {
+  const store = new Map<string, string>();
+  return {
+    store,
+    setShouldThrow: false,
+    getItem(key: string): string | null {
+      return store.has(key) ? store.get(key)! : null;
+    },
+    setItem(key: string, value: string): void {
+      if (this.setShouldThrow) {
+        const err = new Error('Quota exceeded') as Error & { name: string };
+        err.name = 'QuotaExceededError';
+        throw err;
+      }
+      store.set(key, value);
+    },
+    removeItem(key: string): void {
+      store.delete(key);
+    },
+    clear(): void {
+      store.clear();
+    },
+  };
+}
+
+let mockStorage: MockStorage;
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  mockStorage = makeMockStorage();
+  vi.stubGlobal('localStorage', mockStorage);
+  consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  consoleErrorSpy.mockRestore();
+});
+
+describe('loadState', () => {
+  it('returns empty bag when storage is empty', () => {
+    expect(loadState()).toEqual({});
+  });
+
+  it('returns empty bag when raw value is invalid JSON', () => {
+    mockStorage.store.set(STORAGE_KEY, '{not json');
+    expect(loadState()).toEqual({});
+  });
+
+  it('returns empty bag when stored value is null literal', () => {
+    mockStorage.store.set(STORAGE_KEY, 'null');
+    expect(loadState()).toEqual({});
+  });
+
+  it('returns empty bag when stored value is a primitive (number/string)', () => {
+    mockStorage.store.set(STORAGE_KEY, '42');
+    expect(loadState()).toEqual({});
+    mockStorage.store.set(STORAGE_KEY, '"some string"');
+    expect(loadState()).toEqual({});
+  });
+
+  it('PRS-1: rejects an array even though typeof [] === "object"', () => {
+    mockStorage.store.set(STORAGE_KEY, '[1,2,3]');
+    const result = loadState();
+    expect(Array.isArray(result)).toBe(false);
+    expect(result).toEqual({});
+  });
+
+  it('returns the parsed object on a valid round-trip', () => {
+    mockStorage.store.set(STORAGE_KEY, JSON.stringify({ alpha: 1, beta: 'two' }));
+    expect(loadState()).toEqual({ alpha: 1, beta: 'two' });
+  });
+});
+
+describe('saveState — happy path', () => {
+  it('writes serialized state to storage and returns true', () => {
+    const ok = saveState({ key: 'value', n: 7 });
+    expect(ok).toBe(true);
+    expect(mockStorage.store.get(STORAGE_KEY)).toBe(JSON.stringify({ key: 'value', n: 7 }));
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it('round-trips through loadState cleanly', () => {
+    expect(saveState({ a: 1, b: [2, 3], c: { nested: true } })).toBe(true);
+    expect(loadState()).toEqual({ a: 1, b: [2, 3], c: { nested: true } });
+  });
+});
+
+describe('saveState — PRS-2: validator rejects unsupported types', () => {
+  it('returns false and logs on top-level BigInt', () => {
+    const ok = saveState({ count: 123n });
+    expect(ok).toBe(false);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('BigInt is not JSON-serializable'),
+    );
+    expect(mockStorage.store.has(STORAGE_KEY)).toBe(false);
+  });
+
+  it('returns false on nested BigInt with the path in the log', () => {
+    const ok = saveState({ outer: { inner: 1n } });
+    expect(ok).toBe(false);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('$.outer.inner'),
+    );
+  });
+
+  it('returns false on a circular reference', () => {
+    const cyclic: Record<string, unknown> = { name: 'root' };
+    cyclic.self = cyclic;
+    const ok = saveState(cyclic);
+    expect(ok).toBe(false);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('circular reference'),
+    );
+  });
+
+  it('returns false on Date (silently coerced to string by JSON.stringify)', () => {
+    const ok = saveState({ when: new Date('2026-04-25') });
+    expect(ok).toBe(false);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Date'),
+    );
+  });
+
+  it('returns false on Map (silently becomes {})', () => {
+    const ok = saveState({ table: new Map([['k', 'v']]) });
+    expect(ok).toBe(false);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Map'),
+    );
+  });
+
+  it('returns false on Set', () => {
+    const ok = saveState({ s: new Set([1, 2, 3]) });
+    expect(ok).toBe(false);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Set'),
+    );
+  });
+
+  it('returns false on RegExp', () => {
+    const ok = saveState({ pattern: /abc/ });
+    expect(ok).toBe(false);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('RegExp'),
+    );
+  });
+
+  it('returns false on a function', () => {
+    const ok = saveState({ fn: () => 1 });
+    expect(ok).toBe(false);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('function'),
+    );
+  });
+
+  it('returns false on a symbol', () => {
+    const ok = saveState({ sym: Symbol('x') });
+    expect(ok).toBe(false);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('symbol'),
+    );
+  });
+
+  it('rejects a bad value inside an array', () => {
+    const ok = saveState({ list: [1, 2, 99n] });
+    expect(ok).toBe(false);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('$.list[2]'),
+    );
+  });
+});
+
+describe('saveState — PRS-3: localStorage write failures', () => {
+  it('returns false and logs on QuotaExceededError', () => {
+    mockStorage.setShouldThrow = true;
+    const ok = saveState({ ok: true });
+    expect(ok).toBe(false);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('QuotaExceededError'),
+      expect.any(Error),
+    );
+    expect(mockStorage.store.has(STORAGE_KEY)).toBe(false);
+  });
+});

--- a/harnesses/lib/harness-state.ts
+++ b/harnesses/lib/harness-state.ts
@@ -39,18 +39,99 @@ export function loadState(): StateBag {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (raw === null) return {};
     const parsed: unknown = JSON.parse(raw);
-    if (parsed === null || typeof parsed !== 'object') return {};
+    // Array.isArray check is load-bearing: typeof [] === 'object', so without
+    // it a corrupt array in storage gets cast to StateBag and downstream `.x`
+    // accesses return undefined silently instead of resetting cleanly.
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
     return parsed as StateBag;
   } catch {
     return {};
   }
 }
 
-export function saveState(state: StateBag): void {
+type ValidationResult = { readonly valid: true } | { readonly valid: false; readonly reason: string; readonly path: string };
+
+/**
+ * Walks the state tree and rejects values that JSON.stringify mishandles:
+ * BigInt (throws), Date (silently coerced to ISO string, type lost),
+ * Map/Set (silently become {}, data lost), function/symbol (silently
+ * dropped), RegExp (silently becomes {}), and circular references
+ * (throws). Surfacing these at validate-time gives callers a precise path
+ * + reason instead of either a TypeError from stringify or a stale read
+ * later.
+ */
+function validateSerializable(value: unknown, path = '$', visited: WeakSet<object> = new WeakSet()): ValidationResult {
+  if (value === null || value === undefined) return { valid: true };
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return { valid: true };
+
+  if (typeof value === 'bigint') {
+    return { valid: false, reason: 'BigInt is not JSON-serializable', path };
+  }
+  if (typeof value === 'function' || typeof value === 'symbol') {
+    return { valid: false, reason: `${typeof value} is silently dropped by JSON.stringify`, path };
+  }
+
+  if (typeof value !== 'object') {
+    return { valid: false, reason: `unhandled type: ${typeof value}`, path };
+  }
+
+  if (value instanceof Date) {
+    return { valid: false, reason: 'Date silently becomes a string and loses type on round-trip', path };
+  }
+  if (value instanceof Map || value instanceof Set || value instanceof RegExp) {
+    return { valid: false, reason: `${value.constructor.name} silently becomes {} and loses data`, path };
+  }
+
+  if (visited.has(value)) {
+    return { valid: false, reason: 'circular reference detected', path };
+  }
+  visited.add(value);
+
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i += 1) {
+      const child = validateSerializable(value[i], `${path}[${i}]`, visited);
+      if (!child.valid) return child;
+    }
+    return { valid: true };
+  }
+
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    const child = validateSerializable(v, `${path}.${k}`, visited);
+    if (!child.valid) return child;
+  }
+  return { valid: true };
+}
+
+/**
+ * Persist state to localStorage. Returns `true` on success, `false` on
+ * any failure (validation, serialization throw, storage write throw).
+ * Failures are also logged via `console.error` with the precise reason.
+ *
+ * Callers that previously discarded the void return remain compatible.
+ * Hot paths (mid-sweep persistence) should branch on the return and
+ * surface a UI banner so users do not lose progress silently.
+ */
+export function saveState(state: StateBag): boolean {
+  const validation = validateSerializable(state);
+  if (!validation.valid) {
+    console.error(`[harness-state] saveState rejected: ${validation.reason} (at ${validation.path})`);
+    return false;
+  }
+
+  let serialized: string;
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
-  } catch {
-    /* quota exceeded — surface separately */
+    serialized = JSON.stringify(state);
+  } catch (err) {
+    console.error('[harness-state] saveState: JSON.stringify threw', err);
+    return false;
+  }
+
+  try {
+    localStorage.setItem(STORAGE_KEY, serialized);
+    return true;
+  } catch (err) {
+    console.error('[harness-state] saveState: localStorage.setItem threw (likely QuotaExceededError)', err);
+    return false;
   }
 }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    include: ['src/**/*.test.ts', 'scripts/**/*.test.ts'],
+    include: ['src/**/*.test.ts', 'scripts/**/*.test.ts', 'harnesses/**/*.test.ts'],
     coverage: {
       provider: 'v8',
       include: ['src/**/*.ts'],


### PR DESCRIPTION
Closes #94.

Implements PRS-1..4 from the 2026-04-23 harness review session — `loadState`/`saveState` in `harnesses/lib/harness-state.ts` no longer silently swallow type-guard, serialization, or storage failures. Directly addresses the `.claude/rules/common/coding-style.md` rule violation cited in the issue.

## Summary

- **PRS-1** — `loadState` adds `Array.isArray(parsed)` to the type guard. Without it, `typeof [] === 'object'` let a corrupt array in storage get cast to `StateBag` so downstream `.x` accesses returned `undefined` instead of resetting.
- **PRS-2/3** — `saveState` returns `boolean` and logs via `console.error` on any failure. Three layers are reported separately so the log identifies what broke: validator rejection (with the offending `$.path`), `JSON.stringify` throw, `localStorage.setItem` throw (typically `QuotaExceededError`).
- **PRS-4** — A hand-written `validateSerializable` walker runs **before** `JSON.stringify` and rejects values JSON.stringify mishandles: `BigInt` (throws), `Date` (silently coerced to ISO string), `Map`/`Set`/`RegExp` (silently become `{}`), `function`/`symbol` (silently dropped), circular references (throws). No new runtime dep — chose a ~30 LOC walker over the issue's Zod suggestion to keep bundle weight unchanged and match codebase style.

## Backwards compatibility

`saveState` signature changes from `void` to `boolean`. All 13 existing `saveState(state)` call sites in `harnesses/index.ts` ignore the return value, so the change is non-breaking. Hot paths (mid-sweep persistence) can opt in later to surface a UI failure banner — this PR deliberately does not wire that, per the issue body's scope.

## What this PR does NOT do

- Does not touch `acquireSweepLock`/`releaseSweepLock` (#93's scope).
- Does not touch `pingExtension` or contention banner (#95's scope).
- Does not touch `classifyChip` rendering (#96's scope).
- Does not introduce a Zod runtime dep — the issue suggested it; the hand-written validator achieves the same precise-failure-with-path semantics without the dep.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 460 tests pass across 40 files (+19 new in `harnesses/lib/harness-state.test.ts`)
- [x] `npm run build` clean
- [x] New suite covers: load (empty / invalid JSON / null literal / primitive / array / valid round-trip), save (happy path + round-trip), each rejection class (BigInt top-level, BigInt nested with path, circular, Date, Map, Set, RegExp, function, symbol, BigInt-in-array), quota error path.
- [x] `npm run graph:sync` — 0 drift warnings
- [x] First-time enablement of `harnesses/**/*.test.ts` in vitest config — confirmed CI picks up the new file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)