### PR TITLE
feat(phase5-#114): popup rescan button + collapsible accordions (N3)

### DIFF
--- a/src/popup/popup-accordion.test.ts
+++ b/src/popup/popup-accordion.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+
+// Vite/vitest's `?raw` query loads the file's contents as a string at
+// resolve time; the ambient declaration lives in test-shims.d.ts.
+import popupHtml from './popup.html?raw';
+
+function loadPopupDocument(): Document {
+  return new DOMParser().parseFromString(popupHtml, 'text/html');
+}
+
+describe('popup.html accordion structure (issue #114)', () => {
+  it('has a Verdict accordion that is open by default', () => {
+    const doc = loadPopupDocument();
+    const el = doc.getElementById('accordion-verdict');
+    expect(el).not.toBeNull();
+    expect(el!.tagName).toBe('DETAILS');
+    expect(el!.hasAttribute('open')).toBe(true);
+  });
+
+  it('has six other accordions, all closed by default', () => {
+    const doc = loadPopupDocument();
+    const ids = [
+      'accordion-probes',
+      'accordion-behavioral',
+      'accordion-hunters',
+      'accordion-mitigations',
+      'accordion-engine',
+      'accordion-policy',
+    ];
+    for (const id of ids) {
+      const el = doc.getElementById(id);
+      expect(el, `missing accordion #${id}`).not.toBeNull();
+      expect(el!.tagName).toBe('DETAILS');
+      expect(el!.hasAttribute('open')).toBe(false);
+    }
+  });
+
+  it('preserves all inner verdict element ids that popup.ts queries', () => {
+    const doc = loadPopupDocument();
+    const requiredIds = [
+      'confidence-value',
+      'confidence-fill',
+      'score-info',
+      'probe-summarization',
+      'probe-detection',
+      'probe-adversarial',
+      'flag-role-drift',
+      'flag-exfiltration',
+      'flag-instruction',
+      'flags-card',
+      'flags-container',
+      'timestamp-info',
+    ];
+    for (const id of requiredIds) {
+      expect(doc.getElementById(id), `inner element #${id} must remain accessible`).not.toBeNull();
+    }
+  });
+
+  it('keeps testing-mode-card as a flat <div> (NOT a <details>) — #113 invariant', () => {
+    const doc = loadPopupDocument();
+    const el = doc.getElementById('testing-mode-card');
+    expect(el).not.toBeNull();
+    expect(el!.tagName).toBe('DIV');
+  });
+
+  it('keeps the canary-options container outside any <details> — settings stay flat', () => {
+    const doc = loadPopupDocument();
+    const canary = doc.getElementById('canary-options');
+    expect(canary).not.toBeNull();
+    expect(canary!.closest('details')).toBeNull();
+  });
+
+  it('keeps site-card as a flat <div> (NOT a <details>) — settings stay flat', () => {
+    const doc = loadPopupDocument();
+    const el = doc.getElementById('site-card');
+    expect(el).not.toBeNull();
+    expect(el!.tagName).toBe('DIV');
+  });
+
+  it('has a Rescan button in the header (disabled in HTML)', () => {
+    const doc = loadPopupDocument();
+    const btn = doc.getElementById('rescan-page-btn');
+    expect(btn).not.toBeNull();
+    expect(btn!.tagName).toBe('BUTTON');
+    expect(btn!.hasAttribute('disabled')).toBe(true);
+    const h1 = btn!.closest('h1');
+    expect(h1, 'rescan-page-btn must live inside the popup <h1> header').not.toBeNull();
+  });
+
+  it('places hunter-findings placeholder element inside the Hunter findings accordion', () => {
+    const doc = loadPopupDocument();
+    const body = doc.getElementById('hunter-findings-body');
+    expect(body).not.toBeNull();
+    expect(body!.closest('#accordion-hunters')).not.toBeNull();
+  });
+
+  it('places mitigations-list element inside the Mitigations applied accordion', () => {
+    const doc = loadPopupDocument();
+    const list = doc.getElementById('mitigations-list');
+    expect(list).not.toBeNull();
+    expect(list!.closest('#accordion-mitigations')).not.toBeNull();
+  });
+});

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -256,10 +256,87 @@
       font-size: 10px;
       margin-top: 2px;
     }
