### PR TITLE
feat(phase5-#113): testing-mode toggle — observe-only verdicts + rescan-with-prevention

### DIFF
--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -13,6 +13,7 @@ import {
   installStampObservers,
   installNavigationTeardown,
 } from './signaling/page-stamp-embed.js';
+import { rescanWithForcedMitigation } from './rescan.js';
 
 const log = createLogger('Content');
 
@@ -82,6 +83,19 @@ chrome.runtime.onMessage.addListener((message: HoneyLLMMessage) => {
     const updated = applyMitigations(message.verdict);
     setWindowGlobals(updated);
     log.info(`Mitigations applied: ${updated.mitigationsApplied.join(', ')}`);
+  }
+
+  // Issue #113 (N2) — popup-triggered rescan with mitigations forced
+  // on. Re-extract the snapshot and re-send PAGE_SNAPSHOT with
+  // forceMitigation propagated. The async work is fire-and-forget;
+  // the SW confirms via the resulting VERDICT/APPLY_MITIGATION cycle.
+  // Tab context is preserved by chrome.runtime.sendMessage's
+  // sender.tab.id, so a tab switch between click and re-send still
+  // routes the verdict to the originating tab.
+  if (message.type === 'TRIGGER_RESCAN') {
+    void rescanWithForcedMitigation(message.forceMitigation).catch((err) => {
+      log.warn('TRIGGER_RESCAN re-send failed', err);
+    });
   }
 });
 

--- a/src/content/rescan.test.ts
+++ b/src/content/rescan.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { PageSnapshot } from '@/types/snapshot.js';
+import { rescanWithForcedMitigation } from './rescan.js';
+
+interface ChromeStub {
+  runtime: { sendMessage: (msg: unknown) => Promise<unknown> };
+}
+
+function stubChrome(): { sendSpy: ReturnType<typeof vi.fn> } {
+  const sendSpy = vi.fn(async (_msg: unknown) => undefined);
+  const chromeStub: ChromeStub = { runtime: { sendMessage: sendSpy } };
+  vi.stubGlobal('chrome', chromeStub);
+  return { sendSpy };
+}
+
+function makeSnapshot(): PageSnapshot {
+  return {
+    visibleText: 'hello',
+    hiddenText: '',
+    scriptFingerprints: [],
+    metadata: {
+      url: 'https://example.com/',
+      origin: 'https://example.com',
+      title: '',
+      description: '',
+      ogTags: new Map(),
+      cspMeta: null,
+      lang: 'en',
+    },
+    extractedAt: 1_700_000_000_000,
+    charCount: 5,
+  };
+}
+
+describe('rescanWithForcedMitigation', () => {
+  beforeEach(() => vi.unstubAllGlobals());
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('re-runs the extractor each call (no caching)', async () => {
+    stubChrome();
+    const extractor = vi.fn(async () => makeSnapshot());
+    await rescanWithForcedMitigation(true, extractor);
+    await rescanWithForcedMitigation(true, extractor);
+    expect(extractor).toHaveBeenCalledTimes(2);
+  });
+
+  it('sends PAGE_SNAPSHOT with forceMitigation=true via chrome.runtime', async () => {
+    const { sendSpy } = stubChrome();
+    const extractor = vi.fn(async () => makeSnapshot());
+    await rescanWithForcedMitigation(true, extractor);
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    const msg = sendSpy.mock.calls[0]![0] as { type: string; forceMitigation: boolean; snapshot: PageSnapshot };
+    expect(msg.type).toBe('PAGE_SNAPSHOT');
+    expect(msg.forceMitigation).toBe(true);
+    expect(msg.snapshot.visibleText).toBe('hello');
+  });
+
+  it('propagates forceMitigation=false verbatim', async () => {
+    const { sendSpy } = stubChrome();
+    await rescanWithForcedMitigation(false, async () => makeSnapshot());
+    const msg = sendSpy.mock.calls[0]![0] as { forceMitigation: boolean };
+    expect(msg.forceMitigation).toBe(false);
+  });
+
+  it('uses tabId=0 placeholder; SW overwrites from sender.tab.id', async () => {
+    const { sendSpy } = stubChrome();
+    await rescanWithForcedMitigation(true, async () => makeSnapshot());
+    const msg = sendSpy.mock.calls[0]![0] as { tabId: number };
+    expect(msg.tabId).toBe(0);
+  });
+
+  it('returns the extracted snapshot', async () => {
+    stubChrome();
+    const snapshot = makeSnapshot();
+    const result = await rescanWithForcedMitigation(true, async () => snapshot);
+    expect(result).toBe(snapshot);
+  });
+});

