### PR TITLE
fix(ci-#137): resolve unresolved merge-conflict markers in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,6 @@ jobs:
 
       - name: Build
         run: npm run build
-<<<<<<< HEAD
-=======
 
       - name: Build harness bundles
         run: npm run harness:build
@@ -59,40 +57,3 @@ jobs:
         # manually during PR #105 / #94). Fail the PR if a fresh build
         # produces any diff.
         run: git diff --exit-code harnesses/index.js harnesses/nano-harness.js
-
-  graph-drift:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: npm
-      - run: npm ci
-      - name: Determine branch clusters
-        id: clusters
-        run: |
-          NUMS=$(git log origin/main..HEAD --pretty=%s%n%b | grep -oE '#[0-9]+' | tr -d '#' | sort -u | tr '\n' ',' || true)
-          echo "issue_numbers=${NUMS%,}" >> "$GITHUB_OUTPUT"
-      - name: Graph drift check
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ISSUE_NUMBERS: ${{ steps.clusters.outputs.issue_numbers }}
-        run: |
-          CLUSTERS=""
-          IFS=',' read -ra NUMS <<< "$ISSUE_NUMBERS"
-          for n in "${NUMS[@]}"; do
-            [ -z "$n" ] && continue
-            LABELS=$(gh issue view "$n" --json labels -q '.labels[].name' 2>/dev/null | tr '\n' ',' || true)
-            CLUSTERS="$CLUSTERS,$LABELS"
-          done
-          CLUSTERS=$(echo "$CLUSTERS" | tr ',' '\n' | grep -E '^(project-|phase-|upstream|future-feature)' | sort -u | tr '\n' ',' | sed 's/,$//')
-          echo "Branch clusters: $CLUSTERS"
-          if [ -n "$CLUSTERS" ]; then
-            npx tsx scripts/issue-graph/drift-cli.ts --branch-clusters "$CLUSTERS"
-          else
-            npx tsx scripts/issue-graph/drift-cli.ts
-          fi
->>>>>>> ee75cdc (fix(ci-#106): detect harness bundle source/build drift)


### PR DESCRIPTION
Closes #137

## Summary

`.github/workflows/ci.yml` on `main` carried unresolved Git merge-conflict markers (`<<<<<<< HEAD`, `=======`, `>>>>>>> ee75cdc`) introduced when PR #107 merged. Every CI run since has failed at workflow-parse time — visible duration is `0s` and GitHub reports \`This run likely failed because of a workflow file issue.\`

This blocks PR #136 (Phase 5 Stage 1 / issue #115) and every other PR.

## Resolution

- **Kept** the harness-bundle build + drift-check block from PR #107. \`npm run harness:build\` and \`harnesses/{index,nano-harness}.js\` are still live; the drift check is intentional.
- **Dropped** the \`graph-drift\` job entirely. PR #134 removed \`scripts/issue-graph/\`; the job referenced nonexistent code (\`scripts/issue-graph/drift-cli.ts\`) and would have failed even if the workflow parsed.
- **Removed** the three conflict-marker lines.

## Validation

- \`js-yaml\` parses the file cleanly (no schema errors).
- File shrinks from 98 lines (with markers) to 59 lines.
- The \`verify\` job's step list is unchanged in shape: checkout → setup-node → npm ci → typecheck → test → build → harness build → harness-drift check.
- This PR's own CI run is the first observable signal that workflow parsing now succeeds.

## Test plan

- [ ] CI run on this PR shows non-zero duration and reaches \`verify\` job's steps
- [ ] Merge → next PR (#136) inherits a working workflow