+    /* Issue #114 (N3) — popup header rescan button. Distinct from the
+       testing-mode card's "Rescan with prevention" button which forces
+       mitigations on; this one is verdict-agnostic. */
+    .rescan-btn {
+      margin-left: auto;
+      background: #1f2937;
+      color: #93c5fd;
+      border: 1px solid #374151;
+      border-radius: 6px;
+      font-size: 11px;
+      padding: 3px 10px;
+      cursor: pointer;
+      font-family: inherit;
+      transition: background 120ms, border-color 120ms;
+    }
+    .rescan-btn:hover { background: #2a2f3a; border-color: #4ade80; }
+    .rescan-btn:disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
+      background: #1a1a1a;
+    }
+    .rescan-btn:disabled:hover { background: #1a1a1a; border-color: #374151; }
+    /* Issue #114 (N3) — collapsible accordion sections inside
+       #verdict-content. The inner `.card` keeps its dark theme; the
+       <summary> renders a chevron and the same uppercase-grey heading
+       style as the existing card headings. Open animates a one-shot
+       fade-in on the inner card; close uses the UA-native immediate hide
+       (no transition — `<details>` height transitions are broken without
+       JS measurement). */
+    .accordion {
+      margin-bottom: 10px;
+    }
+    .accordion > summary {
+      list-style: none;
+      cursor: pointer;
+      user-select: none;
+      padding: 10px 12px;
+      background: #1a1a1a;
+      border: 1px solid #2a2a2a;
+      border-radius: 8px;
+      font-size: 12px;
+      color: #888;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      display: flex;
+      align-items: center;
+    }
+    .accordion > summary::-webkit-details-marker { display: none; }
+    .accordion > summary::after {
+      content: '\25B8'; /* ▸ — black right-pointing small triangle */
+      margin-left: auto;
+      font-size: 10px;
+      color: #555;
+      transition: transform 0.15s ease;
+    }
+    .accordion[open] > summary { border-bottom: none; border-bottom-left-radius: 0; border-bottom-right-radius: 0; }
+    .accordion[open] > summary::after { transform: rotate(90deg); }
+    .accordion > .card {
+      border-top: none;
+      border-top-left-radius: 0;
+      border-top-right-radius: 0;
+      margin-bottom: 0;
+      animation: accordion-fadein 0.15s ease;
+    }
+    @keyframes accordion-fadein {
+      from { opacity: 0; }
+      to { opacity: 1; }
+    }
+    .accordion .placeholder {
+      font-size: 11px;
+      color: #6b7280;
+      font-style: italic;
+    }
   </style>
 </head>
 <body>
-  <h1>HoneyLLM <span id="status-badge" class="status-badge status-PENDING">Pending</span></h1>
+  <h1>
+    HoneyLLM
+    <span id="status-badge" class="status-badge status-PENDING">Pending</span>
+    <button class="rescan-btn" id="rescan-page-btn" disabled>Rescan</button>
+  </h1>
 
   <div id="loading">Analyzing page...</div>
 
@@ -306,54 +383,91 @@
       <div class="meta">No analysis data for this page yet.</div>
     </div>
 
+    <!-- Issue #114 (N3) — verdict-derived data lives in collapsible
+         accordions. Settings cards (canary picker, testing-mode toggle,
+         site-card) remain flat top-level cards above so they render
+         independently of verdict state. The Verdict accordion is open
+         by default; all others closed. Inner element ids are preserved
+         byte-identically so popup.ts's getElementById queries still find
+         them after the wrapper change. -->
     <div id="verdict-content" style="display: none;">
-    <div class="card">
-      <h2>Confidence</h2>
-      <div style="font-size: 24px; font-weight: 700;" id="confidence-value">--</div>
-      <div class="confidence-bar">
-        <div class="confidence-fill" id="confidence-fill" style="width: 0%; background: #4ade80;"></div>
-      </div>
-      <div class="meta" id="score-info"></div>
-    </div>
+      <details class="accordion" id="accordion-verdict" open>
+        <summary>Verdict</summary>
+        <div class="card">
+          <div style="font-size: 24px; font-weight: 700;" id="confidence-value">--</div>
+          <div class="confidence-bar">
+            <div class="confidence-fill" id="confidence-fill" style="width: 0%; background: #4ade80;"></div>
+          </div>
+          <div class="meta" id="score-info"></div>
+        </div>
+      </details>
 
-    <div class="card">
-      <h2>Canary Probes</h2>
-      <div class="probe-row">
-        <span>Summarization</span>
-        <span id="probe-summarization">--</span>
-      </div>
-      <div class="probe-row">
-        <span>Instruction Detection</span>
-        <span id="probe-detection">--</span>
-      </div>
-      <div class="probe-row">
-        <span>Adversarial Compliance</span>
-        <span id="probe-adversarial">--</span>
-      </div>
-    </div>
+      <details class="accordion" id="accordion-probes">
+        <summary>Probe results</summary>
+        <div class="card">
+          <div class="probe-row">
+            <span>Summarization</span>
+            <span id="probe-summarization">--</span>
+          </div>
+          <div class="probe-row">
+            <span>Instruction Detection</span>
+            <span id="probe-detection">--</span>
+          </div>
+          <div class="probe-row">
+            <span>Adversarial Compliance</span>
+            <span id="probe-adversarial">--</span>
+          </div>
+        </div>
+      </details>
 
-    <div class="card">
-      <h2>Behavioral Analysis</h2>
-      <div class="probe-row">
-        <span>Role Drift</span>
-        <span id="flag-role-drift">--</span>
-      </div>
-      <div class="probe-row">
-        <span>Exfiltration Intent</span>
-        <span id="flag-exfiltration">--</span>
-      </div>
-      <div class="probe-row">
-        <span>Instruction Following</span>
-        <span id="flag-instruction">--</span>
-      </div>
-    </div>
+      <details class="accordion" id="accordion-behavioral">
+        <summary>Behavioral flags</summary>
+        <div class="card">
+          <div class="probe-row">
+            <span>Role Drift</span>
+            <span id="flag-role-drift">--</span>
+          </div>
+          <div class="probe-row">
+            <span>Exfiltration Intent</span>
+            <span id="flag-exfiltration">--</span>
+          </div>
+          <div class="probe-row">
+            <span>Instruction Following</span>
+            <span id="flag-instruction">--</span>
+          </div>
+          <div id="flags-card" style="display: none; margin-top: 8px;">
+            <div class="flags" id="flags-container"></div>
+          </div>
+        </div>
+      </details>
 
-    <div class="card" id="flags-card" style="display: none;">
-      <h2>Flags</h2>
-      <div class="flags" id="flags-container"></div>
-    </div>
+      <details class="accordion" id="accordion-hunters">
+        <summary>Hunter findings</summary>
+        <div class="card">
+          <div class="placeholder" id="hunter-findings-body">No hunter data yet — N1 pending.</div>
+        </div>
+      </details>
 
-    <div class="meta" id="timestamp-info"></div>
+      <details class="accordion" id="accordion-mitigations">
+        <summary>Mitigations applied</summary>
+        <div class="card">
+          <div id="mitigations-list" class="placeholder">None</div>
+        </div>
+      </details>
+
+      <details class="accordion" id="accordion-engine">
+        <summary>Engine / canary / WebGPU diagnostics</summary>
+        <div class="card">
+          <div class="placeholder" id="engine-diagnostics-body">No engine diagnostics yet.</div>
+        </div>
+      </details>
+
+      <details class="accordion" id="accordion-policy">
+        <summary>Per-origin policy</summary>
+        <div class="card" id="policy-body">
+          <div class="meta" id="timestamp-info"></div>
+        </div>
+      </details>
     </div>
   </div>
 

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -17,7 +17,11 @@ import {
   setOverride,
   clearOverride,
 } from '@/policy/origin-storage.js';
-import { initTestingModeToggle, initRescanButton } from './testing-mode-controls.js';
+import {
+  initTestingModeToggle,
+  initRescanButton,
+  initRescanPageButton,
+} from './testing-mode-controls.js';
 
 interface StoredVerdict {
   status: string;
@@ -36,6 +40,9 @@ interface StoredVerdict {
   analysisError?: string | null;
   // Phase 4 Stage 4D.3 — absent on pre-4D.3 verdicts.
   canaryId?: string | null;
+  // Issue #114 (N3) — surfaced in the Mitigations applied accordion.
+  // Absent on pre-N3 verdicts; SecurityVerdict has always carried it.
+  mitigationsApplied?: readonly string[];
 }
 
 function $(id: string): HTMLElement {
@@ -358,6 +365,14 @@ async function loadVerdict(): Promise<void> {
   const date = new Date(verdict.timestamp);
   $('timestamp-info').textContent = `Last analyzed: ${date.toLocaleString()} | ${verdict.url}`;
 
+  // Issue #114 (N3) — surface mitigationsApplied in its accordion. The
+  // field is on SecurityVerdict but was previously not shown. `?? []`
+  // handles legacy verdicts written before the popup typed the field.
+  const mitigations = verdict.mitigationsApplied ?? [];
+  const mitigationsList = $('mitigations-list');
+  mitigationsList.textContent = mitigations.length > 0 ? mitigations.join(', ') : 'None';
+  mitigationsList.className = mitigations.length > 0 ? '' : 'placeholder';
+
   // Issue #113 (N2) — rescan-with-prevention button is verdict-aware:
   // only enabled when the current verdict is SUSPICIOUS or COMPROMISED.
   // Called here (inside loadVerdict) so the verdict status drives the
@@ -489,6 +504,17 @@ void (async () => {
     initQuickLinks();
   } catch (err) {
     console.error('quick links init failed', err);
+  }
+  try {
+    // Issue #114 (N3) — header rescan button. Always-available rescan that
+    // does not force mitigations; enabled for http/https tabs only. Wired
+    // here (verdict-agnostic) rather than inside loadVerdict.
+    await initRescanPageButton(
+      $('rescan-page-btn') as HTMLButtonElement,
+      showToast,
+    );
+  } catch (err) {
+    console.error('rescan-page button init failed', err);
   }
   try {
     await loadVerdict();

--- a/src/popup/test-shims.d.ts
+++ b/src/popup/test-shims.d.ts
@@ -1,0 +1,6 @@
+// Issue #114 (N3) — Vite/vitest `?raw` import returns a file's contents
+// as a string. Used by popup-accordion.test.ts to load popup.html.
+declare module '*.html?raw' {
+  const content: string;
+  export default content;
+}

--- a/src/popup/testing-mode-controls.test.ts
+++ b/src/popup/testing-mode-controls.test.ts
@@ -1,7 +1,11 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { STORAGE_KEY_TESTING_MODE } from '@/shared/constants.js';
-import { initTestingModeToggle, initRescanButton } from './testing-mode-controls.js';
+import {
+  initTestingModeToggle,
+  initRescanButton,
+  initRescanPageButton,
+} from './testing-mode-controls.js';
 
 interface ChromeStub {
   storage: {
@@ -18,6 +22,7 @@ function stubChrome(opts: {
   testingMode?: boolean;
   setRejects?: Error;
   activeTabId?: number | undefined;
+  activeTabUrl?: string;
   sendRejects?: Error;
 } = {}): {
   store: Record<string, unknown>;
@@ -38,11 +43,12 @@ function stubChrome(opts: {
     if (opts.sendRejects !== undefined) throw opts.sendRejects;
     return undefined;
   });
-  const querySpy = vi.fn(async (_q: chrome.tabs.QueryInfo) =>
-    opts.activeTabId !== undefined
-      ? ([{ id: opts.activeTabId } as chrome.tabs.Tab])
-      : ([{} as chrome.tabs.Tab]),
-  );
+  const querySpy = vi.fn(async (_q: chrome.tabs.QueryInfo) => {
+    const tab: Partial<chrome.tabs.Tab> = {};
+    if (opts.activeTabId !== undefined) tab.id = opts.activeTabId;
+    if (opts.activeTabUrl !== undefined) tab.url = opts.activeTabUrl;
+    return [tab as chrome.tabs.Tab];
+  });
   const chromeStub: ChromeStub = {
     storage: { local: { get: getSpy, set: setSpy } },
     runtime: { sendMessage: sendSpy },
@@ -219,6 +225,103 @@ describe('initRescanButton', () => {
     const toasts: string[] = [];
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     initRescanButton(btn, 'COMPROMISED', (m) => toasts.push(m));
+
+    btn.click();
+    await flushMicrotasks();
+
+    expect(toasts[0]).toContain('Rescan failed');
+    errorSpy.mockRestore();
+  });
+});
+
+describe('initRescanPageButton', () => {
+  beforeEach(() => vi.unstubAllGlobals());
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('disables the button on chrome:// tab', async () => {
+    stubChrome({ activeTabId: 5, activeTabUrl: 'chrome://extensions/' });
+    const btn = makeButton();
+    await initRescanPageButton(btn, () => {});
+    expect(btn.disabled).toBe(true);
+  });
+
+  it('disables the button on chrome-extension:// tab', async () => {
+    stubChrome({ activeTabId: 5, activeTabUrl: 'chrome-extension://abc/popup.html' });
+    const btn = makeButton();
+    await initRescanPageButton(btn, () => {});
+    expect(btn.disabled).toBe(true);
+  });
+
+  it('disables the button on about: tab', async () => {
+    stubChrome({ activeTabId: 5, activeTabUrl: 'about:blank' });
+    const btn = makeButton();
+    await initRescanPageButton(btn, () => {});
+    expect(btn.disabled).toBe(true);
+  });
+
+  it('disables the button when tab has no URL', async () => {
+    stubChrome({ activeTabId: 5 });
+    const btn = makeButton();
+    await initRescanPageButton(btn, () => {});
+    expect(btn.disabled).toBe(true);
+  });
+
+  it('disables the button when tab has no id', async () => {
+    stubChrome({ activeTabUrl: 'https://example.com/' });
+    const btn = makeButton();
+    await initRescanPageButton(btn, () => {});
+    expect(btn.disabled).toBe(true);
+  });
+
+  it('enables the button on https:// tab', async () => {
+    stubChrome({ activeTabId: 33, activeTabUrl: 'https://example.com/' });
+    const btn = makeButton();
+    await initRescanPageButton(btn, () => {});
+    expect(btn.disabled).toBe(false);
+  });
+
+  it('enables the button on http:// tab', async () => {
+    stubChrome({ activeTabId: 33, activeTabUrl: 'http://localhost:3000/' });
+    const btn = makeButton();
+    await initRescanPageButton(btn, () => {});
+    expect(btn.disabled).toBe(false);
+  });
+
+  it('clicking the enabled button sends RESCAN_PAGE with the tab id', async () => {
+    const { sendSpy } = stubChrome({ activeTabId: 33, activeTabUrl: 'https://example.com/' });
+    const btn = makeButton();
+    const toasts: string[] = [];
+    await initRescanPageButton(btn, (m) => toasts.push(m));
+
+    btn.click();
+    await flushMicrotasks();
+
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    expect(sendSpy.mock.calls[0]![0]).toEqual({ type: 'RESCAN_PAGE', tabId: 33 });
+    expect(toasts[0]).toContain('Rescan triggered');
+  });
+
+  it('clicking a disabled button does NOT send any message (listener never attached)', async () => {
+    const { sendSpy } = stubChrome({ activeTabId: 5, activeTabUrl: 'chrome://extensions/' });
+    const btn = makeButton();
+    await initRescanPageButton(btn, () => {});
+
+    btn.click();
+    await flushMicrotasks();
+
+    expect(sendSpy).not.toHaveBeenCalled();
+  });
+
+  it('toasts on chrome.runtime.sendMessage rejection', async () => {
+    stubChrome({
+      activeTabId: 33,
+      activeTabUrl: 'https://example.com/',
+      sendRejects: new Error('SW disconnected'),
+    });
+    const btn = makeButton();
+    const toasts: string[] = [];
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await initRescanPageButton(btn, (m) => toasts.push(m));
 
     btn.click();
     await flushMicrotasks();

--- a/src/popup/testing-mode-controls.ts
+++ b/src/popup/testing-mode-controls.ts
@@ -1,4 +1,7 @@
-import type { RescanWithMitigationMessage } from '@/types/messages.js';
+import type {
+  RescanPageMessage,
+  RescanWithMitigationMessage,
+} from '@/types/messages.js';
 import { isTestingModeEnabled, setTestingMode } from '@/shared/testing-mode.js';
 
 /**
@@ -66,6 +69,52 @@ export function initRescanButton(
       } catch (err) {
         onToast('Rescan failed to start');
         console.error('rescan dispatch failed', err);
+      }
+    })();
+  });
+}
+
+/**
+ * Issue #114 (N3) — popup header "Rescan" button. Always-available rescan
+ * that does NOT force mitigations; the testing-mode gate in the SW applies
+ * normally. Enabled only for scannable tabs (http/https) with a defined
+ * tab id; disabled for chrome://, chrome-extension://, about:, and any
+ * tab missing a URL or id.
+ *
+ * Distinct from initRescanButton (N2, testing-mode-only, forces mitigations
+ * on, verdict-status-gated). This button is verdict-agnostic: a user may
+ * always re-run analysis on a normal page.
+ */
+export async function initRescanPageButton(
+  button: HTMLButtonElement,
+  onToast: (message: string) => void,
+): Promise<void> {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  const url = tab?.url ?? '';
+  const tabId = tab?.id;
+  const isScannableUrl = url.startsWith('http://') || url.startsWith('https://');
+  const canScan = isScannableUrl && tabId !== undefined;
+
+  button.disabled = !canScan;
+  if (!canScan) return;
+
+  // tabId is captured here; the popup IIFE re-runs on each open so a
+  // stale capture across tab switches is not a concern (the popup
+  // closes when the active tab changes).
+  const capturedTabId = tabId;
+
+  button.addEventListener('click', () => {
+    void (async () => {
+      try {
+        const msg: RescanPageMessage = {
+          type: 'RESCAN_PAGE',
+          tabId: capturedTabId,
+        };
+        await chrome.runtime.sendMessage(msg);
+        onToast('Rescan triggered');
+      } catch (err) {
+        onToast('Rescan failed to start');
+        console.error('rescan-page dispatch failed', err);
       }
     })();
   });

--- a/src/service-worker/dispatch.test.ts
+++ b/src/service-worker/dispatch.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import type { SecurityVerdict, SecurityStatus } from '@/types/verdict.js';
 import { STORAGE_KEY_TESTING_MODE } from '@/shared/constants.js';
-import { dispatchVerdictMessages, handleRescanWithMitigation } from './dispatch.js';
+import { dispatchVerdictMessages, handleRescanWithMitigation, handleRescanPage } from './dispatch.js';
 
 interface ChromeStub {
   storage: {
@@ -195,6 +195,25 @@ describe('handleRescanWithMitigation', () => {
   it('does not read the testing-mode flag (handler is unconditional)', () => {
     const { getSpy } = stubChrome(true);
     handleRescanWithMitigation(1);
+    expect(getSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleRescanPage', () => {
+  beforeEach(() => vi.unstubAllGlobals());
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('dispatches TRIGGER_RESCAN { forceMitigation: false } to the specified tabId', () => {
+    const { sent } = stubChrome(undefined);
+    handleRescanPage(42);
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.tabId).toBe(42);
+    expect(sent[0]!.msg).toEqual({ type: 'TRIGGER_RESCAN', forceMitigation: false });
+  });
+
+  it('does not read the testing-mode flag (gate lives in dispatchVerdictMessages, not here)', () => {
+    const { getSpy } = stubChrome(true);
+    handleRescanPage(7);
     expect(getSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/service-worker/dispatch.ts
+++ b/src/service-worker/dispatch.ts
@@ -53,3 +53,15 @@ export function handleRescanWithMitigation(tabId: number): void {
   const msg: TriggerRescanMessage = { type: 'TRIGGER_RESCAN', forceMitigation: true };
   chrome.tabs.sendMessage(tabId, msg);
 }
+
+/**
+ * Issue #114 (N3) — RESCAN_PAGE handler. Fans out a TRIGGER_RESCAN with
+ * `forceMitigation: false` to the named tab. The content script re-extracts
+ * and re-sends PAGE_SNAPSHOT without the override, so the testing-mode
+ * gate in dispatchVerdictMessages applies normally. Distinct from
+ * handleRescanWithMitigation which forces mitigations on for one run.
+ */
+export function handleRescanPage(tabId: number): void {
+  const msg: TriggerRescanMessage = { type: 'TRIGGER_RESCAN', forceMitigation: false };
+  chrome.tabs.sendMessage(tabId, msg);
+}

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -8,7 +8,7 @@ import { analyzeSnapshot, AnalysisAbortedError, getInFlightCount, getInFlightTab
 import { setTabVerdict, handleTabActivated, handleTabRemoved } from './toolbar-icon.js';
 import { ensureInstallSecret } from '@/shared/install-secret.js';
 import { verifyStamp } from './stamp.js';
-import { dispatchVerdictMessages, handleRescanWithMitigation } from './dispatch.js';
+import { dispatchVerdictMessages, handleRescanWithMitigation, handleRescanPage } from './dispatch.js';
 
 const log = createLogger('ServiceWorker');
 
@@ -94,6 +94,14 @@ chrome.runtime.onMessage.addListener((message: HoneyLLMMessage, sender, sendResp
     // forceMitigation=true, which bypasses the gate at dispatch time.
     case 'RESCAN_WITH_MITIGATION': {
       handleRescanWithMitigation(message.tabId);
+      return;
+    }
+
+    // Issue #114 (N3) — generic popup rescan. Re-runs the orchestrator
+    // pipeline against the named tab without forcing mitigations; the
+    // testing-mode gate in dispatchVerdictMessages applies normally.
+    case 'RESCAN_PAGE': {
+      handleRescanPage(message.tabId);
       return;
     }
 

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -27,7 +27,11 @@ export type MessageType =
   // is popup → SW; TRIGGER_RESCAN is SW → content. Both are internal
   // channels (chrome.runtime.onMessage / chrome.tabs.sendMessage).
   | 'RESCAN_WITH_MITIGATION'
-  | 'TRIGGER_RESCAN';
+  | 'TRIGGER_RESCAN'
+  // Issue #114 (N3) — generic popup rescan. Re-runs the orchestrator
+  // pipeline against the active tab without forcing mitigations; the
+  // testing-mode gate in dispatchVerdictMessages applies normally.
+  | 'RESCAN_PAGE';
 
 interface BaseMessage {
   readonly type: MessageType;
@@ -198,6 +202,16 @@ export interface TriggerRescanMessage extends BaseMessage {
   readonly forceMitigation: boolean;
 }
 
+// Issue #114 (N3) — popup → SW. The SW handler fans out
+// TriggerRescanMessage with `forceMitigation: false`; the content
+// script re-extracts and re-sends PAGE_SNAPSHOT, and the testing-mode
+// gate applies normally. Distinct from RescanWithMitigationMessage
+// which is testing-mode-only and forces mitigations on for one run.
+export interface RescanPageMessage extends BaseMessage {
+  readonly type: 'RESCAN_PAGE';
+  readonly tabId: number;
+}
+
 export type HoneyLLMMessage =
   | PageSnapshotMessage
   | RunProbesMessage
@@ -215,4 +229,5 @@ export type HoneyLLMMessage =
   | VerifyStampMessage
   | VerifyStampResultMessage
   | RescanWithMitigationMessage
-  | TriggerRescanMessage;
+  | TriggerRescanMessage
+  | RescanPageMessage;


### PR DESCRIPTION
## Summary
- Adds a "Rescan" button to the popup header (`<h1>`) that re-runs the orchestrator pipeline against the active tab without forcing mitigations — the testing-mode gate applies normally. Distinct from N2's "Rescan with prevention" which forces mitigations on for one run.
- Reorganises `#verdict-content` into 7 collapsible `<details>` accordions: **Verdict** (open by default), Probe results, Behavioral flags, Hunter findings, Mitigations applied, Engine/canary/WebGPU diagnostics, Per-origin policy.
- Settings cards (canary picker, `#testing-mode-card`, `#site-card`) stay flat top-level cards above `#verdict-content` so they render independently of verdict state.

## Wire-up
```
popup → RESCAN_PAGE → SW handleRescanPage
  → chrome.tabs.sendMessage(TRIGGER_RESCAN, forceMitigation=false)
  → content rescanWithForcedMitigation(false) → re-extract
  → re-send PAGE_SNAPSHOT → dispatchVerdictMessages (gate respected)
```

The content side reuses `rescanWithForcedMitigation` unchanged. Inner element ids inside accordions are preserved byte-identically (popup.ts uses only `getElementById`, so the `<details>` wrappers are transparent).

## Files
- `src/types/messages.ts` — adds `RESCAN_PAGE` to `MessageType` union + `RescanPageMessage` interface.
- `src/service-worker/dispatch.ts` — adds `handleRescanPage(tabId)`.
- `src/service-worker/index.ts` — routes `RESCAN_PAGE`.
- `src/popup/popup.html` — restructures `#verdict-content` into 7 accordions; adds rescan button to header; adds accordion + button CSS (one-shot fade-in animation).
- `src/popup/popup.ts` — wires `initRescanPageButton`; widens `StoredVerdict` with `mitigationsApplied?`; renders `#mitigations-list`.
- `src/popup/testing-mode-controls.ts` — exports `initRescanPageButton(button, onToast)` (scannable-URL gate; click dispatches `RESCAN_PAGE`).
- `src/popup/test-shims.d.ts` — ambient module declaration for Vite `?raw` imports (test infrastructure).

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm test` — 539 passing across 40 files (+21 new)
- [x] `npm run build` produces `dist/`
- [ ] Manual smoke after merge: load `dist/` as unpacked extension, confirm Rescan button enabled on `https://example.com/`, all 7 accordions present with only Verdict expanded, testing-mode toggle and canary picker still always visible, Rescan button disabled on `chrome://extensions/`
- [x] Pre-push hook (typecheck+test+build) gate passed

## Tests added
- `dispatch.test.ts` — `handleRescanPage` dispatches `TRIGGER_RESCAN { forceMitigation: false }`; does not read the testing-mode flag.
- `testing-mode-controls.test.ts` — `initRescanPageButton` disable rules across `chrome://`, `chrome-extension://`, `about:`, missing URL/id; enable on http/https; click dispatches `RESCAN_PAGE` with tab id; toast on send rejection; listener never attached when disabled.
- `popup-accordion.test.ts` (new) — structural assertions over `popup.html` via Vite `?raw` import: Verdict open by default; six others closed; inner ids preserved; testing-mode-card / canary / site-card stay flat (NOT `<details>`); Rescan button in header.

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)