--- a/src/content/rescan.ts
+++ b/src/content/rescan.ts
@@ -1,0 +1,34 @@
+import type { PageSnapshot } from '@/types/snapshot.js';
+import type { PageSnapshotMessage } from '@/types/messages.js';
+import { extractPageSnapshot } from './ingestion/extractor.js';
+
+/**
+ * Issue #113 (N2) — TRIGGER_RESCAN handler. Called by the content
+ * script's onMessage listener when the SW asks the page to re-extract
+ * itself with mitigations forced on.
+ *
+ * Re-extracts the snapshot afresh (page state may have changed since
+ * load) and re-sends PAGE_SNAPSHOT carrying the forceMitigation flag
+ * so the SW dispatcher bypasses the testing-mode gate for this single
+ * verdict. The persisted toggle is not mutated — observe-only mode
+ * resumes for subsequent navigations.
+ *
+ * `tabId: 0` is a placeholder; the SW overwrites it with
+ * `sender.tab.id` from the message frame on receipt. Returns the
+ * extracted snapshot for callers / tests; logging is the caller's
+ * responsibility.
+ */
+export async function rescanWithForcedMitigation(
+  forceMitigation: boolean,
+  extractor: () => Promise<PageSnapshot> = extractPageSnapshot,
+): Promise<PageSnapshot> {
+  const snapshot = await extractor();
+  const msg: PageSnapshotMessage = {
+    type: 'PAGE_SNAPSHOT',
+    tabId: 0,
+    snapshot,
+    forceMitigation,
+  };
+  await chrome.runtime.sendMessage(msg);
+  return snapshot;
+}

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -228,6 +228,34 @@
     }
     .quick-link:hover { background: #2a2f3a; border-color: #374151; }
     .quick-link .ql-hint { color: #6b7280; font-size: 10px; margin-left: 4px; }
+    .quick-link:disabled {
+      opacity: 0.45;
+      cursor: not-allowed;
+      background: #1a1a1a;
+    }
+    .quick-link:disabled:hover { background: #1a1a1a; border-color: #2a2a2a; }
+    /* Issue #113 — testing-mode card */
+    .testing-toggle {
+      display: flex;
+      align-items: flex-start;
+      gap: 8px;
+      padding: 4px 0 8px 0;
+      font-size: 12px;
+      cursor: pointer;
+      color: #e0e0e0;
+      line-height: 1.4;
+    }
+    .testing-toggle input[type="checkbox"] {
+      cursor: pointer;
+      accent-color: #facc15;
+      margin-top: 2px;
+    }
+    .testing-toggle .testing-label-note {
+      display: block;
+      color: #6b7280;
+      font-size: 10px;
+      margin-top: 2px;
+    }
   </style>
 </head>
 <body>
@@ -257,6 +285,20 @@
     <div class="card">
       <h2>Canary</h2>
       <div id="canary-options"></div>
+    </div>
+
+    <div class="card" id="testing-mode-card">
+      <h2>Testing mode</h2>
+      <label class="testing-toggle">
+        <input type="checkbox" id="testing-mode-checkbox">
+        <span>
+          Observe-only — suppress mitigations on all pages
+          <span class="testing-label-note">Verdicts still publish; DOM, network guard, redirects untouched.</span>
+        </span>
+      </label>
+      <button class="quick-link" id="rescan-with-prevention-btn" disabled>
+        Rescan with prevention<span class="ql-hint">— forces mitigations once</span>
+      </button>
     </div>
 
     <div id="no-data" class="card" style="display: none;">

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -17,6 +17,7 @@ import {
   setOverride,
   clearOverride,
 } from '@/policy/origin-storage.js';
+import { initTestingModeToggle, initRescanButton } from './testing-mode-controls.js';
 
 interface StoredVerdict {
   status: string;
@@ -345,7 +346,7 @@ async function loadVerdict(): Promise<void> {
   if (verdict.flags.length > 0) {
     $('flags-card').style.display = 'block';
     const container = $('flags-container');
-    container.innerHTML = '';
+    container.replaceChildren();
     for (const flag of verdict.flags) {
       const tag = document.createElement('span');
       tag.className = 'flag-tag';
@@ -356,6 +357,16 @@ async function loadVerdict(): Promise<void> {
 
   const date = new Date(verdict.timestamp);
   $('timestamp-info').textContent = `Last analyzed: ${date.toLocaleString()} | ${verdict.url}`;
+
+  // Issue #113 (N2) — rescan-with-prevention button is verdict-aware:
+  // only enabled when the current verdict is SUSPICIOUS or COMPROMISED.
+  // Called here (inside loadVerdict) so the verdict status drives the
+  // initial enable/disable state without an extra round-trip.
+  initRescanButton(
+    $('rescan-with-prevention-btn') as HTMLButtonElement,
+    verdict.status,
+    showToast,
+  );
 }
 
 /**
@@ -463,6 +474,16 @@ void (async () => {
     await initCanarySelector();
   } catch (err) {
     console.error('canary selector init failed', err);
+  }
+  try {
+    // Issue #113 (N2) — observe-mode toggle. Independent of verdict;
+    // initialised early so the user can flip it before / during a scan.
+    await initTestingModeToggle(
+      $('testing-mode-checkbox') as HTMLInputElement,
+      showToast,
+    );
+  } catch (err) {
+    console.error('testing-mode toggle init failed', err);
   }
   try {
     initQuickLinks();

--- a/src/popup/testing-mode-controls.test.ts
+++ b/src/popup/testing-mode-controls.test.ts
@@ -1,0 +1,229 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { STORAGE_KEY_TESTING_MODE } from '@/shared/constants.js';
+import { initTestingModeToggle, initRescanButton } from './testing-mode-controls.js';
+
+interface ChromeStub {
+  storage: {
+    local: {
+      get: (key: string) => Promise<Record<string, unknown>>;
+      set: (items: Record<string, unknown>) => Promise<void>;
+    };
+  };
+  runtime: { sendMessage: (msg: unknown) => Promise<unknown> };
+  tabs: { query: (q: chrome.tabs.QueryInfo) => Promise<chrome.tabs.Tab[]> };
+}
+
+function stubChrome(opts: {
+  testingMode?: boolean;
+  setRejects?: Error;
+  activeTabId?: number | undefined;
+  sendRejects?: Error;
+} = {}): {
+  store: Record<string, unknown>;
+  setSpy: ReturnType<typeof vi.fn>;
+  sendSpy: ReturnType<typeof vi.fn>;
+  querySpy: ReturnType<typeof vi.fn>;
+} {
+  const store: Record<string, unknown> = {};
+  if (opts.testingMode !== undefined) store[STORAGE_KEY_TESTING_MODE] = opts.testingMode;
+  const setSpy = vi.fn(async (items: Record<string, unknown>) => {
+    if (opts.setRejects !== undefined) throw opts.setRejects;
+    Object.assign(store, items);
+  });
+  const getSpy = vi.fn(async (key: string) =>
+    key in store ? { [key]: store[key] } : {},
+  );
+  const sendSpy = vi.fn(async (_msg: unknown) => {
+    if (opts.sendRejects !== undefined) throw opts.sendRejects;
+    return undefined;
+  });
+  const querySpy = vi.fn(async (_q: chrome.tabs.QueryInfo) =>
+    opts.activeTabId !== undefined
+      ? ([{ id: opts.activeTabId } as chrome.tabs.Tab])
+      : ([{} as chrome.tabs.Tab]),
+  );
+  const chromeStub: ChromeStub = {
+    storage: { local: { get: getSpy, set: setSpy } },
+    runtime: { sendMessage: sendSpy },
+    tabs: { query: querySpy },
+  };
+  vi.stubGlobal('chrome', chromeStub);
+  return { store, setSpy, sendSpy, querySpy };
+}
+
+function makeCheckbox(): HTMLInputElement {
+  const el = document.createElement('input');
+  el.type = 'checkbox';
+  return el;
+}
+
+function makeButton(): HTMLButtonElement {
+  return document.createElement('button');
+}
+
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('initTestingModeToggle', () => {
+  beforeEach(() => vi.unstubAllGlobals());
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('initial checkbox state reflects stored testing-mode=false', async () => {
+    stubChrome({ testingMode: false });
+    const checkbox = makeCheckbox();
+    await initTestingModeToggle(checkbox, () => {});
+    expect(checkbox.checked).toBe(false);
+  });
+
+  it('initial checkbox state reflects stored testing-mode=true', async () => {
+    stubChrome({ testingMode: true });
+    const checkbox = makeCheckbox();
+    await initTestingModeToggle(checkbox, () => {});
+    expect(checkbox.checked).toBe(true);
+  });
+
+  it('initial checkbox state defaults to false when key absent', async () => {
+    stubChrome({});
+    const checkbox = makeCheckbox();
+    await initTestingModeToggle(checkbox, () => {});
+    expect(checkbox.checked).toBe(false);
+  });
+
+  it('toggling checkbox to true calls setTestingMode(true) and shows ON toast', async () => {
+    const { setSpy } = stubChrome({ testingMode: false });
+    const checkbox = makeCheckbox();
+    const toasts: string[] = [];
+    await initTestingModeToggle(checkbox, (m) => toasts.push(m));
+
+    checkbox.checked = true;
+    checkbox.dispatchEvent(new Event('change'));
+    await flushMicrotasks();
+
+    expect(setSpy).toHaveBeenCalledWith({ [STORAGE_KEY_TESTING_MODE]: true });
+    expect(toasts[0]).toContain('Testing mode ON');
+  });
+
+  it('toggling checkbox to false calls setTestingMode(false) and shows OFF toast', async () => {
+    const { setSpy } = stubChrome({ testingMode: true });
+    const checkbox = makeCheckbox();
+    const toasts: string[] = [];
+    await initTestingModeToggle(checkbox, (m) => toasts.push(m));
+
+    checkbox.checked = false;
+    checkbox.dispatchEvent(new Event('change'));
+    await flushMicrotasks();
+
+    expect(setSpy).toHaveBeenCalledWith({ [STORAGE_KEY_TESTING_MODE]: false });
+    expect(toasts[0]).toContain('Testing mode OFF');
+  });
+
+  it('rolls back checkbox state and toasts on persist failure', async () => {
+    stubChrome({ testingMode: false, setRejects: new Error('quota exceeded') });
+    const checkbox = makeCheckbox();
+    const toasts: string[] = [];
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await initTestingModeToggle(checkbox, (m) => toasts.push(m));
+
+    checkbox.checked = true;
+    checkbox.dispatchEvent(new Event('change'));
+    await flushMicrotasks();
+
+    expect(checkbox.checked).toBe(false); // rolled back
+    expect(toasts[0]).toContain('Failed');
+    errorSpy.mockRestore();
+  });
+});
+
+describe('initRescanButton', () => {
+  beforeEach(() => vi.unstubAllGlobals());
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('button is disabled when verdictStatus is undefined', () => {
+    stubChrome();
+    const btn = makeButton();
+    initRescanButton(btn, undefined, () => {});
+    expect(btn.disabled).toBe(true);
+  });
+
+  it('button is disabled when verdictStatus is CLEAN', () => {
+    stubChrome();
+    const btn = makeButton();
+    initRescanButton(btn, 'CLEAN', () => {});
+    expect(btn.disabled).toBe(true);
+  });
+
+  it('button is disabled when verdictStatus is UNKNOWN', () => {
+    stubChrome();
+    const btn = makeButton();
+    initRescanButton(btn, 'UNKNOWN', () => {});
+    expect(btn.disabled).toBe(true);
+  });
+
+  it('button is enabled when verdictStatus is SUSPICIOUS', () => {
+    stubChrome();
+    const btn = makeButton();
+    initRescanButton(btn, 'SUSPICIOUS', () => {});
+    expect(btn.disabled).toBe(false);
+  });
+
+  it('button is enabled when verdictStatus is COMPROMISED', () => {
+    stubChrome();
+    const btn = makeButton();
+    initRescanButton(btn, 'COMPROMISED', () => {});
+    expect(btn.disabled).toBe(false);
+  });
+
+  it('clicking enabled button sends RESCAN_WITH_MITIGATION with active tabId', async () => {
+    const { sendSpy } = stubChrome({ activeTabId: 77 });
+    const btn = makeButton();
+    const toasts: string[] = [];
+    initRescanButton(btn, 'SUSPICIOUS', (m) => toasts.push(m));
+
+    btn.click();
+    await flushMicrotasks();
+
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    expect(sendSpy.mock.calls[0]![0]).toEqual({ type: 'RESCAN_WITH_MITIGATION', tabId: 77 });
+    expect(toasts[0]).toContain('Rescan triggered');
+  });
+
+  it('clicking disabled button does NOT send any message (listener never attached)', async () => {
+    const { sendSpy } = stubChrome({ activeTabId: 1 });
+    const btn = makeButton();
+    initRescanButton(btn, 'CLEAN', () => {});
+
+    btn.click();
+    await flushMicrotasks();
+
+    expect(sendSpy).not.toHaveBeenCalled();
+  });
+
+  it('toasts when no active tab is found', async () => {
+    const { sendSpy } = stubChrome({ activeTabId: undefined });
+    const btn = makeButton();
+    const toasts: string[] = [];
+    initRescanButton(btn, 'COMPROMISED', (m) => toasts.push(m));
+
+    btn.click();
+    await flushMicrotasks();
+
+    expect(sendSpy).not.toHaveBeenCalled();
+    expect(toasts[0]).toContain('No active tab');
+  });
+
+  it('toasts on chrome.runtime.sendMessage rejection', async () => {
+    stubChrome({ activeTabId: 1, sendRejects: new Error('SW disconnected') });
+    const btn = makeButton();
+    const toasts: string[] = [];
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    initRescanButton(btn, 'COMPROMISED', (m) => toasts.push(m));
+
+    btn.click();
+    await flushMicrotasks();
+
+    expect(toasts[0]).toContain('Rescan failed');
+    errorSpy.mockRestore();
+  });
+});

--- a/src/popup/testing-mode-controls.ts
+++ b/src/popup/testing-mode-controls.ts
@@ -1,0 +1,72 @@
+import type { RescanWithMitigationMessage } from '@/types/messages.js';
+import { isTestingModeEnabled, setTestingMode } from '@/shared/testing-mode.js';
+
+/**
+ * Issue #113 (N2) — popup observe-mode toggle. Reads the current flag,
+ * sets the checkbox state, and attaches a change listener that
+ * persists user toggles via setTestingMode. Failures bubble out via
+ * the onToast callback so the caller can route to the popup's existing
+ * showToast affordance.
+ */
+export async function initTestingModeToggle(
+  checkbox: HTMLInputElement,
+  onToast: (message: string) => void,
+): Promise<void> {
+  checkbox.checked = await isTestingModeEnabled();
+  checkbox.addEventListener('change', () => {
+    void (async () => {
+      try {
+        await setTestingMode(checkbox.checked);
+        onToast(
+          checkbox.checked
+            ? 'Testing mode ON — mitigations suppressed'
+            : 'Testing mode OFF — normal mitigation',
+        );
+      } catch (err) {
+        // Roll back the visual state so the checkbox doesn't lie
+        // about persisted state.
+        checkbox.checked = !checkbox.checked;
+        onToast('Failed to save testing-mode toggle');
+        console.error('testing-mode persist failed', err);
+      }
+    })();
+  });
+}
+
+/**
+ * Issue #113 (N2) — popup "Rescan with prevention" button. The button
+ * is only meaningful when there's a verdict that warrants mitigation;
+ * it stays disabled for CLEAN, UNKNOWN, or absent verdicts. The click
+ * dispatches RESCAN_WITH_MITIGATION to the SW, which fans out a
+ * TRIGGER_RESCAN to the active tab.
+ */
+export function initRescanButton(
+  button: HTMLButtonElement,
+  verdictStatus: string | undefined,
+  onToast: (message: string) => void,
+): void {
+  const canRescan = verdictStatus === 'SUSPICIOUS' || verdictStatus === 'COMPROMISED';
+  button.disabled = !canRescan;
+  if (!canRescan) return;
+
+  button.addEventListener('click', () => {
+    void (async () => {
+      try {
+        const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+        if (tab?.id === undefined) {
+          onToast('No active tab — cannot rescan');
+          return;
+        }
+        const msg: RescanWithMitigationMessage = {
+          type: 'RESCAN_WITH_MITIGATION',
+          tabId: tab.id,
+        };
+        await chrome.runtime.sendMessage(msg);
+        onToast('Rescan triggered — mitigations will apply');
+      } catch (err) {
+        onToast('Rescan failed to start');
+        console.error('rescan dispatch failed', err);
+      }
+    })();
+  });
+}

--- a/src/service-worker/dispatch.test.ts
+++ b/src/service-worker/dispatch.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { SecurityVerdict, SecurityStatus } from '@/types/verdict.js';
+import { STORAGE_KEY_TESTING_MODE } from '@/shared/constants.js';
+import { dispatchVerdictMessages, handleRescanWithMitigation } from './dispatch.js';
+
+interface ChromeStub {
+  storage: {
+    local: {
+      get: (key: string) => Promise<Record<string, unknown>>;
+    };
+  };
+  tabs: {
+    sendMessage: (tabId: number, msg: unknown) => Promise<unknown>;
+  };
+}
+
+interface SentMessage {
+  readonly tabId: number;
+  readonly msg: unknown;
+}
+
+function stubChrome(testingMode: boolean | undefined): {
+  sent: SentMessage[];
+  sendSpy: ReturnType<typeof vi.fn>;
+  getSpy: ReturnType<typeof vi.fn>;
+} {
+  const sent: SentMessage[] = [];
+  const sendSpy = vi.fn(async (tabId: number, msg: unknown) => {
+    sent.push({ tabId, msg });
+  });
+  const getSpy = vi.fn(async (key: string) => {
+    if (key === STORAGE_KEY_TESTING_MODE && testingMode !== undefined) {
+      return { [key]: testingMode };
+    }
+    return {};
+  });
+  const chromeStub: ChromeStub = {
+    storage: { local: { get: getSpy } },
+    tabs: { sendMessage: sendSpy },
+  };
+  vi.stubGlobal('chrome', chromeStub);
+  return { sent, sendSpy, getSpy };
+}
+
+function makeVerdict(status: SecurityStatus, analysisError: string | null = null): SecurityVerdict {
+  return {
+    status,
+    confidence: status === 'CLEAN' ? 0.95 : 0.7,
+    totalScore: status === 'CLEAN' ? 0 : 50,
+    probeResults: [],
+    behavioralFlags: {
+      roleDrift: false,
+      exfiltrationIntent: false,
+      instructionFollowing: false,
+      hiddenContentAwareness: false,
+    },
+    mitigationsApplied: [],
+    timestamp: 1_700_000_000_000,
+    url: 'https://example.com/',
+    analysisError,
+    canaryId: 'gemma-2-2b-mlc',
+    webgpuAdapterMode: 'core',
+    stamp: null,
+  };
+}
+
+function findMessage(sent: SentMessage[], type: string): SentMessage | undefined {
+  return sent.find((s) => {
+    const m = s.msg as { type?: unknown };
+    return m.type === type;
+  });
+}
+
+describe('dispatchVerdictMessages — testing-mode gate', () => {
+  beforeEach(() => vi.unstubAllGlobals());
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('always dispatches VERDICT regardless of testing-mode (CLEAN, mode off)', async () => {
+    const { sent } = stubChrome(false);
+    await dispatchVerdictMessages(1, makeVerdict('CLEAN'), false);
+    expect(findMessage(sent, 'VERDICT')).toBeDefined();
+  });
+
+  it('always dispatches VERDICT regardless of testing-mode (CLEAN, mode on)', async () => {
+    const { sent } = stubChrome(true);
+    await dispatchVerdictMessages(1, makeVerdict('CLEAN'), false);
+    expect(findMessage(sent, 'VERDICT')).toBeDefined();
+  });
+
+  it('always dispatches VERDICT (SUSPICIOUS, mode on)', async () => {
+    const { sent } = stubChrome(true);
+    await dispatchVerdictMessages(1, makeVerdict('SUSPICIOUS'), false);
+    expect(findMessage(sent, 'VERDICT')).toBeDefined();
+  });
+
+  it('always dispatches VERDICT (COMPROMISED, mode off)', async () => {
+    const { sent } = stubChrome(false);
+    await dispatchVerdictMessages(1, makeVerdict('COMPROMISED'), false);
+    expect(findMessage(sent, 'VERDICT')).toBeDefined();
+  });
+
+  it('does NOT dispatch APPLY_MITIGATION when testing-mode is on (COMPROMISED)', async () => {
+    const { sent } = stubChrome(true);
+    await dispatchVerdictMessages(1, makeVerdict('COMPROMISED'), false);
+    expect(findMessage(sent, 'APPLY_MITIGATION')).toBeUndefined();
+  });
+
+  it('does NOT dispatch APPLY_MITIGATION when testing-mode is on (SUSPICIOUS)', async () => {
+    const { sent } = stubChrome(true);
+    await dispatchVerdictMessages(1, makeVerdict('SUSPICIOUS'), false);
+    expect(findMessage(sent, 'APPLY_MITIGATION')).toBeUndefined();
+  });
+
+  it('dispatches APPLY_MITIGATION when testing-mode is off (COMPROMISED)', async () => {
+    const { sent } = stubChrome(false);
+    await dispatchVerdictMessages(1, makeVerdict('COMPROMISED'), false);
+    const mitigation = findMessage(sent, 'APPLY_MITIGATION');
+    expect(mitigation).toBeDefined();
+    expect((mitigation!.msg as { verdict: SecurityVerdict }).verdict.status).toBe('COMPROMISED');
+  });
+
+  it('dispatches APPLY_MITIGATION when testing-mode is off (SUSPICIOUS)', async () => {
+    const { sent } = stubChrome(false);
+    await dispatchVerdictMessages(1, makeVerdict('SUSPICIOUS'), false);
+    expect(findMessage(sent, 'APPLY_MITIGATION')).toBeDefined();
+  });
+
+  it('does NOT dispatch APPLY_MITIGATION when verdict is CLEAN, regardless of testing-mode', async () => {
+    const { sent: sentOff } = stubChrome(false);
+    await dispatchVerdictMessages(1, makeVerdict('CLEAN'), false);
+    expect(findMessage(sentOff, 'APPLY_MITIGATION')).toBeUndefined();
+
+    vi.unstubAllGlobals();
+    const { sent: sentOn } = stubChrome(true);
+    await dispatchVerdictMessages(1, makeVerdict('CLEAN'), false);
+    expect(findMessage(sentOn, 'APPLY_MITIGATION')).toBeUndefined();
+  });
+
+  it('does NOT dispatch APPLY_MITIGATION for origin-skipped verdict (UNKNOWN + origin_denied:)', async () => {
+    const { sent } = stubChrome(false);
+    await dispatchVerdictMessages(1, makeVerdict('UNKNOWN', 'origin_denied: deny-list match'), false);
+    expect(findMessage(sent, 'APPLY_MITIGATION')).toBeUndefined();
+  });
+
+  it('forceMitigation=true overrides testing-mode=true (COMPROMISED)', async () => {
+    const { sent } = stubChrome(true);
+    await dispatchVerdictMessages(1, makeVerdict('COMPROMISED'), true);
+    expect(findMessage(sent, 'APPLY_MITIGATION')).toBeDefined();
+  });
+
+  it('forceMitigation=true overrides testing-mode=true (SUSPICIOUS)', async () => {
+    const { sent } = stubChrome(true);
+    await dispatchVerdictMessages(1, makeVerdict('SUSPICIOUS'), true);
+    expect(findMessage(sent, 'APPLY_MITIGATION')).toBeDefined();
+  });
+
+  it('forceMitigation=true does NOT cause APPLY_MITIGATION on a CLEAN verdict', async () => {
+    const { sent } = stubChrome(true);
+    await dispatchVerdictMessages(1, makeVerdict('CLEAN'), true);
+    expect(findMessage(sent, 'APPLY_MITIGATION')).toBeUndefined();
+  });
+
+  it('forceMitigation=false respects testing-mode=true (no APPLY_MITIGATION)', async () => {
+    const { sent } = stubChrome(true);
+    await dispatchVerdictMessages(1, makeVerdict('SUSPICIOUS'), false);
+    expect(findMessage(sent, 'APPLY_MITIGATION')).toBeUndefined();
+  });
+
+  it('does not call chrome.storage.local.get when forceMitigation=true (skips the gate read)', async () => {
+    const { getSpy } = stubChrome(true);
+    await dispatchVerdictMessages(1, makeVerdict('SUSPICIOUS'), true);
+    expect(getSpy).not.toHaveBeenCalled();
+  });
+
+  it('VERDICT message carries the correct tabId', async () => {
+    const { sent } = stubChrome(false);
+    await dispatchVerdictMessages(42, makeVerdict('CLEAN'), false);
+    const verdictMsg = findMessage(sent, 'VERDICT');
+    expect(verdictMsg!.tabId).toBe(42);
+  });
+});
+
+describe('handleRescanWithMitigation', () => {
+  beforeEach(() => vi.unstubAllGlobals());
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('dispatches TRIGGER_RESCAN { forceMitigation: true } to the specified tabId', () => {
+    const { sent } = stubChrome(undefined);
+    handleRescanWithMitigation(99);
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.tabId).toBe(99);
+    expect(sent[0]!.msg).toEqual({ type: 'TRIGGER_RESCAN', forceMitigation: true });
+  });
+
+  it('does not read the testing-mode flag (handler is unconditional)', () => {
+    const { getSpy } = stubChrome(true);
+    handleRescanWithMitigation(1);
+    expect(getSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/service-worker/dispatch.ts
+++ b/src/service-worker/dispatch.ts
@@ -1,0 +1,55 @@
+import type { SecurityVerdict } from '@/types/verdict.js';
+import type {
+  ApplyMitigationMessage,
+  TriggerRescanMessage,
+  VerdictMessage,
+} from '@/types/messages.js';
+import { isTestingModeEnabled } from '@/shared/testing-mode.js';
+
+/**
+ * Issue #113 (N2) — VERDICT + APPLY_MITIGATION dispatch with testing-mode gate.
+ *
+ * VERDICT is always dispatched: window-globals, meta tag, page-stamp embed,
+ * and toolbar icon all key off it, and observe-mode is meant to leave those
+ * surfaces working.
+ *
+ * APPLY_MITIGATION is dispatched only when:
+ *   - verdict.status is 'COMPROMISED' or 'SUSPICIOUS' (status guard, outer)
+ *   - AND (forceMitigation is true) OR (testing-mode is off)
+ *
+ * `forceMitigation` is set by the TRIGGER_RESCAN path (popup → SW →
+ * content → SW). It overrides the testing-mode flag for this single
+ * verdict only; the persisted toggle is not mutated. Origin-skipped
+ * verdicts are 'UNKNOWN' so they fail the status guard and never
+ * dispatch APPLY_MITIGATION regardless of testing-mode.
+ *
+ * Race window: a user toggle flip while analysis is in flight reads
+ * the new state when this fires. Acceptable — applying current
+ * testing-mode at dispatch time matches user intent at that moment.
+ */
+export async function dispatchVerdictMessages(
+  tabId: number,
+  verdict: SecurityVerdict,
+  forceMitigation: boolean,
+): Promise<void> {
+  const verdictMsg: VerdictMessage = { type: 'VERDICT', verdict };
+  chrome.tabs.sendMessage(tabId, verdictMsg);
+
+  if (verdict.status !== 'COMPROMISED' && verdict.status !== 'SUSPICIOUS') return;
+
+  if (!forceMitigation && (await isTestingModeEnabled())) return;
+
+  const mitigateMsg: ApplyMitigationMessage = { type: 'APPLY_MITIGATION', verdict };
+  chrome.tabs.sendMessage(tabId, mitigateMsg);
+}
+
+/**
+ * Issue #113 (N2) — RESCAN_WITH_MITIGATION handler. Fans out a
+ * TRIGGER_RESCAN to the named tab unconditionally; the content script
+ * re-extracts and re-sends PAGE_SNAPSHOT with `forceMitigation: true`,
+ * which then bypasses the testing-mode gate at dispatch time.
+ */
+export function handleRescanWithMitigation(tabId: number): void {
+  const msg: TriggerRescanMessage = { type: 'TRIGGER_RESCAN', forceMitigation: true };
+  chrome.tabs.sendMessage(tabId, msg);
+}

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -1,7 +1,5 @@
 import type {
   HoneyLLMMessage,
-  VerdictMessage,
-  ApplyMitigationMessage,
   VerifyStampResultMessage,
 } from '@/types/messages.js';
 import { createLogger } from '@/shared/logger.js';
@@ -10,6 +8,7 @@ import { analyzeSnapshot, AnalysisAbortedError, getInFlightCount, getInFlightTab
 import { setTabVerdict, handleTabActivated, handleTabRemoved } from './toolbar-icon.js';
 import { ensureInstallSecret } from '@/shared/install-secret.js';
 import { verifyStamp } from './stamp.js';
+import { dispatchVerdictMessages, handleRescanWithMitigation } from './dispatch.js';
 
 const log = createLogger('ServiceWorker');
 
@@ -49,19 +48,15 @@ chrome.runtime.onMessage.addListener((message: HoneyLLMMessage, sender, sendResp
         return;
       }
 
+      // Issue #113 (N2) — forceMitigation propagates from TRIGGER_RESCAN
+      // through the content script's re-sent PAGE_SNAPSHOT. When true,
+      // the dispatch helper bypasses the testing-mode gate for this
+      // single verdict only; the persisted toggle is not mutated.
+      const forceMitigation = message.forceMitigation === true;
       analyzeSnapshot(tabId, message.snapshot)
-        .then((verdict) => {
+        .then(async (verdict) => {
           setTabVerdict(tabId, verdict.status);
-          const verdictMsg: VerdictMessage = { type: 'VERDICT', verdict };
-          chrome.tabs.sendMessage(tabId, verdictMsg);
-
-          if (verdict.status === 'COMPROMISED' || verdict.status === 'SUSPICIOUS') {
-            const mitigateMsg: ApplyMitigationMessage = {
-              type: 'APPLY_MITIGATION',
-              verdict,
-            };
-            chrome.tabs.sendMessage(tabId, mitigateMsg);
-          }
+          await dispatchVerdictMessages(tabId, verdict, forceMitigation);
         })
         .catch((err) => {
           // Issue #11 — an abort from a newer PAGE_SNAPSHOT is expected,
@@ -92,6 +87,16 @@ chrome.runtime.onMessage.addListener((message: HoneyLLMMessage, sender, sendResp
     // onMessageExternal for HONEYLLM_STATUS_PING (see below); exposing
     // stamp verification there would let the harness use HoneyLLM as
     // an HMAC oracle against the install secret. Internal channel only.
+    // Issue #113 (N2) — popup-triggered rescan with mitigations forced
+    // on for one run, regardless of the testing-mode flag. The handler
+    // fans out a TRIGGER_RESCAN to the target tab; the content script
+    // re-extracts the snapshot and re-sends PAGE_SNAPSHOT with
+    // forceMitigation=true, which bypasses the gate at dispatch time.
+    case 'RESCAN_WITH_MITIGATION': {
+      handleRescanWithMitigation(message.tabId);
+      return;
+    }
+
     case 'VERIFY_STAMP': {
       ensureInstallSecret()
         .then((secret) => verifyStamp(message.stamp, secret, message.currentUrl))

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -189,7 +189,25 @@ export const STORAGE_KEY_ORIGIN_OVERRIDES = 'honeyllm:origin-overrides';
 // production code; the Playwright runner toggles it for the duration of a
 // sweep and unsets it afterwards. `local` is used over `sync` because sync
 // is eventually consistent across contexts even on a single device.
+//
+// NOTE: distinct from `STORAGE_KEY_TESTING_MODE` (issue #113) — that key
+// is the user-facing observe-only toggle persisted from the popup.
 export const STORAGE_KEY_TEST_MODE = 'honeyllm:test-mode';
+
+/**
+ * Issue #113 (N2) — observe-only mode. When
+ * `chrome.storage.local[STORAGE_KEY_TESTING_MODE]` is strictly `true`,
+ * the service worker still runs the full analysis pipeline (snapshot →
+ * probes → verdict → persistence → window-globals → meta tag → toolbar
+ * icon → page stamp) but suppresses the `APPLY_MITIGATION` dispatch so
+ * the content script does not modify the DOM, activate the network
+ * guard, or arm the redirect blocker. Default `false`. Stored in
+ * `local` (per-device debugging affordance, synchronously consistent).
+ *
+ * NOTE: distinct from `STORAGE_KEY_TEST_MODE` above — that key gates
+ * the Phase 3 Track A direct-probe test harness, a different concern.
+ */
+export const STORAGE_KEY_TESTING_MODE = 'honeyllm:testing-mode';
 
 /**
  * Issue #117 (N13) — per-install HMAC secret used to sign page stamps.

--- a/src/shared/testing-mode.test.ts
+++ b/src/shared/testing-mode.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { STORAGE_KEY_TESTING_MODE } from './constants.js';
+import { isTestingModeEnabled, setTestingMode } from './testing-mode.js';
+
+interface ChromeStub {
+  storage: {
+    local: {
+      get: (key: string) => Promise<Record<string, unknown>>;
+      set: (items: Record<string, unknown>) => Promise<void>;
+    };
+  };
+}
+
+function stubChrome(initial: Record<string, unknown> = {}): {
+  readStore: () => Record<string, unknown>;
+  setSpy: ReturnType<typeof vi.fn>;
+  getSpy: ReturnType<typeof vi.fn>;
+} {
+  const store: Record<string, unknown> = { ...initial };
+  const setSpy = vi.fn(async (items: Record<string, unknown>) => {
+    Object.assign(store, items);
+  });
+  const getSpy = vi.fn(async (key: string) =>
+    key in store ? { [key]: store[key] } : {},
+  );
+  const chromeStub: ChromeStub = {
+    storage: { local: { get: getSpy, set: setSpy } },
+  };
+  vi.stubGlobal('chrome', chromeStub);
+  return { readStore: () => store, setSpy, getSpy };
+}
+
+describe('isTestingModeEnabled', () => {
+  beforeEach(() => vi.unstubAllGlobals());
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('returns false when key is absent', async () => {
+    stubChrome();
+    expect(await isTestingModeEnabled()).toBe(false);
+  });
+
+  it('returns false when stored value is non-boolean (number 1)', async () => {
+    stubChrome({ [STORAGE_KEY_TESTING_MODE]: 1 });
+    expect(await isTestingModeEnabled()).toBe(false);
+  });
+
+  it('returns false when stored value is the string "true"', async () => {
+    stubChrome({ [STORAGE_KEY_TESTING_MODE]: 'true' });
+    expect(await isTestingModeEnabled()).toBe(false);
+  });
+
+  it('returns false when stored value is null', async () => {
+    stubChrome({ [STORAGE_KEY_TESTING_MODE]: null });
+    expect(await isTestingModeEnabled()).toBe(false);
+  });
+
+  it('returns false when stored value is boolean false', async () => {
+    stubChrome({ [STORAGE_KEY_TESTING_MODE]: false });
+    expect(await isTestingModeEnabled()).toBe(false);
+  });
+
+  it('returns true only when stored value is strictly boolean true', async () => {
+    stubChrome({ [STORAGE_KEY_TESTING_MODE]: true });
+    expect(await isTestingModeEnabled()).toBe(true);
+  });
+});
+
+describe('setTestingMode', () => {
+  beforeEach(() => vi.unstubAllGlobals());
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('writes { honeyllm:testing-mode: true } to chrome.storage.local', async () => {
+    const { setSpy, readStore } = stubChrome();
+    await setTestingMode(true);
+    expect(setSpy).toHaveBeenCalledTimes(1);
+    expect(setSpy).toHaveBeenCalledWith({ [STORAGE_KEY_TESTING_MODE]: true });
+    expect(readStore()[STORAGE_KEY_TESTING_MODE]).toBe(true);
+  });
+
+  it('writes { honeyllm:testing-mode: false } to chrome.storage.local', async () => {
+    const { setSpy, readStore } = stubChrome({ [STORAGE_KEY_TESTING_MODE]: true });
+    await setTestingMode(false);
+    expect(setSpy).toHaveBeenCalledTimes(1);
+    expect(setSpy).toHaveBeenCalledWith({ [STORAGE_KEY_TESTING_MODE]: false });
+    expect(readStore()[STORAGE_KEY_TESTING_MODE]).toBe(false);
+  });
+
+  it('round-trips via isTestingModeEnabled', async () => {
+    stubChrome();
+    expect(await isTestingModeEnabled()).toBe(false);
+    await setTestingMode(true);
+    expect(await isTestingModeEnabled()).toBe(true);
+    await setTestingMode(false);
+    expect(await isTestingModeEnabled()).toBe(false);
+  });
+});

--- a/src/shared/testing-mode.ts
+++ b/src/shared/testing-mode.ts
@@ -1,0 +1,29 @@
+import { STORAGE_KEY_TESTING_MODE } from './constants.js';
+
+/**
+ * Issue #113 (N2) — observe-only mode read.
+ *
+ * Returns `true` only when `chrome.storage.local[STORAGE_KEY_TESTING_MODE]`
+ * is strictly the boolean `true`. Any other value (absent key, string,
+ * number, null, false) resolves to `false`. The strict-equality check
+ * defends against accidental persistence of stringified or coerced
+ * values from older popups, since the gate must default to OFF.
+ *
+ * Not cached: the popup writes the flag at runtime via `setTestingMode`,
+ * so an in-memory cache would go stale. The read is a single
+ * chrome.storage round-trip on the verdict-dispatch path — negligible.
+ */
+export async function isTestingModeEnabled(): Promise<boolean> {
+  const result = await chrome.storage.local.get(STORAGE_KEY_TESTING_MODE);
+  return result[STORAGE_KEY_TESTING_MODE] === true;
+}
+
+/**
+ * Issue #113 (N2) — observe-only mode write. Persists the boolean
+ * verbatim into `chrome.storage.local`. Failures (quota, etc.) bubble
+ * up so the popup can show a toast and refrain from claiming the
+ * toggle was saved.
+ */
+export async function setTestingMode(enabled: boolean): Promise<void> {
+  await chrome.storage.local.set({ [STORAGE_KEY_TESTING_MODE]: enabled });
+}

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -22,7 +22,12 @@ export type MessageType =
   // (registered on chrome.runtime.onMessage, NOT onMessageExternal —
   // see service-worker/index.ts for the security rationale).
   | 'VERIFY_STAMP'
-  | 'VERIFY_STAMP_RESULT';
+  | 'VERIFY_STAMP_RESULT'
+  // Issue #113 (N2) — testing-mode rescan flow. RESCAN_WITH_MITIGATION
+  // is popup → SW; TRIGGER_RESCAN is SW → content. Both are internal
+  // channels (chrome.runtime.onMessage / chrome.tabs.sendMessage).
+  | 'RESCAN_WITH_MITIGATION'
+  | 'TRIGGER_RESCAN';
 
 interface BaseMessage {
   readonly type: MessageType;
@@ -32,6 +37,14 @@ export interface PageSnapshotMessage extends BaseMessage {
   readonly type: 'PAGE_SNAPSHOT';
   readonly tabId: number;
   readonly snapshot: PageSnapshot;
+  /**
+   * Issue #113 (N2) — set only by the TRIGGER_RESCAN path. When `true`,
+   * the SW dispatches APPLY_MITIGATION for SUSPICIOUS/COMPROMISED
+   * verdicts even if testing-mode is enabled. The flag affects this
+   * single verdict only; the persisted testing-mode toggle is not
+   * mutated. Absent on the normal page-load snapshot path.
+   */
+  readonly forceMitigation?: boolean;
 }
 
 export interface RunProbesMessage extends BaseMessage {
@@ -169,6 +182,22 @@ export interface VerifyStampResultMessage extends BaseMessage {
   readonly result: VerifyStampResult;
 }
 
+// Issue #113 (N2) — observe-only rescan-with-prevention. The popup
+// dispatches RescanWithMitigationMessage for the active tab; the SW
+// fans out a TriggerRescanMessage to that tab's content script, which
+// re-extracts the snapshot and re-sends PAGE_SNAPSHOT with
+// `forceMitigation: true`. The override applies for that one verdict
+// only; the persisted testing-mode toggle is not mutated.
+export interface RescanWithMitigationMessage extends BaseMessage {
+  readonly type: 'RESCAN_WITH_MITIGATION';
+  readonly tabId: number;
+}
+
+export interface TriggerRescanMessage extends BaseMessage {
+  readonly type: 'TRIGGER_RESCAN';
+  readonly forceMitigation: boolean;
+}
+
 export type HoneyLLMMessage =
   | PageSnapshotMessage
   | RunProbesMessage
@@ -184,4 +213,6 @@ export type HoneyLLMMessage =
   | RunProbeBuiltinMessage
   | ProbeBuiltinResultMessage
   | VerifyStampMessage
-  | VerifyStampResultMessage;
+  | VerifyStampResultMessage
+  | RescanWithMitigationMessage
+  | TriggerRescanMessage;


### PR DESCRIPTION
## Summary

Phase 5 N2 (foundation issue, unblocks N10). Adds an observe-only mode toggle in the popup that gates the `APPLY_MITIGATION` dispatch in the service worker. When ON, HoneyLLM still scores verdicts and surfaces them everywhere normal (window globals, meta tag, toolbar icon, IndexedDB, page stamp) — but the content script does not modify the DOM, activate the network guard, or arm the redirect blocker.

A new "Rescan with prevention" button in the popup forces a one-shot rescan with mitigations on, regardless of the toggle, so the page-stamp + VERIFY_STAMP loop from #117 can A/B compare LLM consumption pre- vs post-mitigation.

## Acceptance criteria

- [x] Toggle is OFF by default
- [x] When ON, mitigations do not run on any verdict severity
- [x] Verdict still surfaces everywhere (window globals, meta tag, toolbar icon, popup, page stamp, persisted store)
- [x] "Rescan with prevention" button forces mitigations for one run regardless of toggle state
- [x] Button disabled when verdict is CLEAN / UNKNOWN / absent (only meaningful when there's something to mitigate)
- [x] New tests cover both modes and the rescan path

## Architecture

- `STORAGE_KEY_TESTING_MODE = 'honeyllm:testing-mode'` in `chrome.storage.local` (per-device, synchronously consistent). Distinct from the existing `STORAGE_KEY_TEST_MODE` (Phase 3 Track A direct-probe gate).
- `src/shared/testing-mode.ts` — strict-`true` read; defaults to `false` for absent / non-boolean values.
- `src/service-worker/dispatch.ts` — extracted `dispatchVerdictMessages(tabId, verdict, forceMitigation)`. VERDICT always sent; APPLY_MITIGATION sent iff status ∈ {COMPROMISED, SUSPICIOUS} AND (forceMitigation OR !testingMode).
- `RESCAN_WITH_MITIGATION` (popup → SW) → `TRIGGER_RESCAN` (SW → content) → content re-extracts and re-sends `PAGE_SNAPSHOT` with optional `forceMitigation: true`. Override applies for that one verdict only; the persisted toggle is not mutated.
- Pre-existing unsafe-HTML setter at `src/popup/popup.ts:348` switched to `container.replaceChildren()` (bundled fix; the post-tool-use hook would otherwise reject popup.ts edits).

## Tests

47 new tests across 4 new test files (471 → 518):
- `src/shared/testing-mode.test.ts` (9) — read defaults, strict-true, round-trip
- `src/service-worker/dispatch.test.ts` (18) — gate matrix (testing-mode × status × forceMitigation), origin-skipped no-op, RESCAN handler
- `src/content/rescan.test.ts` (5) — re-extraction, message shape, tab-id placeholder
- `src/popup/testing-mode-controls.test.ts` (15, jsdom) — toggle init/persist/rollback, button enable matrix, dispatch shape, error toasts

## Test plan

- [ ] CI green (typecheck + test + build)
- [ ] `npm run build`, load `dist/` unpacked. Default OFF — visit a known-SUSPICIOUS fixture (`fixtures.host-things.online`), confirm DOM sanitised + verdict surfaced.
- [ ] Toggle ON, reload same fixture — confirm DOM unmodified but verdict still in `__AI_SITE_STATUS__`, `<meta>`, toolbar icon, popup, page stamp embedded.
- [ ] With SUSPICIOUS verdict loaded, click "Rescan with prevention" — observe DOM mutates and verdict re-stamps.
- [ ] Toggle OFF, reload — confirm normal behaviour resumes.

Closes #113