### PR TITLE
feat(phase5-#117): HoneyLLM page stamp + LLM verification protocol (N13)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "honeyllm",
       "version": "0.1.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@mlc-ai/web-llm": "^0.2.74"
       },
@@ -14,6 +15,7 @@
         "@anthropic-ai/sdk": "^0.39.0",
         "@playwright/test": "^1.49.0",
         "@types/chrome": "^0.0.287",
+        "jsdom": "^29.1.0",
         "sharp": "^0.34.5",
         "tsx": "^4.21.0",
         "typescript": "^5.7.0",
@@ -53,6 +55,210 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.10.0",
@@ -505,6 +711,24 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@img/colour": {
@@ -1710,6 +1934,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -1754,6 +1988,79 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -1787,6 +2094,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-define-property": {
@@ -2105,6 +2425,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/humanize-ms": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
@@ -2113,6 +2446,92 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.0.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.0.tgz",
+      "integrity": "sha512-YNUc7fB9QuvSSQWfrH0xF+TyABkxUwx8sswgIDaCrw4Hol8BghdZDkITtZheRJeMtzWlnTfsM3bBBusRvpO1wg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/loglevel": {
@@ -2126,6 +2545,16 @@
       "funding": {
         "type": "tidelift",
         "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/magic-string": {
@@ -2147,6 +2576,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
@@ -2250,6 +2686,19 @@
       ],
       "license": "MIT"
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -2310,9 +2759,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "dev": true,
       "funding": [
         {
@@ -2336,6 +2785,26 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -2391,6 +2860,19 @@
         "@rollup/rollup-win32-x64-gnu": "4.60.1",
         "@rollup/rollup-win32-x64-msvc": "4.60.1",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/semver": {
@@ -2482,6 +2964,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -2524,6 +3013,39 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.29",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.29.tgz",
+      "integrity": "sha512-JIXCerhudr/N6OWLwLF1HVsTTUo7ry6qHa5eWZEkiMuxsIiAACL55tGLfqfHfoH7QaMQUW8fngD7u7TxWexYQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.29"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.29",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.29.tgz",
+      "integrity": "sha512-W99NuU7b1DcG3uJ3v9k9VztCH3WialNbBkBft5wCs8V8mexu0XQqaZEYb9l9RNNzK8+3EJ9PKWB0/RUtTQ/o+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -3074,6 +3596,16 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
@@ -3261,6 +3793,19 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "4.0.0-beta.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
@@ -3277,6 +3822,16 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -3305,6 +3860,23 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@anthropic-ai/sdk": "^0.39.0",
     "@playwright/test": "^1.49.0",
     "@types/chrome": "^0.0.287",
+    "jsdom": "^29.1.0",
     "sharp": "^0.34.5",
     "tsx": "^4.21.0",
     "typescript": "^5.7.0",

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -8,6 +8,11 @@ import { sanitizeSuspiciousNodes } from './mitigation/dom-sanitizer.js';
 import { activateRedirectBlocker } from './mitigation/redirect-blocker.js';
 import { setWindowGlobals } from './signaling/window-globals.js';
 import { setSecurityMetaTag } from './signaling/meta-tag.js';
+import {
+  embedStamp,
+  installStampObservers,
+  installNavigationTeardown,
+} from './signaling/page-stamp-embed.js';
 
 const log = createLogger('Content');
 
@@ -62,6 +67,15 @@ chrome.runtime.onMessage.addListener((message: HoneyLLMMessage) => {
 
     setWindowGlobals(verdict);
     setSecurityMetaTag(verdict.status);
+
+    // Issue #117 (N13) — embed page stamp when one was issued. Origin-
+    // skipped verdicts and verdicts where ensureInstallSecret failed
+    // arrive with stamp=null and skip the embed path.
+    if (verdict.stamp !== null) {
+      const nodes = embedStamp(verdict.stamp);
+      const observers = installStampObservers(nodes, verdict.stamp);
+      installNavigationTeardown(observers, nodes);
+    }
   }
 
   if (message.type === 'APPLY_MITIGATION') {

--- a/src/content/signaling/page-stamp-embed.test.ts
+++ b/src/content/signaling/page-stamp-embed.test.ts
@@ -1,0 +1,164 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  embedStamp,
+  installStampObservers,
+  installNavigationTeardown,
+} from './page-stamp-embed.js';
+import type { PageStamp } from '@/types/page-stamp.js';
+import { STAMP_VERSION } from '@/shared/constants.js';
+
+const FIXTURE_STAMP: PageStamp = {
+  v: STAMP_VERSION,
+  url: 'https://example.com/page',
+  status: 'CLEAN',
+  timestamp: 1_700_000_000_000,
+  nonce: 'AbCdEfGhIjKlMnOpQrStUv',
+  hmac: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+};
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function countStampNodes(): number {
+  return document.querySelectorAll('[data-honeyllm-stamp]').length;
+}
+
+function resetDom(): void {
+  document.head.replaceChildren();
+  document.body.replaceChildren();
+}
+
+describe('embedStamp', () => {
+  beforeEach(() => {
+    resetDom();
+  });
+
+  afterEach(() => {
+    resetDom();
+  });
+
+  it('inserts three [data-honeyllm-stamp] elements (badge in body, meta in head, invisible in body)', () => {
+    const nodes = embedStamp(FIXTURE_STAMP);
+    expect(nodes.badge.parentNode).toBe(document.body);
+    expect(nodes.meta.parentNode).toBe(document.head);
+    expect(nodes.invisible.parentNode).toBe(document.body);
+    expect(countStampNodes()).toBe(3);
+  });
+
+  it('renders the visible badge with the shield prefix and first 8 chars of stamp.hmac', () => {
+    const nodes = embedStamp(FIXTURE_STAMP);
+    expect(nodes.badge.textContent).toContain('🛡️');
+    expect(nodes.badge.textContent).toContain('HoneyLLM scanned');
+    expect(nodes.badge.textContent).toContain(FIXTURE_STAMP.hmac.slice(0, 8));
+    expect(nodes.badge.style.position).toBe('fixed');
+  });
+
+  it('round-trips the full stamp via base64url(JSON.stringify) in the meta tag content', () => {
+    const nodes = embedStamp(FIXTURE_STAMP);
+    const content = nodes.meta.getAttribute('content');
+    expect(content).not.toBeNull();
+    const standard = content!.replaceAll('-', '+').replaceAll('_', '/');
+    const padded = standard + '='.repeat((4 - (standard.length % 4)) % 4);
+    const decoded = JSON.parse(atob(padded));
+    expect(decoded).toEqual(FIXTURE_STAMP);
+  });
+
+  it('renders the invisible div as aria-hidden display:none with non-empty content', () => {
+    const nodes = embedStamp(FIXTURE_STAMP);
+    expect(nodes.invisible.getAttribute('aria-hidden')).toBe('true');
+    expect(nodes.invisible.style.display).toBe('none');
+    expect(nodes.invisible.textContent).not.toBe('');
+  });
+
+  it('is idempotent: a second call leaves exactly 3 stamp nodes (no duplicates)', () => {
+    embedStamp(FIXTURE_STAMP);
+    embedStamp(FIXTURE_STAMP);
+    expect(countStampNodes()).toBe(3);
+  });
+});
+
+describe('installStampObservers', () => {
+  beforeEach(() => {
+    resetDom();
+  });
+
+  afterEach(() => {
+    resetDom();
+  });
+
+  it('re-adds the stamp when the badge is removed by another script', async () => {
+    const nodes = embedStamp(FIXTURE_STAMP);
+    const obs = installStampObservers(nodes, FIXTURE_STAMP);
+    try {
+      nodes.badge.remove();
+      expect(countStampNodes()).toBe(2);
+      await flushMicrotasks();
+      expect(countStampNodes()).toBe(3);
+    } finally {
+      obs.disconnect();
+    }
+  });
+
+  it('does not loop on its own re-adds (count stays at 3 after one removal+re-embed cycle)', async () => {
+    const nodes = embedStamp(FIXTURE_STAMP);
+    const obs = installStampObservers(nodes, FIXTURE_STAMP);
+    try {
+      nodes.invisible.remove();
+      await flushMicrotasks();
+      await flushMicrotasks();
+      expect(countStampNodes()).toBe(3);
+    } finally {
+      obs.disconnect();
+    }
+  });
+
+  it('re-adds when the meta tag is removed (head observer is wired)', async () => {
+    const nodes = embedStamp(FIXTURE_STAMP);
+    const obs = installStampObservers(nodes, FIXTURE_STAMP);
+    try {
+      nodes.meta.remove();
+      expect(document.head.querySelector('meta[name="honeyllm-stamp"]')).toBeNull();
+      await flushMicrotasks();
+      expect(document.head.querySelector('meta[name="honeyllm-stamp"]')).not.toBeNull();
+    } finally {
+      obs.disconnect();
+    }
+  });
+});
+
+describe('installNavigationTeardown', () => {
+  beforeEach(() => {
+    resetDom();
+  });
+
+  afterEach(() => {
+    resetDom();
+  });
+
+  it('removes all stamp nodes and disconnects observers on popstate', async () => {
+    const nodes = embedStamp(FIXTURE_STAMP);
+    const obs = installStampObservers(nodes, FIXTURE_STAMP);
+    installNavigationTeardown(obs, nodes);
+    expect(countStampNodes()).toBe(3);
+    window.dispatchEvent(new PopStateEvent('popstate'));
+    await flushMicrotasks();
+    expect(countStampNodes()).toBe(0);
+    // After teardown, observers are gone — clearing children must NOT trigger re-add
+    resetDom();
+    await flushMicrotasks();
+    expect(countStampNodes()).toBe(0);
+  });
+
+  it('also tears down on hashchange', async () => {
+    const nodes = embedStamp(FIXTURE_STAMP);
+    const obs = installStampObservers(nodes, FIXTURE_STAMP);
+    installNavigationTeardown(obs, nodes);
+    window.dispatchEvent(new HashChangeEvent('hashchange'));
+    await flushMicrotasks();
+    expect(countStampNodes()).toBe(0);
+  });
+});

--- a/src/content/signaling/page-stamp-embed.ts
+++ b/src/content/signaling/page-stamp-embed.ts
@@ -1,0 +1,152 @@
+import type { PageStamp } from '@/types/page-stamp.js';
+
+/**
+ * Issue #117 (N13) — DOM embed + persistence for the page stamp.
+ *
+ * Three nodes are embedded so the LLM ingestion path always sees at
+ * least one form of the stamp:
+ *  - visible badge (text content survives most LLM ingestion)
+ *  - <meta name="honeyllm-stamp"> in head
+ *  - invisible aria-hidden div (doesn't affect layout/a11y, available
+ *    to assistive tech that reads structured content)
+ *
+ * MutationObserver guarding uses element-reference tracking, NOT a
+ * count guard. A page that copies the `data-honeyllm-stamp` attribute
+ * onto its own elements would defeat a count check; per-element-ref
+ * tracking via `isConnected` correctly detects when our specific
+ * nodes have been removed.
+ *
+ * Two observers are scoped tightly (head and body, no subtree) so a
+ * SPA's heavy DOM churn doesn't fire thousands of callbacks per
+ * second. Both badge and invisible div are direct children of body;
+ * meta is a direct child of head.
+ *
+ * SPA navigation: MV3 content scripts survive history.pushState. The
+ * navigation teardown listener removes the stamp nodes and
+ * disconnects the observers on `popstate`/`hashchange` so an old-URL
+ * stamp is never re-injected into a new page after a same-document
+ * nav.
+ */
+
+const STAMP_DATA_ATTR = 'data-honeyllm-stamp';
+const META_NAME = 'honeyllm-stamp';
+
+export interface StampNodes {
+  readonly badge: HTMLDivElement;
+  readonly meta: HTMLMetaElement;
+  readonly invisible: HTMLDivElement;
+}
+
+export interface StampObservers {
+  readonly head: MutationObserver;
+  readonly body: MutationObserver;
+  disconnect(): void;
+}
+
+function bytesToBase64url(bytes: Uint8Array): string {
+  let binary = '';
+  for (let i = 0; i < bytes.length; i += 1) {
+    binary += String.fromCharCode(bytes[i]!);
+  }
+  return btoa(binary).replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '');
+}
+
+function encodeStamp(stamp: PageStamp): string {
+  const json = JSON.stringify(stamp);
+  return bytesToBase64url(new TextEncoder().encode(json));
+}
+
+function removeExistingStamps(): void {
+  const existing = document.querySelectorAll(`[${STAMP_DATA_ATTR}]`);
+  existing.forEach((el) => el.remove());
+}
+
+function buildBadge(stamp: PageStamp): HTMLDivElement {
+  const badge = document.createElement('div');
+  badge.setAttribute(STAMP_DATA_ATTR, '1');
+  badge.className = 'honeyllm-stamp-badge';
+  badge.style.position = 'fixed';
+  badge.style.top = '8px';
+  badge.style.right = '8px';
+  badge.style.zIndex = '2147483647';
+  badge.style.padding = '4px 8px';
+  badge.style.background = 'rgba(20,28,40,0.9)';
+  badge.style.color = '#fff';
+  badge.style.font = '11px/1.4 system-ui, -apple-system, sans-serif';
+  badge.style.borderRadius = '4px';
+  badge.style.pointerEvents = 'none';
+  badge.textContent = `🛡️ HoneyLLM scanned · ${stamp.hmac.slice(0, 8)}`;
+  return badge;
+}
+
+function buildMeta(stamp: PageStamp): HTMLMetaElement {
+  const meta = document.createElement('meta');
+  meta.setAttribute('name', META_NAME);
+  meta.setAttribute(STAMP_DATA_ATTR, '1');
+  meta.setAttribute('content', encodeStamp(stamp));
+  return meta;
+}
+
+function buildInvisible(stamp: PageStamp): HTMLDivElement {
+  const div = document.createElement('div');
+  div.setAttribute(STAMP_DATA_ATTR, '1');
+  div.setAttribute('aria-hidden', 'true');
+  div.style.display = 'none';
+  div.textContent = encodeStamp(stamp);
+  return div;
+}
+
+export function embedStamp(stamp: PageStamp): StampNodes {
+  removeExistingStamps();
+  const badge = buildBadge(stamp);
+  const meta = buildMeta(stamp);
+  const invisible = buildInvisible(stamp);
+  document.head.appendChild(meta);
+  document.body.appendChild(badge);
+  document.body.appendChild(invisible);
+  return { badge, meta, invisible };
+}
+
+export function installStampObservers(initial: StampNodes, stamp: PageStamp): StampObservers {
+  let current: StampNodes = initial;
+
+  const reembedIfMissing = (): void => {
+    if (
+      !current.badge.isConnected ||
+      !current.meta.isConnected ||
+      !current.invisible.isConnected
+    ) {
+      current = embedStamp(stamp);
+    }
+  };
+
+  const head = new MutationObserver(reembedIfMissing);
+  head.observe(document.head, { childList: true });
+
+  const body = new MutationObserver(reembedIfMissing);
+  body.observe(document.body, { childList: true });
+
+  return {
+    head,
+    body,
+    disconnect(): void {
+      head.disconnect();
+      body.disconnect();
+    },
+  };
+}
+
+export function installNavigationTeardown(
+  observers: StampObservers,
+  _nodes: StampNodes,
+): void {
+  const teardown = (): void => {
+    observers.disconnect();
+    const remaining = document.querySelectorAll(`[${STAMP_DATA_ATTR}]`);
+    remaining.forEach((el) => el.remove());
+    window.removeEventListener('popstate', teardown);
+    window.removeEventListener('hashchange', teardown);
+  };
+  window.addEventListener('popstate', teardown);
+  window.addEventListener('hashchange', teardown);
+}

--- a/src/policy/engine.test.ts
+++ b/src/policy/engine.test.ts
@@ -73,6 +73,26 @@ describe('evaluatePolicy', () => {
     expect(verdict.timestamp).toBeLessThanOrEqual(after);
   });
 
+  it('emits stamp: null on every evaluatePolicy output (orchestrator attaches the real stamp downstream)', () => {
+    const clean = evaluatePolicy(
+      [makeResult({ probeName: 'summarization', passed: true })],
+      CLEAN_FLAGS,
+      'https://example.com',
+    );
+    expect(clean.stamp).toBeNull();
+
+    const allErrored = evaluatePolicy(
+      [
+        makeResult({ probeName: 'summarization', errorMessage: 'engine timeout' }),
+        makeResult({ probeName: 'instruction_detection', errorMessage: 'engine timeout' }),
+      ],
+      CLEAN_FLAGS,
+      'https://example.com',
+    );
+    expect(allErrored.status).toBe('UNKNOWN');
+    expect(allErrored.stamp).toBeNull();
+  });
+
   it('confidence is between 0 and 1', () => {
     const clean = evaluatePolicy([], CLEAN_FLAGS, 'https://a.com');
     expect(clean.confidence).toBeGreaterThanOrEqual(0);

--- a/src/policy/engine.ts
+++ b/src/policy/engine.ts
@@ -61,6 +61,7 @@ export function evaluatePolicy(
       analysisError: aggregateError,
       canaryId,
       webgpuAdapterMode,
+      stamp: null,
     };
   }
 
@@ -80,5 +81,6 @@ export function evaluatePolicy(
     analysisError: aggregateError,
     canaryId,
     webgpuAdapterMode,
+    stamp: null,
   };
 }

--- a/src/policy/storage.ts
+++ b/src/policy/storage.ts
@@ -31,6 +31,10 @@ export async function persistVerdict(verdict: SecurityVerdict): Promise<void> {
       // Phase 4 Stage 4D.3 — record which canary produced this verdict so the
       // popup can display it and detect user-selection vs actual divergence.
       canaryId: verdict.canaryId,
+      // Issue #117 (N13) — persist the page stamp so the popup can read
+      // it on open and call VERIFY_STAMP if the LLM's returned stamp
+      // matches. Null on origin-skipped or stamp-failure verdicts.
+      stamp: verdict.stamp,
     },
   });
 
@@ -40,7 +44,16 @@ export async function persistVerdict(verdict: SecurityVerdict): Promise<void> {
 export async function getVerdict(url: string): Promise<SecurityVerdict | null> {
   const key = originKey(url);
   const result = await chrome.storage.local.get(key);
-  return (result[key] as SecurityVerdict) ?? null;
+  const stored = result[key];
+  if (stored === null || stored === undefined) return null;
+  // Issue #117 — verdicts persisted before the stamp field was added
+  // come back with `stamp === undefined`. Coalesce to null so callers
+  // always observe the canonical SecurityVerdict shape.
+  const restored = stored as SecurityVerdict & { stamp?: unknown };
+  if (restored.stamp === undefined) {
+    return { ...restored, stamp: null };
+  }
+  return restored as SecurityVerdict;
 }
 
 export async function getAllVerdicts(): Promise<Record<string, unknown>> {

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -1,19 +1,39 @@
-import type { HoneyLLMMessage, VerdictMessage, ApplyMitigationMessage } from '@/types/messages.js';
+import type {
+  HoneyLLMMessage,
+  VerdictMessage,
+  ApplyMitigationMessage,
+  VerifyStampResultMessage,
+} from '@/types/messages.js';
 import { createLogger } from '@/shared/logger.js';
 import { startKeepalive } from './keepalive.js';
 import { analyzeSnapshot, AnalysisAbortedError, getInFlightCount, getInFlightTabIds } from './orchestrator.js';
 import { setTabVerdict, handleTabActivated, handleTabRemoved } from './toolbar-icon.js';
+import { ensureInstallSecret } from '@/shared/install-secret.js';
+import { verifyStamp } from './stamp.js';
 
 const log = createLogger('ServiceWorker');
+
+// Issue #117 (N13) — bootstrap the per-install HMAC secret on every
+// SW wakeup. ensureInstallSecret is read-before-write idempotent, so
+// onInstalled (which fires on every UPDATE, not just first install)
+// will not rotate the secret. Errors are logged at warn — the call
+// will be retried on the first VERIFY_STAMP / verdict-stamping path.
+function bootstrapInstallSecret(): void {
+  ensureInstallSecret().catch((err) => {
+    log.warn('Install secret bootstrap failed; will retry on first use', err);
+  });
+}
 
 chrome.runtime.onInstalled.addListener(() => {
   log.info('HoneyLLM installed');
   startKeepalive();
+  bootstrapInstallSecret();
 });
 
 chrome.runtime.onStartup.addListener(() => {
   log.info('HoneyLLM startup');
   startKeepalive();
+  bootstrapInstallSecret();
 });
 
 // Phase 4 Stage 4D.4 — per-tab icon state lifecycle hooks.
@@ -67,6 +87,33 @@ chrome.runtime.onMessage.addListener((message: HoneyLLMMessage, sender, sendResp
       return;
     }
 
+    // Issue #117 (N13) — VERIFY_STAMP is registered on onMessage ONLY,
+    // never onMessageExternal. The local harness already reaches
+    // onMessageExternal for HONEYLLM_STATUS_PING (see below); exposing
+    // stamp verification there would let the harness use HoneyLLM as
+    // an HMAC oracle against the install secret. Internal channel only.
+    case 'VERIFY_STAMP': {
+      ensureInstallSecret()
+        .then((secret) => verifyStamp(message.stamp, secret, message.currentUrl))
+        .then((result) => {
+          const response: VerifyStampResultMessage = {
+            type: 'VERIFY_STAMP_RESULT',
+            result,
+          };
+          sendResponse(response);
+        })
+        .catch((err) => {
+          log.error('VERIFY_STAMP handler failed', err);
+          const response: VerifyStampResultMessage = {
+            type: 'VERIFY_STAMP_RESULT',
+            result: { valid: false, mismatchReason: 'malformed' },
+          };
+          sendResponse(response);
+        });
+      // Returning true keeps the message port open for the async sendResponse.
+      return true;
+    }
+
     default:
       return;
   }
@@ -79,6 +126,13 @@ chrome.runtime.onMessage.addListener((message: HoneyLLMMessage, sender, sendResp
  * to tolerate the contention.
  *
  * externally_connectable in manifest.json restricts the origin.
+ *
+ * SECURITY (issue #117): VERIFY_STAMP is deliberately NOT handled here.
+ * Even though the harness origin is in externally_connectable, exposing
+ * stamp verification on this channel would let the harness use
+ * HoneyLLM as an HMAC oracle against the install secret (feed
+ * arbitrary stamps, observe valid|wrong-secret, narrow toward the
+ * secret). Internal `chrome.runtime.onMessage` only.
  */
 chrome.runtime.onMessageExternal.addListener((message: unknown, _sender, sendResponse) => {
   if (message === null || typeof message !== 'object' || !('type' in message)) return;

--- a/src/service-worker/orchestrator.test.ts
+++ b/src/service-worker/orchestrator.test.ts
@@ -121,6 +121,22 @@ describe('buildOriginSkippedVerdict (issue #20)', () => {
     );
     expect(verdict.canaryId).toBeNull();
   });
+
+  it('emits stamp: null — origin-skipped verdicts are deliberately unstamped (issue #117)', () => {
+    const denyList = buildOriginSkippedVerdict(
+      snapshotFixture({ url: 'https://mail.google.com/' }),
+      'Gmail',
+      'deny_list_match',
+    );
+    expect(denyList.stamp).toBeNull();
+
+    const userOverride = buildOriginSkippedVerdict(
+      snapshotFixture(),
+      null,
+      'user_override_skip',
+    );
+    expect(userOverride.stamp).toBeNull();
+  });
 });
 
 describe('swapInFlightController (issue #11)', () => {

--- a/src/service-worker/orchestrator.ts
+++ b/src/service-worker/orchestrator.ts
@@ -1,5 +1,6 @@
 import type { PageSnapshot } from '@/types/snapshot.js';
 import type { ProbeResult, SecurityVerdict, WebGPUAdapterMode } from '@/types/verdict.js';
+import type { PageStamp } from '@/types/page-stamp.js';
 import type { RunProbesMessage, ProbeResultsMessage } from '@/types/messages.js';
 import { MAX_CHUNKS_PER_PAGE } from '@/shared/constants.js';
 import { chunkText } from '@/hunters/hawk/chunking.js';
@@ -11,6 +12,8 @@ import { evaluatePolicy } from '@/policy/engine.js';
 import { persistVerdict } from '@/policy/storage.js';
 import { resolveOriginPolicy } from '@/policy/origin-policy.js';
 import { getOverrides } from '@/policy/origin-storage.js';
+import { ensureInstallSecret } from '@/shared/install-secret.js';
+import { generateStamp } from './stamp.js';
 
 const log = createLogger('Orchestrator');
 
@@ -107,6 +110,10 @@ export function buildOriginSkippedVerdict(
     analysisError: `origin_denied: ${errorSuffix}`,
     canaryId: null,
     webgpuAdapterMode: null,
+    // Issue #117 — origin-skipped verdicts are deliberately unstamped.
+    // The stamp attests to "we scanned this URL," contradicting "we
+    // deliberately skipped." Structural rather than runtime-guarded.
+    stamp: null,
   };
 }
 
@@ -246,7 +253,7 @@ export async function analyzeSnapshot(
       capped ? `chunk_count_capped (${allChunks.length} chunks → kept first ${MAX_CHUNKS_PER_PAGE})` : null,
     );
     const behavioralFlags = analyzeBehavior(mergedResults);
-    const verdict = evaluatePolicy(
+    const verdict0 = evaluatePolicy(
       mergedResults,
       behavioralFlags,
       snapshot.metadata.url,
@@ -254,6 +261,23 @@ export async function analyzeSnapshot(
       canaryId,
       webgpuAdapterMode,
     );
+
+    // Issue #117 (N13) — stamp the verdict with an HMAC-bound page
+    // stamp. Origin-skipped verdicts already short-circuited above with
+    // stamp: null in their literal; here we attempt to stamp every
+    // post-evaluatePolicy verdict (engine-failure UNKNOWN included —
+    // the scan was attempted, the stamp attests to that). If the
+    // install secret can't be loaded or the HMAC compute throws, fall
+    // back to stamp: null and surface via the logger rather than
+    // failing the whole verdict.
+    let stamp: PageStamp | null = null;
+    try {
+      const secret = await ensureInstallSecret();
+      stamp = await generateStamp(verdict0, secret);
+    } catch (err) {
+      log.error('Failed to generate page stamp', err);
+    }
+    const verdict: SecurityVerdict = { ...verdict0, stamp };
 
     await persistVerdict(verdict);
 

--- a/src/service-worker/stamp.test.ts
+++ b/src/service-worker/stamp.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { generateStamp, verifyStamp } from './stamp.js';
+import type { PageStamp } from '@/types/page-stamp.js';
+import { STAMP_VERSION } from '@/shared/constants.js';
+
+const SECRET_A = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+const SECRET_B = 'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
+
+const VERDICT_INPUT = {
+  url: 'https://example.com/page',
+  status: 'CLEAN' as const,
+  timestamp: 1_700_000_000_000,
+};
+
+describe('generateStamp', () => {
+  it('returns a stamp with the expected shape and field sizes', async () => {
+    const stamp = await generateStamp(VERDICT_INPUT, SECRET_A);
+    expect(stamp.v).toBe(STAMP_VERSION);
+    expect(stamp.url).toBe('https://example.com/page');
+    expect(stamp.status).toBe('CLEAN');
+    expect(stamp.timestamp).toBe(1_700_000_000_000);
+    // nonce is 16 bytes -> 22 chars base64url unpadded
+    expect(stamp.nonce).toMatch(/^[A-Za-z0-9_-]{22}$/);
+    // hmac is 32 bytes -> 43 chars base64url unpadded
+    expect(stamp.hmac).toMatch(/^[A-Za-z0-9_-]{43}$/);
+  });
+
+  it('produces a different HMAC when the secret differs', async () => {
+    const a = await generateStamp(VERDICT_INPUT, SECRET_A);
+    const b = await generateStamp({ ...VERDICT_INPUT }, SECRET_B);
+    // Different nonces will already differ — clamp the comparison by
+    // verifying via the same nonce path: forge a fixed nonce by spying
+    // on getRandomValues. Here we just assert the stamps differ.
+    expect(a.hmac).not.toBe(b.hmac);
+  });
+
+  it('produces a different HMAC when the url differs', async () => {
+    const fixedNonce = new Uint8Array(16).fill(7);
+    const spy = vi
+      .spyOn(crypto, 'getRandomValues')
+      .mockImplementation(<T extends ArrayBufferView | null>(arr: T): T => {
+        if (arr instanceof Uint8Array) arr.set(fixedNonce);
+        return arr;
+      });
+    try {
+      const a = await generateStamp(VERDICT_INPUT, SECRET_A);
+      const b = await generateStamp(
+        { ...VERDICT_INPUT, url: 'https://example.com/different' },
+        SECRET_A,
+      );
+      expect(a.nonce).toBe(b.nonce);
+      expect(a.hmac).not.toBe(b.hmac);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('produces a different HMAC when the status differs', async () => {
+    const fixedNonce = new Uint8Array(16).fill(7);
+    const spy = vi
+      .spyOn(crypto, 'getRandomValues')
+      .mockImplementation(<T extends ArrayBufferView | null>(arr: T): T => {
+        if (arr instanceof Uint8Array) arr.set(fixedNonce);
+        return arr;
+      });
+    try {
+      const a = await generateStamp(VERDICT_INPUT, SECRET_A);
+      const b = await generateStamp(
+        { ...VERDICT_INPUT, status: 'COMPROMISED' },
+        SECRET_A,
+      );
+      expect(a.hmac).not.toBe(b.hmac);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('produces a different HMAC when the timestamp differs', async () => {
+    const fixedNonce = new Uint8Array(16).fill(7);
+    const spy = vi
+      .spyOn(crypto, 'getRandomValues')
+      .mockImplementation(<T extends ArrayBufferView | null>(arr: T): T => {
+        if (arr instanceof Uint8Array) arr.set(fixedNonce);
+        return arr;
+      });
+    try {
+      const a = await generateStamp(VERDICT_INPUT, SECRET_A);
+      const b = await generateStamp(
+        { ...VERDICT_INPUT, timestamp: VERDICT_INPUT.timestamp + 1 },
+        SECRET_A,
+      );
+      expect(a.hmac).not.toBe(b.hmac);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('produces a different HMAC when the nonce differs', async () => {
+    let counter = 0;
+    const spy = vi
+      .spyOn(crypto, 'getRandomValues')
+      .mockImplementation(<T extends ArrayBufferView | null>(arr: T): T => {
+        if (arr instanceof Uint8Array) arr.fill(counter++);
+        return arr;
+      });
+    try {
+      const a = await generateStamp(VERDICT_INPUT, SECRET_A);
+      const b = await generateStamp(VERDICT_INPUT, SECRET_A);
+      expect(a.nonce).not.toBe(b.nonce);
+      expect(a.hmac).not.toBe(b.hmac);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('produces a deterministic HMAC for identical inputs (fixed nonce)', async () => {
+    const fixedNonce = new Uint8Array(16).fill(42);
+    const spy = vi
+      .spyOn(crypto, 'getRandomValues')
+      .mockImplementation(<T extends ArrayBufferView | null>(arr: T): T => {
+        if (arr instanceof Uint8Array) arr.set(fixedNonce);
+        return arr;
+      });
+    try {
+      const a = await generateStamp(VERDICT_INPUT, SECRET_A);
+      const b = await generateStamp(VERDICT_INPUT, SECRET_A);
+      expect(a.hmac).toBe(b.hmac);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+describe('verifyStamp', () => {
+  let signSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    signSpy = vi.spyOn(crypto.subtle, 'sign');
+  });
+
+  afterEach(() => {
+    signSpy.mockRestore();
+  });
+
+  it('returns valid:true for a stamp that round-trips with the same secret + URL', async () => {
+    const stamp = await generateStamp(VERDICT_INPUT, SECRET_A);
+    signSpy.mockClear();
+    const result = await verifyStamp(stamp, SECRET_A, VERDICT_INPUT.url);
+    expect(result).toEqual({ valid: true });
+  });
+
+  it('treats trivially equivalent URLs as a match (case, fragment, trailing slash)', async () => {
+    const stamp = await generateStamp(VERDICT_INPUT, SECRET_A);
+
+    const upperHost = await verifyStamp(stamp, SECRET_A, 'HTTPS://EXAMPLE.com/page');
+    expect(upperHost).toEqual({ valid: true });
+
+    const withFragment = await verifyStamp(stamp, SECRET_A, 'https://example.com/page#anchor');
+    expect(withFragment).toEqual({ valid: true });
+
+    const stampOfTrailing = await generateStamp(
+      { ...VERDICT_INPUT, url: 'https://example.com/page/' },
+      SECRET_A,
+    );
+    const noTrailing = await verifyStamp(stampOfTrailing, SECRET_A, 'https://example.com/page');
+    expect(noTrailing).toEqual({ valid: true });
+  });
+
+  it('returns malformed for missing required fields and does not invoke crypto.subtle.sign', async () => {
+    signSpy.mockClear();
+    const result = await verifyStamp(
+      { v: 1, url: 'https://example.com/page', status: 'CLEAN', timestamp: 0, nonce: 'x' },
+      SECRET_A,
+      'https://example.com/page',
+    );
+    expect(result).toEqual({ valid: false, mismatchReason: 'malformed' });
+    expect(signSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns malformed for a non-object input', async () => {
+    signSpy.mockClear();
+    expect(await verifyStamp(null, SECRET_A, 'https://example.com/')).toEqual({
+      valid: false,
+      mismatchReason: 'malformed',
+    });
+    expect(await verifyStamp('not-an-object', SECRET_A, 'https://example.com/')).toEqual({
+      valid: false,
+      mismatchReason: 'malformed',
+    });
+    expect(signSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns unknown-version when v !== STAMP_VERSION', async () => {
+    const stamp = await generateStamp(VERDICT_INPUT, SECRET_A);
+    signSpy.mockClear();
+    const result = await verifyStamp(
+      { ...stamp, v: 2 } as unknown as PageStamp,
+      SECRET_A,
+      VERDICT_INPUT.url,
+    );
+    expect(result).toEqual({ valid: false, mismatchReason: 'unknown-version' });
+    expect(signSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns wrong-url when normalised URLs differ', async () => {
+    const stamp = await generateStamp(VERDICT_INPUT, SECRET_A);
+    signSpy.mockClear();
+    const result = await verifyStamp(stamp, SECRET_A, 'https://other.example.com/page');
+    expect(result).toEqual({ valid: false, mismatchReason: 'wrong-url' });
+    expect(signSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns wrong-secret when HMAC is tampered (constant-time path reached)', async () => {
+    const stamp = await generateStamp(VERDICT_INPUT, SECRET_A);
+    // Flip the last char of the HMAC (preserving base64url alphabet).
+    const last = stamp.hmac.slice(-1);
+    const flipped = (last === 'A' ? 'B' : 'A');
+    const tampered: PageStamp = { ...stamp, hmac: stamp.hmac.slice(0, -1) + flipped };
+    signSpy.mockClear();
+    const result = await verifyStamp(tampered, SECRET_A, VERDICT_INPUT.url);
+    expect(result).toEqual({ valid: false, mismatchReason: 'wrong-secret' });
+    expect(signSpy).toHaveBeenCalled();
+  });
+});

--- a/src/service-worker/stamp.test.ts
+++ b/src/service-worker/stamp.test.ts
@@ -212,10 +212,15 @@ describe('verifyStamp', () => {
 
   it('returns wrong-secret when HMAC is tampered (constant-time path reached)', async () => {
     const stamp = await generateStamp(VERDICT_INPUT, SECRET_A);
-    // Flip the last char of the HMAC (preserving base64url alphabet).
-    const last = stamp.hmac.slice(-1);
-    const flipped = (last === 'A' ? 'B' : 'A');
-    const tampered: PageStamp = { ...stamp, hmac: stamp.hmac.slice(0, -1) + flipped };
+    // Flip the FIRST char of the HMAC. The last base64url char of a
+    // 43-char string carries only 4 real bits + 2 padding bits, so a
+    // last-char flip can leave the decoded bytes unchanged when the
+    // flip only affects padding. The first char carries 6 real bits
+    // mapping to byte 0 — flipping it always changes the underlying
+    // bytes, so the tamper is reliably detected by the verifier.
+    const first = stamp.hmac[0];
+    const flippedFirst = first === 'A' ? 'B' : 'A';
+    const tampered: PageStamp = { ...stamp, hmac: flippedFirst + stamp.hmac.slice(1) };
     signSpy.mockClear();
     const result = await verifyStamp(tampered, SECRET_A, VERDICT_INPUT.url);
     expect(result).toEqual({ valid: false, mismatchReason: 'wrong-secret' });

--- a/src/service-worker/stamp.ts
+++ b/src/service-worker/stamp.ts
@@ -1,0 +1,204 @@
+import type { PageStamp, VerifyStampResult } from '@/types/page-stamp.js';
+import type { SecurityStatus } from '@/types/verdict.js';
+import { STAMP_VERSION } from '@/shared/constants.js';
+
+/**
+ * Issue #117 (N13) — page stamp generation and verification.
+ *
+ * Canonical HMAC input is `${v}\n${normalisedUrl}\n${status}\n${timestamp}\n${nonce}`.
+ * URLs are normalised on both sign and verify so trivially equivalent
+ * forms (case, fragment, trailing slash) verify successfully without
+ * widening the cryptographic surface.
+ *
+ * `verifyStamp` ordering: shape → version → URL → HMAC. The first three
+ * checks short-circuit before any crypto compute (URL and version are
+ * already public — they're embedded in the meta tag, so no timing
+ * oracle exists for them). The HMAC step uses a constant-time byte
+ * comparison after `crypto.subtle.sign`.
+ *
+ * No TTL: stamps attest to a scan event at a specific timestamp;
+ * freshness is a caller-side policy. `'expired'` is deliberately not in
+ * the `mismatchReason` union.
+ */
+
+const NONCE_BYTES = 16;
+
+interface PageStampLike {
+  readonly v: number;
+  readonly url: string;
+  readonly status: SecurityStatus;
+  readonly timestamp: number;
+  readonly nonce: string;
+  readonly hmac: string;
+}
+
+function bytesToBase64url(bytes: Uint8Array): string {
+  let binary = '';
+  for (let i = 0; i < bytes.length; i += 1) {
+    binary += String.fromCharCode(bytes[i]!);
+  }
+  return btoa(binary).replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '');
+}
+
+function base64urlToBytes(s: string): Uint8Array {
+  const standard = s.replaceAll('-', '+').replaceAll('_', '/');
+  const padLen = (4 - (standard.length % 4)) % 4;
+  const binary = atob(standard + '='.repeat(padLen));
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+export function normaliseStampUrl(input: string): string {
+  const u = new URL(input);
+  u.hash = '';
+  u.hostname = u.hostname.toLowerCase();
+  u.protocol = u.protocol.toLowerCase();
+  let pathname = u.pathname;
+  if (pathname.length > 1 && pathname.endsWith('/')) {
+    pathname = pathname.slice(0, -1);
+  }
+  const portPart = u.port ? `:${u.port}` : '';
+  return `${u.protocol}//${u.hostname}${portPart}${pathname}${u.search}`;
+}
+
+interface CanonicalInput {
+  readonly v: number;
+  readonly url: string;
+  readonly status: SecurityStatus;
+  readonly timestamp: number;
+  readonly nonce: string;
+}
+
+function buildCanonicalInput(parts: CanonicalInput): Uint8Array {
+  const canonical = `${parts.v}\n${parts.url}\n${parts.status}\n${parts.timestamp}\n${parts.nonce}`;
+  return new TextEncoder().encode(canonical);
+}
+
+async function importHmacKey(secretBase64url: string): Promise<CryptoKey> {
+  const secretBytes = base64urlToBytes(secretBase64url);
+  return crypto.subtle.importKey(
+    'raw',
+    secretBytes as BufferSource,
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+}
+
+function constantTimeEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i += 1) {
+    diff |= a[i]! ^ b[i]!;
+  }
+  return diff === 0;
+}
+
+function isSecurityStatus(value: unknown): value is SecurityStatus {
+  return (
+    value === 'CLEAN' ||
+    value === 'SUSPICIOUS' ||
+    value === 'COMPROMISED' ||
+    value === 'UNKNOWN'
+  );
+}
+
+function isPageStampShape(input: unknown): input is PageStampLike {
+  if (input === null || typeof input !== 'object') return false;
+  const o = input as Record<string, unknown>;
+  return (
+    typeof o.v === 'number' &&
+    typeof o.url === 'string' &&
+    isSecurityStatus(o.status) &&
+    typeof o.timestamp === 'number' &&
+    typeof o.nonce === 'string' &&
+    typeof o.hmac === 'string'
+  );
+}
+
+export interface GenerateStampInput {
+  readonly url: string;
+  readonly status: SecurityStatus;
+  readonly timestamp: number;
+}
+
+export async function generateStamp(
+  input: GenerateStampInput,
+  secret: string,
+): Promise<PageStamp> {
+  const normalisedUrl = normaliseStampUrl(input.url);
+  const nonceBytes = new Uint8Array(NONCE_BYTES);
+  crypto.getRandomValues(nonceBytes);
+  const nonce = bytesToBase64url(nonceBytes);
+
+  const key = await importHmacKey(secret);
+  const data = buildCanonicalInput({
+    v: STAMP_VERSION,
+    url: normalisedUrl,
+    status: input.status,
+    timestamp: input.timestamp,
+    nonce,
+  });
+  const sig = await crypto.subtle.sign('HMAC', key, data as BufferSource);
+  const hmac = bytesToBase64url(new Uint8Array(sig));
+
+  return {
+    v: STAMP_VERSION,
+    url: normalisedUrl,
+    status: input.status,
+    timestamp: input.timestamp,
+    nonce,
+    hmac,
+  };
+}
+
+export async function verifyStamp(
+  input: unknown,
+  secret: string,
+  currentUrl: string,
+): Promise<VerifyStampResult> {
+  if (!isPageStampShape(input)) {
+    return { valid: false, mismatchReason: 'malformed' };
+  }
+  if (input.v !== STAMP_VERSION) {
+    return { valid: false, mismatchReason: 'unknown-version' };
+  }
+
+  let normalisedCurrent: string;
+  let normalisedStampUrl: string;
+  try {
+    normalisedCurrent = normaliseStampUrl(currentUrl);
+    normalisedStampUrl = normaliseStampUrl(input.url);
+  } catch {
+    return { valid: false, mismatchReason: 'malformed' };
+  }
+  if (normalisedCurrent !== normalisedStampUrl) {
+    return { valid: false, mismatchReason: 'wrong-url' };
+  }
+
+  let actual: Uint8Array;
+  try {
+    actual = base64urlToBytes(input.hmac);
+  } catch {
+    return { valid: false, mismatchReason: 'malformed' };
+  }
+
+  const key = await importHmacKey(secret);
+  const data = buildCanonicalInput({
+    v: input.v,
+    url: normalisedStampUrl,
+    status: input.status,
+    timestamp: input.timestamp,
+    nonce: input.nonce,
+  });
+  const sig = await crypto.subtle.sign('HMAC', key, data as BufferSource);
+  const expected = new Uint8Array(sig);
+
+  if (!constantTimeEqual(actual, expected)) {
+    return { valid: false, mismatchReason: 'wrong-secret' };
+  }
+  return { valid: true };
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -190,3 +190,19 @@ export const STORAGE_KEY_ORIGIN_OVERRIDES = 'honeyllm:origin-overrides';
 // sweep and unsets it afterwards. `local` is used over `sync` because sync
 // is eventually consistent across contexts even on a single device.
 export const STORAGE_KEY_TEST_MODE = 'honeyllm:test-mode';
+
+/**
+ * Issue #117 (N13) — per-install HMAC secret used to sign page stamps.
+ * Stored in `chrome.storage.local` (not sync) so the secret stays
+ * device-local and never traverses Google's sync layer. Generated lazily
+ * on first call to `ensureInstallSecret()`; never rotated by the
+ * extension itself (uninstall+reinstall or storage wipe rotates).
+ */
+export const STORAGE_KEY_INSTALL_SECRET = 'honeyllm:install-secret';
+
+/**
+ * Issue #117 (N13) — page-stamp schema version. Bumped only on
+ * incompatible canonical-form changes. The verifier rejects stamps with
+ * `v !== STAMP_VERSION` as `unknown-version` before touching crypto.
+ */
+export const STAMP_VERSION = 1 as const;

--- a/src/shared/install-secret.test.ts
+++ b/src/shared/install-secret.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { STORAGE_KEY_INSTALL_SECRET } from './constants.js';
+import { ensureInstallSecret, _resetForTesting } from './install-secret.js';
+
+interface ChromeStub {
+  storage: {
+    local: {
+      get: (key: string) => Promise<Record<string, unknown>>;
+      set: (items: Record<string, unknown>) => Promise<void>;
+    };
+  };
+}
+
+function stubChrome(
+  initial: Record<string, unknown> = {},
+  opts: { setRejects?: Error } = {},
+): {
+  readStore: () => Record<string, unknown>;
+  setSpy: ReturnType<typeof vi.fn>;
+  getSpy: ReturnType<typeof vi.fn>;
+} {
+  const store: Record<string, unknown> = { ...initial };
+  const setSpy = vi.fn(async (items: Record<string, unknown>) => {
+    if (opts.setRejects !== undefined) throw opts.setRejects;
+    Object.assign(store, items);
+  });
+  const getSpy = vi.fn(async (key: string) =>
+    key in store ? { [key]: store[key] } : {},
+  );
+  const chromeStub: ChromeStub = {
+    storage: {
+      local: {
+        get: getSpy,
+        set: setSpy,
+      },
+    },
+  };
+  vi.stubGlobal('chrome', chromeStub);
+  return { readStore: () => store, setSpy, getSpy };
+}
+
+describe('ensureInstallSecret', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    _resetForTesting();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    _resetForTesting();
+  });
+
+  it('returns existing secret without calling set', async () => {
+    const { setSpy } = stubChrome({
+      [STORAGE_KEY_INSTALL_SECRET]: 'existing-secret-1234567890ABCDEF',
+    });
+    expect(await ensureInstallSecret()).toBe('existing-secret-1234567890ABCDEF');
+    expect(setSpy).not.toHaveBeenCalled();
+  });
+
+  it('lazily generates and persists when storage is empty', async () => {
+    const { readStore, setSpy } = stubChrome();
+    const secret = await ensureInstallSecret();
+    expect(secret).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(secret.length).toBe(43); // 32 bytes -> 43 chars base64url unpadded
+    expect(setSpy).toHaveBeenCalledTimes(1);
+    expect(setSpy).toHaveBeenCalledWith({ [STORAGE_KEY_INSTALL_SECRET]: secret });
+    expect(readStore()[STORAGE_KEY_INSTALL_SECRET]).toBe(secret);
+  });
+
+  it('produces base64url alphabet only (no +, /, =)', async () => {
+    stubChrome();
+    const secret = await ensureInstallSecret();
+    expect(secret).not.toContain('+');
+    expect(secret).not.toContain('/');
+    expect(secret).not.toContain('=');
+  });
+
+  it('is single-flight under concurrent calls (set invoked exactly once)', async () => {
+    const { setSpy } = stubChrome();
+    const [a, b, c] = await Promise.all([
+      ensureInstallSecret(),
+      ensureInstallSecret(),
+      ensureInstallSecret(),
+    ]);
+    expect(a).toBe(b);
+    expect(b).toBe(c);
+    expect(setSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('is idempotent on sequential calls (no extra set after first resolved)', async () => {
+    const { setSpy } = stubChrome();
+    const a = await ensureInstallSecret();
+    const b = await ensureInstallSecret();
+    const c = await ensureInstallSecret();
+    expect(a).toBe(b);
+    expect(b).toBe(c);
+    expect(setSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces storage.set rejection rather than returning an unpersisted secret', async () => {
+    stubChrome({}, { setRejects: new Error('QUOTA_BYTES quota exceeded') });
+    await expect(ensureInstallSecret()).rejects.toThrow('QUOTA_BYTES quota exceeded');
+  });
+});

--- a/src/shared/install-secret.ts
+++ b/src/shared/install-secret.ts
@@ -1,0 +1,65 @@
+import { STORAGE_KEY_INSTALL_SECRET } from './constants.js';
+
+/**
+ * Issue #117 (N13) — per-install HMAC secret used to sign page stamps.
+ *
+ * The secret is generated lazily on first use, stored in
+ * `chrome.storage.local`, and never leaves the SW context. MV3 service
+ * workers terminate after ~30s idle, so the in-memory cache here is
+ * session-scoped — the read-before-write path on next wakeup recovers
+ * the persisted secret without rotating it.
+ *
+ * `chrome.runtime.onInstalled` fires on every extension UPDATE, not
+ * just first install; the read-before-write idempotency is what
+ * prevents the secret from rotating on update (which would invalidate
+ * every stamp embedded in already-loaded pages).
+ *
+ * If `chrome.storage.local.set` rejects, we propagate the error rather
+ * than caching a never-persisted secret. Per the #94 precedent: surface
+ * persistence failures, never silently swallow.
+ */
+
+const SECRET_BYTES = 32;
+
+let cached: string | null = null;
+let inFlight: Promise<string> | null = null;
+
+function bytesToBase64url(bytes: Uint8Array): string {
+  let binary = '';
+  for (let i = 0; i < bytes.length; i += 1) {
+    binary += String.fromCharCode(bytes[i]!);
+  }
+  return btoa(binary).replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '');
+}
+
+async function compute(): Promise<string> {
+  const stored = await chrome.storage.local.get(STORAGE_KEY_INSTALL_SECRET);
+  const existing = stored[STORAGE_KEY_INSTALL_SECRET];
+  if (typeof existing === 'string' && existing.length > 0) {
+    return existing;
+  }
+  const bytes = new Uint8Array(SECRET_BYTES);
+  crypto.getRandomValues(bytes);
+  const secret = bytesToBase64url(bytes);
+  await chrome.storage.local.set({ [STORAGE_KEY_INSTALL_SECRET]: secret });
+  return secret;
+}
+
+export async function ensureInstallSecret(): Promise<string> {
+  if (cached !== null) return cached;
+  if (inFlight !== null) return inFlight;
+
+  inFlight = compute();
+  try {
+    cached = await inFlight;
+    return cached;
+  } catch (err) {
+    inFlight = null;
+    throw err;
+  }
+}
+
+export function _resetForTesting(): void {
+  cached = null;
+  inFlight = null;
+}

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -1,5 +1,6 @@
 import type { PageSnapshot } from './snapshot.js';
 import type { ProbeResult, SecurityVerdict, WebGPUAdapterMode } from './verdict.js';
+import type { VerifyStampResult } from './page-stamp.js';
 
 export type MessageType =
   | 'PAGE_SNAPSHOT'
@@ -16,7 +17,12 @@ export type MessageType =
   | 'RUN_PROBE_DIRECT'
   | 'PROBE_DIRECT_RESULT'
   | 'RUN_PROBE_BUILTIN'
-  | 'PROBE_BUILTIN_RESULT';
+  | 'PROBE_BUILTIN_RESULT'
+  // Issue #117 (N13) — page-stamp verification. Internal-only channel
+  // (registered on chrome.runtime.onMessage, NOT onMessageExternal —
+  // see service-worker/index.ts for the security rationale).
+  | 'VERIFY_STAMP'
+  | 'VERIFY_STAMP_RESULT';
 
 interface BaseMessage {
   readonly type: MessageType;
@@ -144,6 +150,25 @@ export interface ProbeBuiltinResultMessage extends BaseMessage {
   readonly errorMessage: string | null;
 }
 
+// Issue #117 (N13) — VERIFY_STAMP is dispatched from the popup or
+// internal test harness via `chrome.runtime.sendMessage`. The `stamp`
+// field is `unknown` because it's untrusted input (the LLM's returned
+// payload, possibly tampered); `verifyStamp` narrows it via runtime
+// shape checks before any crypto compute. `currentUrl` is the URL the
+// caller wants to verify the stamp against — its match against
+// `stamp.url` (after normalisation) is what makes the URL check
+// meaningful rather than tautological.
+export interface VerifyStampMessage extends BaseMessage {
+  readonly type: 'VERIFY_STAMP';
+  readonly stamp: unknown;
+  readonly currentUrl: string;
+}
+
+export interface VerifyStampResultMessage extends BaseMessage {
+  readonly type: 'VERIFY_STAMP_RESULT';
+  readonly result: VerifyStampResult;
+}
+
 export type HoneyLLMMessage =
   | PageSnapshotMessage
   | RunProbesMessage
@@ -157,4 +182,6 @@ export type HoneyLLMMessage =
   | RunProbeDirectMessage
   | ProbeDirectResultMessage
   | RunProbeBuiltinMessage
-  | ProbeBuiltinResultMessage;
+  | ProbeBuiltinResultMessage
+  | VerifyStampMessage
+  | VerifyStampResultMessage;

--- a/src/types/page-stamp.ts
+++ b/src/types/page-stamp.ts
@@ -1,0 +1,45 @@
+import type { SecurityStatus } from './verdict.js';
+import { STAMP_VERSION } from '@/shared/constants.js';
+
+/**
+ * Issue #117 (N13) — cryptographically-bound page stamp.
+ *
+ * Embedded in the DOM after a successful scan so an LLM consumer's
+ * "what did you read?" can be verified back to "did the LLM see the
+ * post-mitigation page?" The HMAC is computed in the service worker
+ * with a per-install secret that never leaves device.
+ *
+ * Canonical input for the HMAC is `${v}\n${url}\n${status}\n${timestamp}\n${nonce}`
+ * where `url` has been passed through `normaliseStampUrl`. See
+ * `src/service-worker/stamp.ts` for the implementation.
+ */
+export interface PageStamp {
+  readonly v: typeof STAMP_VERSION;
+  readonly url: string;
+  readonly status: SecurityStatus;
+  readonly timestamp: number;
+  readonly nonce: string;
+  readonly hmac: string;
+}
+
+/**
+ * Result of `verifyStamp`. The `mismatchReason` discriminator lets
+ * callers distinguish operator-friendly failure modes:
+ *   - 'malformed'        — input shape didn't pass narrowing
+ *   - 'unknown-version'  — `v` is not the current STAMP_VERSION
+ *   - 'wrong-url'        — caller-supplied URL doesn't match stamp URL
+ *                          (after normalisation)
+ *   - 'wrong-secret'     — HMAC differs (constant-time compared)
+ *
+ * No 'expired' value: TTL is a caller-side policy, not a stamp-side
+ * property. Callers who need freshness compare `stamp.timestamp` to
+ * `Date.now()` themselves.
+ */
+export type VerifyStampResult =
+  | { readonly valid: true }
+  | {
+      readonly valid: false;
+      readonly mismatchReason: 'wrong-secret' | 'wrong-url' | 'malformed' | 'unknown-version';
+    };
+
+export { STAMP_VERSION };

--- a/src/types/verdict.ts
+++ b/src/types/verdict.ts
@@ -1,3 +1,5 @@
+import type { PageStamp } from './page-stamp.js';
+
 export type SecurityStatus = 'CLEAN' | 'SUSPICIOUS' | 'COMPROMISED' | 'UNKNOWN';
 
 // Phase 4 Stage 4E — mirrors AdapterMode in src/offscreen/webgpu-introspection.ts.
@@ -55,6 +57,12 @@ export interface SecurityVerdict {
   // Nano-only path where no WebGPU probe ran, or when the introspection
   // result wasn't available at verdict-assembly time.
   readonly webgpuAdapterMode: WebGPUAdapterMode | null;
+  // Issue #117 (N13) — HMAC-SHA256 page stamp produced after the verdict
+  // was scored. Null when no stamp was issued: origin-skipped verdicts
+  // (the scan was not attempted) and verdicts where ensureInstallSecret
+  // failed (we couldn't issue a stamp for operational reasons). Engine-
+  // failure UNKNOWN verdicts (a scan was attempted) DO carry a stamp.
+  readonly stamp: PageStamp | null;
 }
 
 export interface AISecurityReport {


### PR DESCRIPTION
## Summary

- Cryptographically-bound page stamps that prove an LLM ingested the post-mitigation DOM.
- Per-install HMAC secret in `chrome.storage.local`; HMAC-SHA256 over canonical `(v, normalisedUrl, status, timestamp, nonce)`.
- Three DOM embeds (fixed-position badge, `<meta name="honeyllm-stamp">`, invisible `aria-hidden` div) + scoped MutationObservers for re-add + SPA navigation teardown on `popstate`/`hashchange`.
- New internal-only `VERIFY_STAMP` message handler on `chrome.runtime.onMessage` for popup/test-harness verification.

## Design highlights (folded in from agent review)

- **No TTL on stamps** — stamps attest to a scan event; freshness is a caller-side policy. `'expired'` is not in `mismatchReason`.
- **URL normalisation** (lowercase scheme+host, strip fragment, strip trailing slash) on both sign AND verify so trivially equivalent URLs round-trip.
- **Two scoped observers** (head + body, `childList:true`, no `subtree`) instead of one big subtree observer — collapses callback rate on SPAs.
- **`appendChild` + `position:fixed` overlay** for the badge, not `body.firstChild` — avoids layout shift.
- **`ensureInstallSecret`** is read-before-write idempotent (avoids rotation on extension UPDATE) and propagates `chrome.storage.local.set` failures (per #94 precedent — never returns an unpersisted secret).
- **`VERIFY_STAMP` is deliberately NOT registered on `onMessageExternal`** — the local harness already reaches that channel and exposing verify there would create an HMAC oracle against the install secret. Documented as load-bearing in the SW dispatch.
- **`origin_denied` verdicts carry `stamp:null`** structurally via `buildOriginSkippedVerdict`'s literal — no runtime guard, no analysisError-string parsing in the stamping path. Engine-failure UNKNOWN (a scan was attempted) IS stamped.

## Verifier ordering

1. Shape narrow → `'malformed'` (sign not called)
2. Version check → `'unknown-version'` (sign not called)
3. URL match (after normalisation) → `'wrong-url'` (sign not called)
4. HMAC compute + constant-time compare → `'wrong-secret'` or `valid:true`

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 471 tests pass across 35 files (32 → 35 files; 439 → 471 tests; 32 new cases)
- [x] `npm run build` — `dist/` rebuilds clean
- [x] `npm audit` — 0 vulnerabilities
- [x] Broad secret grep clean
- [x] Pre-push hook passed without `--no-verify`
- [ ] Manual smoke: load `dist/` unpacked, verify badge appears, verify meta-tag content decodes to issued stamp, verify `VERIFY_STAMP` round-trip, verify tampered stamp returns `wrong-secret`, verify deny-listed origin has `stamp:null`, verify SPA navigation teardown.

## Files

**New:** `src/types/page-stamp.ts`, `src/shared/install-secret.ts`, `src/service-worker/stamp.ts`, `src/content/signaling/page-stamp-embed.ts` + 4 test files.

**Modified:** `src/shared/constants.ts` (+`STORAGE_KEY_INSTALL_SECRET`, `STAMP_VERSION`), `src/types/verdict.ts` (+`stamp` field), `src/types/messages.ts` (+`VERIFY_STAMP`/`VERIFY_STAMP_RESULT`), `src/policy/engine.ts` (2 verdict literals), `src/service-worker/orchestrator.ts` (+stamp wiring), `src/policy/storage.ts` (persist + restore-coalesce), `src/service-worker/index.ts` (+VERIFY_STAMP case, +bootstrap), `src/content/index.ts` (+embed wiring).

## Non-goals

- No popup UI for verification — that's the test-harness / N10 work.

Closes #117