### PR TITLE
refactor(phase5-#115): unify boundary-aware chunker for Hunters and probes

### DIFF
--- a/src/hunters/hawk/chunking.test.ts
+++ b/src/hunters/hawk/chunking.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { chunkByWords } from './chunking.js';
+import { chunkByWords, chunkText } from './chunking.js';
 
 describe('chunkByWords', () => {
   it('returns the original text as a single chunk when shorter than window', () => {
@@ -30,5 +30,88 @@ describe('chunkByWords', () => {
     const words = Array.from({ length: 100 }, (_, i) => `w${i}`).join(' ');
     const chunks = chunkByWords(words, 50, 25);
     expect(chunks[chunks.length - 1]).toContain('w99');
+  });
+});
+
+describe('chunkText (canonical boundary-aware chunker)', () => {
+  it('returns a single chunk with full hash on the fast path when text fits in maxChars', async () => {
+    const text = 'short input that fits';
+    const chunks = await chunkText(text, { maxChars: 100 });
+    expect(chunks).toHaveLength(1);
+    const [only] = chunks;
+    expect(only!.text).toBe(text);
+    expect(only!.start).toBe(0);
+    expect(only!.end).toBe(text.length);
+    expect(only!.contentHash).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('prefers a paragraph break over a sentence break within the window', async () => {
+    // maxChars=40, halfMark=20. \n\n at index 23 (>=20) wins; sentence at index 38 is later but loses.
+    const text = 'aaaaaa. bbbbbb. cccccc.\n\ndddddd. eeeeee. ffffff. ggggg';
+    const chunks = await chunkText(text, { maxChars: 40 });
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks[0]!.end).toBe(24); // paragraphAt (23) + 1
+    expect(chunks[0]!.text).toBe(text.slice(0, 24));
+  });
+
+  it('falls through to sentence boundary when no paragraph break is in range', async () => {
+    // maxChars=30, halfMark=15. Last '. ' at index 28 wins; +1 = 29.
+    const text = 'aaaa. bbbb. cccc. dddd. eeee. ffff';
+    const chunks = await chunkText(text, { maxChars: 30 });
+    expect(chunks[0]!.end).toBe(29);
+    expect(chunks[0]!.text).toBe(text.slice(0, 29));
+  });
+
+  it('falls through to a word boundary when neither paragraph nor sentence is found', async () => {
+    // maxChars=20. No '\n\n', no '. ', no '! ', no '? '. Last space ≤ 20 is index 18; +1 = 19.
+    const text = 'one two three four five six seven eight nine ten';
+    const chunks = await chunkText(text, { maxChars: 20 });
+    expect(chunks[0]!.end).toBe(19);
+    expect(chunks[0]!.text).toBe('one two three four ');
+  });
+
+  it('hard-cuts at exactly maxChars when no boundary exists', async () => {
+    const maxChars = 10;
+    const text = 'a'.repeat(maxChars * 2 + 5);
+    const chunks = await chunkText(text, { maxChars });
+    expect(chunks).toHaveLength(3);
+    expect(chunks[0]!.end).toBe(maxChars);
+    expect(chunks[1]!.end).toBe(maxChars * 2);
+    expect(chunks[2]!.end).toBe(text.length);
+  });
+
+  it('produces chunks whose text matches source.slice(start, end) and reconstructs to the source', async () => {
+    const text = 'aaaaaa. bbbbbb. cccccc.\n\ndddddd. eeeeee. ffffff. gggggg. hhhhhh.\n\niiiiii jjjjjj kkkkkk llllll';
+    const chunks = await chunkText(text, { maxChars: 40 });
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.text).toBe(text.slice(chunk.start, chunk.end));
+    }
+    expect(chunks.map((c) => c.text).join('')).toBe(text);
+  });
+
+  it("covers the tail so the last chunk's end equals text.length", async () => {
+    const text = 'one two three four five six seven eight nine ten eleven twelve';
+    const chunks = await chunkText(text, { maxChars: 20 });
+    expect(chunks[chunks.length - 1]!.end).toBe(text.length);
+  });
+
+  it('produces deterministic contentHash values for identical text and different hashes for different text', async () => {
+    const a = await chunkText('hello world', { maxChars: 100 });
+    const b = await chunkText('hello world', { maxChars: 100 });
+    const c = await chunkText('hello worlD', { maxChars: 100 });
+    expect(a[0]!.contentHash).toBe(b[0]!.contentHash);
+    expect(a[0]!.contentHash).not.toBe(c[0]!.contentHash);
+  });
+
+  it('regression: sentence-only input splits at the same offset as the prior orchestrator chunker', async () => {
+    // The pre-#115 orchestrator chunker used:
+    //   splitAt = lastIndexOf('. ', maxChars); if (-1 || < halfMark) splitAt = lastIndexOf(' ', ...);
+    //   else splitAt += 1
+    // For this input with maxChars=30: '. ' at 28 → splitAt = 29.
+    const text = 'aaaa. bbbb. cccc. dddd. eeee. ffff gggg hhhh iiii';
+    const chunks = await chunkText(text, { maxChars: 30 });
+    expect(chunks[0]!.end).toBe(29);
+    expect(chunks[0]!.text).toBe(text.slice(0, 29));
   });
 });

--- a/src/hunters/hawk/chunking.ts
+++ b/src/hunters/hawk/chunking.ts
@@ -1,17 +1,24 @@
 /**
- * Sliding-window chunking for Hawk v1.
+ * Chunking primitives shared by Hunters and the canary-probe orchestrator.
  *
- * Real injection payloads are typically 30-100 words embedded in much
- * larger pages (benign article + hidden injection div). Page-level
- * density features dilute the signal to near-zero. By scoring each
- * chunk independently and taking the maximum, we preserve the needle's
- * signal even when it lives in a haystack.
+ * Two functions live here:
  *
- * Window size (50 words) and stride (25 words, 50% overlap) are chosen
- * so a typical injection fits entirely within at least one window,
- * and so boundary-straddling attacks can't escape by sitting across
- * chunk edges.
+ * - `chunkText` (canonical) — boundary-aware text splitter used by the
+ *   service-worker orchestrator to dispatch RUN_PROBES messages, and (after
+ *   N1) by the Hunter pipeline for tier routing. Returns structured `Chunk`
+ *   objects with byte-offsets and a sha256 contentHash so downstream cache
+ *   layers (N11) can key results per-chunk.
+ *
+ * - `chunkByWords` (Hawk-internal) — sliding 50-word window over an already-
+ *   chunked string, used inside Hawk's per-window ML scoring. Real injection
+ *   payloads are typically 30-100 words embedded in much larger pages, so
+ *   page-level density features dilute the signal; scoring each window
+ *   independently and taking the max preserves the needle's signal even
+ *   when it lives in a haystack.
  */
+
+import { MAX_CHUNK_CHARS } from '@/shared/constants.js';
+import type { Chunk } from '@/types/chunk.js';
 
 const DEFAULT_WINDOW = 50;
 const DEFAULT_STRIDE = 25;
@@ -33,5 +40,116 @@ export function chunkByWords(
     chunks.push(chunk);
     if (i + windowSize >= words.length) break;
   }
+  return chunks;
+}
+
+interface ChunkTextOptions {
+  readonly maxChars?: number;
+}
+
+async function sha256Hex(content: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(content);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  return Array.from(new Uint8Array(hashBuffer))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+const SENTENCE_DELIMITERS = ['. ', '! ', '? ', '.\n'] as const;
+
+/**
+ * Pick the split point for the next chunk in `remaining`.
+ *
+ * Boundary chain (each step searches within `[0, maxChars]`; first hit at
+ * or past the 50% mark wins, otherwise we fall through):
+ *   1. Paragraph break  — `\n\n`
+ *   2. Sentence boundary — latest of `. ` / `! ` / `? ` / `.\n`
+ *   3. Word break        — last single space
+ *   4. Hard cut          — exactly `maxChars`
+ *
+ * The 50% guard mirrors the prior orchestrator chunker: if the best
+ * boundary lands in the first half of the window, we'd be wasting too
+ * much of the budget, so we fall through to the next strategy.
+ *
+ * Returned offset points to the *first character of the next chunk* —
+ * the boundary token itself stays with the prior chunk. Reconstruction
+ * `prior + next === remaining` is preserved.
+ */
+function findSplit(remaining: string, maxChars: number): number {
+  const halfMark = maxChars * 0.5;
+
+  const paragraphAt = remaining.lastIndexOf('\n\n', maxChars);
+  if (paragraphAt !== -1 && paragraphAt >= halfMark) {
+    return paragraphAt + 1;
+  }
+
+  let bestSentence = -1;
+  for (const delim of SENTENCE_DELIMITERS) {
+    const idx = remaining.lastIndexOf(delim, maxChars);
+    if (idx > bestSentence) bestSentence = idx;
+  }
+  if (bestSentence !== -1 && bestSentence >= halfMark) {
+    return bestSentence + 1;
+  }
+
+  const wordAt = remaining.lastIndexOf(' ', maxChars);
+  if (wordAt !== -1) {
+    return wordAt + 1;
+  }
+
+  return maxChars;
+}
+
+/**
+ * Canonical boundary-aware text chunker. See file-level comment for design.
+ *
+ * Async because each chunk's `contentHash` is computed via `crypto.subtle`,
+ * matching the sha256-hex pattern used in `src/content/ingestion/script-
+ * summary.ts`.
+ */
+export async function chunkText(
+  text: string,
+  opts: ChunkTextOptions = {},
+): Promise<readonly Chunk[]> {
+  const maxChars = opts.maxChars ?? MAX_CHUNK_CHARS;
+
+  if (text.length <= maxChars) {
+    return [
+      {
+        text,
+        start: 0,
+        end: text.length,
+        contentHash: await sha256Hex(text),
+      },
+    ];
+  }
+
+  const chunks: Chunk[] = [];
+  let cursor = 0;
+
+  while (cursor < text.length) {
+    const remaining = text.slice(cursor);
+    if (remaining.length <= maxChars) {
+      chunks.push({
+        text: remaining,
+        start: cursor,
+        end: cursor + remaining.length,
+        contentHash: await sha256Hex(remaining),
+      });
+      break;
+    }
+
+    const splitAt = findSplit(remaining, maxChars);
+    const chunkSlice = remaining.slice(0, splitAt);
+    chunks.push({
+      text: chunkSlice,
+      start: cursor,
+      end: cursor + splitAt,
+      contentHash: await sha256Hex(chunkSlice),
+    });
+    cursor += splitAt;
+  }
+
   return chunks;
 }

--- a/src/service-worker/orchestrator.ts
+++ b/src/service-worker/orchestrator.ts
@@ -1,7 +1,8 @@
 import type { PageSnapshot } from '@/types/snapshot.js';
 import type { ProbeResult, SecurityVerdict, WebGPUAdapterMode } from '@/types/verdict.js';
 import type { RunProbesMessage, ProbeResultsMessage } from '@/types/messages.js';
-import { MAX_CHUNK_CHARS, MAX_CHUNKS_PER_PAGE } from '@/shared/constants.js';
+import { MAX_CHUNKS_PER_PAGE } from '@/shared/constants.js';
+import { chunkText } from '@/hunters/hawk/chunking.js';
 import { createLogger } from '@/shared/logger.js';
 import { ensureOffscreenDocument } from './offscreen-manager.js';
 import { connectOffscreenPort } from './keepalive.js';
@@ -59,35 +60,6 @@ export class AnalysisAbortedError extends Error {
     super(reason);
     this.name = 'AnalysisAbortedError';
   }
-}
-
-function chunkText(text: string): readonly string[] {
-  if (text.length <= MAX_CHUNK_CHARS) return [text];
-
-  const chunks: string[] = [];
-  let remaining = text;
-
-  while (remaining.length > 0) {
-    if (remaining.length <= MAX_CHUNK_CHARS) {
-      chunks.push(remaining);
-      break;
-    }
-
-    let splitAt = remaining.lastIndexOf('. ', MAX_CHUNK_CHARS);
-    if (splitAt === -1 || splitAt < MAX_CHUNK_CHARS * 0.5) {
-      splitAt = remaining.lastIndexOf(' ', MAX_CHUNK_CHARS);
-    }
-    if (splitAt === -1) {
-      splitAt = MAX_CHUNK_CHARS;
-    } else {
-      splitAt += 1;
-    }
-
-    chunks.push(remaining.slice(0, splitAt));
-    remaining = remaining.slice(splitAt);
-  }
-
-  return chunks;
 }
 
 function buildAnalysisText(snapshot: PageSnapshot): string {
@@ -208,7 +180,7 @@ export async function analyzeSnapshot(
   connectOffscreenPort();
 
   const fullText = buildAnalysisText(snapshot);
-  const allChunks = chunkText(fullText);
+  const allChunks = await chunkText(fullText);
 
   // Phase 4 Stage 4B — enforce MAX_CHUNKS_PER_PAGE cap to bound latency and
   // avoid the sustained-engine-use failure mode. Truncation is recorded via
@@ -244,7 +216,7 @@ export async function analyzeSnapshot(
         log.info(`Analysis for ${snapshot.metadata.url} aborted between chunks (${reason})`);
         throw new AnalysisAbortedError(reason);
       }
-      const chunk = chunks[index]!;
+      const chunk = chunks[index]!.text;
       const { results, canaryId: chunkCanaryId, webgpuAdapterMode: chunkAdapterMode } = await runChunkProbes({
         tabId,
         chunk,

--- a/src/types/chunk.ts
+++ b/src/types/chunk.ts
@@ -1,0 +1,15 @@
+/**
+ * Canonical chunk shape produced by `chunkText` (src/hunters/hawk/chunking.ts).
+ *
+ * Both the orchestrator's probe-dispatch path and (in N1) the Hunter pipeline
+ * consume chunks of this shape. `start`/`end` are byte-offsets into the
+ * source text so downstream consumers can map findings back to DOM ranges.
+ * `contentHash` is the sha256-hex of `text` and is stable across calls so
+ * the N11 cache can key per-chunk results.
+ */
+export interface Chunk {
+  readonly text: string;
+  readonly start: number;
+  readonly end: number;
+  readonly contentHash: string;
+}


### PR DESCRIPTION
Closes #115

## Summary

Consolidates the two independent chunkers (orchestrator's inline `chunkText` + Hawk's `chunkByWords`) into one canonical entry point in `src/hunters/hawk/chunking.ts` so the upcoming N1 Hunter-tier-routing contract has a single source of truth for chunk boundaries.

- **New `chunkText(text, opts?)`** returning `Promise<readonly Chunk[]>` with `{text, start, end, contentHash}`. Boundary chain: paragraph (`\n\n`) → sentence (`. ` / `! ` / `? ` / `.\n`) → word → hard cut. The 50% guard from the prior orchestrator chunker is preserved at every step except the hard cut, making the new chain a strict superset of the old behaviour.
- **`contentHash` is sha256-hex** (deterministic; ready for the N11 cache). Reuses the same `crypto.subtle.digest('SHA-256', …)` flow already present in `src/content/ingestion/script-summary.ts`.
- **New `Chunk` interface** in `src/types/chunk.ts`.
- **Orchestrator** drops its inline `chunkText`; `analyzeSnapshot` now `await`s the canonical chunker and dereferences `.text` for the RUN_PROBES payload. Message shape unchanged (`chunk: string`).
- **Hawk's `chunkByWords` is preserved verbatim** — it remains as an internal sliding-window helper inside Hawk's per-window ML scoring. N1 (the next stage) will rewire Hawk to consume canonical chunks; doing it here would expand scope.

## Why this is regression-safe

The new boundary chain is a strict superset of the old chain (`. ` → word → hard). Every previously-found split point is still reachable. A regression test pins this: a sentence-only input still splits at the exact offset the old orchestrator chunker would have produced.

Phase 2 byte-identity (`scripts/fixtures/phase2-inputs.test.ts:57`) runs against the v1 classifier on `row.output` directly and never routes through the chunker, so it is unaffected.

## Test plan

- [x] 9 new TDD cases for `chunkText` in `src/hunters/hawk/chunking.test.ts` (single-chunk fast path, paragraph preference, sentence fallback, word fallback, hard cut, offset reconstructability, tail coverage, hash determinism, regression vs old orchestrator)
- [x] Existing `chunkByWords` cases unchanged
- [x] `npm test` — 439/439 green (was 430)
- [x] `npm run typecheck` — clean
- [x] `npm run build` — `dist/` rebuilds clean
- [ ] Manual smoke (optional, post-merge): load `dist/` unpacked, open a long Wikipedia article, confirm SW console logs `Split into N chunk(s)` with N>1

## Notes for reviewer

- `chunkByWords` is intentionally untouched. N1 is the right place to rewire Hawk's consumer; this PR is the foundation, not the wiring.
- `chunkText` is async because `crypto.subtle.digest` is async. The orchestrator absorbs one extra `await` at the call site.