### PR TITLE
feat(phase5-#144): render Hunter findings accordion from hunterSummary

### DIFF
--- a/src/popup/hunter-findings.ts
+++ b/src/popup/hunter-findings.ts
@@ -1,0 +1,65 @@
+export interface HunterSummary {
+  readonly benign: number;
+  readonly uncertain: number;
+  readonly flagged: number;
+  readonly totalChunks: number;
+  readonly skippedChunks: number;
+}
+
+const PLACEHOLDER_LEGACY = 'No hunter data yet.';
+const PLACEHOLDER_SKIPPED = 'Hunter analysis skipped (no chunks).';
+
+interface Row {
+  readonly label: string;
+  readonly value: number;
+  readonly cls: 'benign' | 'uncertain' | 'flagged';
+}
+
+export function renderHunterSummary(
+  body: HTMLElement,
+  summary: HunterSummary | null | undefined,
+): void {
+  if (summary === undefined) {
+    body.replaceChildren();
+    body.className = 'placeholder';
+    body.textContent = PLACEHOLDER_LEGACY;
+    return;
+  }
+  if (summary === null) {
+    body.replaceChildren();
+    body.className = 'placeholder';
+    body.textContent = PLACEHOLDER_SKIPPED;
+    return;
+  }
+
+  const rows: readonly Row[] = [
+    { label: 'Benign', value: summary.benign, cls: 'benign' },
+    { label: 'Uncertain', value: summary.uncertain, cls: 'uncertain' },
+    { label: 'Flagged', value: summary.flagged, cls: 'flagged' },
+  ];
+
+  const ul = document.createElement('ul');
+  ul.className = 'hunter-finding-list';
+  for (const row of rows) {
+    const li = document.createElement('li');
+    li.className = `hunter-finding-row ${row.cls}${row.value === 0 ? ' dim' : ''}`;
+    const label = document.createElement('span');
+    label.className = 'hunter-finding-label';
+    label.textContent = `${row.label}:`;
+    const value = document.createElement('span');
+    value.className = 'hunter-finding-value';
+    value.textContent = String(row.value);
+    li.append(label, value);
+    ul.appendChild(li);
+  }
+
+  const meta = document.createElement('div');
+  meta.className = 'hunter-finding-meta';
+  meta.textContent =
+    summary.skippedChunks > 0
+      ? `${summary.totalChunks} chunks scanned (${summary.skippedChunks} skipped)`
+      : `${summary.totalChunks} chunks scanned`;
+
+  body.replaceChildren(ul, meta);
+  body.className = '';
+}

--- a/src/popup/popup-hunter-findings.test.ts
+++ b/src/popup/popup-hunter-findings.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+
+import { renderHunterSummary } from './hunter-findings';
+
+function makeBody(): HTMLElement {
+  const div = document.createElement('div');
+  div.id = 'hunter-findings-body';
+  div.className = 'placeholder';
+  div.textContent = 'No hunter data yet — N1 pending.';
+  return div;
+}
+
+describe('renderHunterSummary (issue #144)', () => {
+  it('renders three colour-coded rows + meta line for mixed counts', () => {
+    const body = makeBody();
+    renderHunterSummary(body, {
+      benign: 3,
+      uncertain: 1,
+      flagged: 0,
+      totalChunks: 4,
+      skippedChunks: 3,
+    });
+    const rows = body.querySelectorAll('.hunter-finding-row');
+    expect(rows).toHaveLength(3);
+    expect(rows[0].className).toContain('benign');
+    expect(rows[0].textContent).toContain('Benign:');
+    expect(rows[0].textContent).toContain('3');
+    expect(rows[1].className).toContain('uncertain');
+    expect(rows[1].textContent).toContain('1');
+    expect(rows[2].className).toContain('flagged');
+    expect(rows[2].className).toContain('dim');
+    expect(body.querySelector('.hunter-finding-meta')!.textContent).toBe(
+      '4 chunks scanned (3 skipped)',
+    );
+    expect(body.className).toBe('');
+  });
+
+  it('renders all-zero counts with every row dimmed and meta without skipped', () => {
+    const body = makeBody();
+    renderHunterSummary(body, {
+      benign: 0,
+      uncertain: 0,
+      flagged: 0,
+      totalChunks: 0,
+      skippedChunks: 0,
+    });
+    const rows = body.querySelectorAll('.hunter-finding-row');
+    expect(rows).toHaveLength(3);
+    rows.forEach((r) => expect(r.className).toContain('dim'));
+    expect(body.querySelector('.hunter-finding-meta')!.textContent).toBe('0 chunks scanned');
+  });
+
+  it('shows "No hunter data yet." when hunterSummary is undefined (legacy verdict)', () => {
+    const body = makeBody();
+    renderHunterSummary(body, undefined);
+    expect(body.textContent).toBe('No hunter data yet.');
+    expect(body.className).toBe('placeholder');
+    expect(body.querySelector('.hunter-finding-row')).toBeNull();
+  });
+
+  it('shows "Hunter analysis skipped (no chunks)." when hunterSummary is null', () => {
+    const body = makeBody();
+    renderHunterSummary(body, null);
+    expect(body.textContent).toBe('Hunter analysis skipped (no chunks).');
+    expect(body.className).toBe('placeholder');
+  });
+
+  it('replaces previous render on re-call (idempotency)', () => {
+    const body = makeBody();
+    renderHunterSummary(body, {
+      benign: 3,
+      uncertain: 1,
+      flagged: 0,
+      totalChunks: 4,
+      skippedChunks: 0,
+    });
+    renderHunterSummary(body, undefined);
+    expect(body.querySelectorAll('.hunter-finding-row')).toHaveLength(0);
+    expect(body.textContent).toBe('No hunter data yet.');
+  });
+});

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -329,6 +329,30 @@
       color: #6b7280;
       font-style: italic;
     }
