### PR TITLE
fix(ci-#106): detect harness bundle source/build drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,53 @@ jobs:
 
       - name: Build
         run: npm run build
+<<<<<<< HEAD
+=======
+
+      - name: Build harness bundles
+        run: npm run harness:build
+
+      - name: Verify harness bundles in sync with source
+        # `harnesses/{index,nano-harness}.js` are committed esbuild artifacts
+        # served directly by harnesses/*.html and Cloudflare Pages. Source
+        # edits without a rebuild leave the deployed bundle stale (caught
+        # manually during PR #105 / #94). Fail the PR if a fresh build
+        # produces any diff.
+        run: git diff --exit-code harnesses/index.js harnesses/nano-harness.js
+
+  graph-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Determine branch clusters
+        id: clusters
+        run: |
+          NUMS=$(git log origin/main..HEAD --pretty=%s%n%b | grep -oE '#[0-9]+' | tr -d '#' | sort -u | tr '\n' ',' || true)
+          echo "issue_numbers=${NUMS%,}" >> "$GITHUB_OUTPUT"
+      - name: Graph drift check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBERS: ${{ steps.clusters.outputs.issue_numbers }}
+        run: |
+          CLUSTERS=""
+          IFS=',' read -ra NUMS <<< "$ISSUE_NUMBERS"
+          for n in "${NUMS[@]}"; do
+            [ -z "$n" ] && continue
+            LABELS=$(gh issue view "$n" --json labels -q '.labels[].name' 2>/dev/null | tr '\n' ',' || true)
+            CLUSTERS="$CLUSTERS,$LABELS"
+          done
+          CLUSTERS=$(echo "$CLUSTERS" | tr ',' '\n' | grep -E '^(project-|phase-|upstream|future-feature)' | sort -u | tr '\n' ',' | sed 's/,$//')
+          echo "Branch clusters: $CLUSTERS"
+          if [ -n "$CLUSTERS" ]; then
+            npx tsx scripts/issue-graph/drift-cli.ts --branch-clusters "$CLUSTERS"
+          else
+            npx tsx scripts/issue-graph/drift-cli.ts
+          fi
+>>>>>>> ee75cdc (fix(ci-#106): detect harness bundle source/build drift)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,7 @@ Push the branch early so other sessions can see it.
 ### 3. Make changes
 
 - Run `npm run typecheck`, `npm test`, and `npm run build` locally before pushing.
+- If you touch anything imported by `harnesses/*.ts` (i.e. anything bundled into `harnesses/index.js` or `harnesses/nano-harness.js`), also run `npm run harness:build` and commit the regenerated bundle. The deployed harness loads the committed `.js` directly — CI rejects PRs that leave the bundle out of sync with source.
 - The local pre-push hook also runs these — don't bypass it (`--no-verify`).
 - Use conventional commit messages: `feat:`, `fix:`, `refactor:`, `test:`, `docs:`, `chore:`. Reference the issue number in the scope when applicable, e.g. `fix(phase3-#13): ...`.
 - Keep PRs focused. If scope grows, split into a new issue + branch.


### PR DESCRIPTION
Closes #106.

Adds a CI step that rebuilds the committed harness bundles and fails the PR if a fresh build produces any diff. Surfaced during PR #105 review when a source-only `saveState` fix would have been deployed-stale because no CI step regenerates `harnesses/{index,nano-harness}.js`.

## Related work

- **#94 / PR #105** — direct trigger. The source fix was correct but the committed bundle was stale; rescued by follow-up commit `b6fed27` (manual rebuild). This PR prevents that class of mistake.
- **#95 / PR #101**, **#96 / PR #102** — parallel session PRs that both happened to include the rebuilt bundle. There's no documented rule that says they should — workflow muscle memory only.
- **#100 (closed)** — overlay cleanup post-merge cascade. Confirms the overlay-drift pattern this PR mirrors for bundle-drift.
- **`scripts/build-harnesses.ts`** — esbuild harness build entry. Not modified.

## What this PR is NOT doing

- Does not change `scripts/build-harnesses.ts` or any harness source.
- Does not gitignore the bundles (alternative considered, parked for follow-up — see issue body).
- Does not address the missing local pre-push hook referenced in `CONTRIBUTING.md` (separate doc bug).
- Does not touch the existing `dist/` extension build, which is already covered by `npm run build`.

## Summary

- New CI steps in `.github/workflows/ci.yml` after `Build`:
  - `npm run harness:build` rebuilds both bundles.
  - `git diff --exit-code harnesses/index.js harnesses/nano-harness.js` fails the run if the fresh bundle differs from what the contributor committed.
- One-line note in `CONTRIBUTING.md` § "Make changes" pointing at `npm run harness:build`.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 441 tests pass (39 files; this branch is off main, so the +19 tests from PR #105 are not included)
- [x] `npm run build` clean
- [x] **Local rehearsal of the new CI step** — ran `npm run harness:build` then `git diff --exit-code harnesses/index.js harnesses/nano-harness.js` → exit 0 (drift check passes when source matches bundle, as expected on a clean tree)
- [x] `npm run graph:sync` — 0 drift warnings (overlay updated to acknowledge open PRs #104 and #105 as in-progress alongside #106)

🤖 Generated with [Claude Code](https://claude.com/claude-code)