+    .hunter-finding-list {
+      list-style: none;
+      padding: 0;
+      margin: 0 0 6px 0;
+    }
+    .hunter-finding-row {
+      display: flex;
+      justify-content: space-between;
+      padding: 2px 0;
+      font-size: 12px;
+    }
+    .hunter-finding-row .hunter-finding-value {
+      font-variant-numeric: tabular-nums;
+      font-weight: 600;
+    }
+    .hunter-finding-row.benign { color: #4ade80; }
+    .hunter-finding-row.uncertain { color: #facc15; }
+    .hunter-finding-row.flagged { color: #f87171; }
+    .hunter-finding-row.dim { opacity: 0.5; }
+    .hunter-finding-meta {
+      color: #6b7280;
+      font-size: 11px;
+      font-style: italic;
+    }
   </style>
 </head>
 <body>

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -22,6 +22,7 @@ import {
   initRescanButton,
   initRescanPageButton,
 } from './testing-mode-controls.js';
+import { renderHunterSummary, type HunterSummary } from './hunter-findings.js';
 
 interface StoredVerdict {
   status: string;
@@ -43,15 +44,10 @@ interface StoredVerdict {
   // Issue #114 (N3) — surfaced in the Mitigations applied accordion.
   // Absent on pre-N3 verdicts; SecurityVerdict has always carried it.
   mitigationsApplied?: readonly string[];
-  // Issue #112 (N1) — compact hunter tier summary. Absent on pre-#112
-  // verdicts; the popup follow-up PR will render it in #hunter-findings-body.
-  hunterSummary?: {
-    benign: number;
-    uncertain: number;
-    flagged: number;
-    totalChunks: number;
-    skippedChunks: number;
-  } | null;
+  // Issue #112 (N1) — compact hunter tier summary, rendered by #144.
+  // Absent on pre-#112 verdicts; null when orchestrator reported
+  // perChunkAnalysis === null (origin-skipped or empty page).
+  hunterSummary?: HunterSummary | null;
 }
 
 function $(id: string): HTMLElement {
@@ -381,6 +377,8 @@ async function loadVerdict(): Promise<void> {
   const mitigationsList = $('mitigations-list');
   mitigationsList.textContent = mitigations.length > 0 ? mitigations.join(', ') : 'None';
   mitigationsList.className = mitigations.length > 0 ? '' : 'placeholder';
+
+  renderHunterSummary($('hunter-findings-body'), verdict.hunterSummary);
 
   // Issue #113 (N2) — rescan-with-prevention button is verdict-aware:
   // only enabled when the current verdict is SUSPICIOUS or COMPROMISED.


### PR DESCRIPTION
Closes #144.

## Summary

- Closes the data → UI loop opened by #112 (PR #143). `hunterSummary` has been persisted on every verdict since the tier-router shipped; the popup was still showing the `No hunter data yet — N1 pending.` placeholder.
- New `src/popup/hunter-findings.ts` exports a pure `renderHunterSummary(body, summary)` that builds a three-row severity-coloured list (green / yellow / red, dimmed when value === 0) plus a meta line (`N chunks scanned [(M skipped)]`). The function lives in its own module so it is unit-testable under jsdom without bootstrapping `popup.ts` side effects.
- Distinguishes the two empty states (per UX call): `undefined` → `No hunter data yet.` (pre-#112 verdict in storage); `null` → `Hunter analysis skipped (no chunks).` (orchestrator signalled `perChunkAnalysis === null` — origin-skipped or empty page).
- `popup.ts` now imports `HunterSummary` as the single source of truth for the `StoredVerdict` field shape and calls `renderHunterSummary` inside `loadVerdict` immediately after the Mitigations block.
- `popup.html` adds eight CSS rules under the existing inline style block; all colours reuse the status-badge tokens that were already in the file (`#4ade80`, `#facc15`, `#f87171`).

## Tests

- +5 jsdom cases in `src/popup/popup-hunter-findings.test.ts`:
  1. mixed counts → 3 rows, correct colour classes, meta with `(N skipped)`
  2. all-zero counts → every row dimmed, meta without skipped
  3. `undefined` summary → legacy fallback string + `placeholder` class
  4. `null` summary → skipped fallback string + `placeholder` class
  5. idempotent re-render (mixed → undefined clears prior rows)
- Total: **558** (was 553).
- `popup-accordion.test.ts` unchanged — its `#hunter-findings-body` presence assertion (line 91) still passes because the empty-state copy is set dynamically; the static HTML wrapper has not changed.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` — 558/558
- [x] `npm run build` — clean
- [ ] Manual smoke (extension reload):
  - [ ] benign page → expect mostly Benign with non-zero `skipped`
  - [ ] flagged fixture page → expect non-zero Uncertain/Flagged
  - [ ] fresh-install (no stored verdict) → `No hunter data yet.`
  - [ ] origin-skipped tab → `Hunter analysis skipped (no chunks).`

## Out of scope

- #145 page-level early-exit optimisation.
- Visual polish beyond the three coloured rows + meta line.
- Reflecting `MAX_CHUNKS_PER_PAGE = 4` in the meta — would over-claim the cap as the page chunk count.

## Related

- #112 / PR #143 (152c83b) — wired Hunters as front-of-pipeline tier-router and started writing `hunterSummary` to storage.
- Verification routine `trig_01KNkDRDCmszwijP4HvqT7jJ` (2026-05-13) — will check the prune-rate + canary tests after both #144 and #145 land.