### PR TITLE
feat(phase5-#145): orchestrator honors HuntReport.shouldSkipProbes for page-level early-exit

### DIFF
--- a/src/policy/storage.ts
+++ b/src/policy/storage.ts
@@ -38,15 +38,19 @@ export async function persistVerdict(verdict: SecurityVerdict): Promise<void> {
       // Issue #112 (N1) — compact tier summary for the popup Hunter findings
       // accordion. Full perChunkAnalysis stays in-memory only (it duplicates
       // probeResults already covered by `flags`); storage gets only counts.
+      // Issue #145 — exclude `notScanned` padding entries from tier counts
+      // (their `tierRouting` is reused from the trigger chunk and would
+      // inflate UNCERTAIN/FLAGGED). Surface separately via `notScannedChunks`.
       hunterSummary:
         verdict.perChunkAnalysis === null
           ? null
           : {
-              benign: verdict.perChunkAnalysis.filter((c) => c.tierRouting.decision === 'BENIGN').length,
-              uncertain: verdict.perChunkAnalysis.filter((c) => c.tierRouting.decision === 'UNCERTAIN').length,
-              flagged: verdict.perChunkAnalysis.filter((c) => c.tierRouting.decision === 'FLAGGED').length,
+              benign: verdict.perChunkAnalysis.filter((c) => !c.notScanned && c.tierRouting.decision === 'BENIGN').length,
+              uncertain: verdict.perChunkAnalysis.filter((c) => !c.notScanned && c.tierRouting.decision === 'UNCERTAIN').length,
+              flagged: verdict.perChunkAnalysis.filter((c) => !c.notScanned && c.tierRouting.decision === 'FLAGGED').length,
               totalChunks: verdict.perChunkAnalysis.length,
-              skippedChunks: verdict.perChunkAnalysis.filter((c) => c.probeResults === null).length,
+              skippedChunks: verdict.perChunkAnalysis.filter((c) => !c.notScanned && c.probeResults === null).length,
+              notScannedChunks: verdict.perChunkAnalysis.filter((c) => c.notScanned === true).length,
             },
     },
   });

--- a/src/popup/hunter-findings.ts
+++ b/src/popup/hunter-findings.ts
@@ -4,7 +4,14 @@ export interface HunterSummary {
   readonly flagged: number;
   readonly totalChunks: number;
   readonly skippedChunks: number;
+  // Issue #145 — count of chunks that were padded out because the orchestrator
+  // exited the chunk loop early on a high-confidence Hunter compromise. Optional
+  // for backwards compatibility with verdicts persisted before this field was
+  // added; absent or zero means no early-exit badge is rendered.
+  readonly notScannedChunks?: number;
 }
+
+const EARLY_EXIT_BADGE_TEXT = 'Early exit: high-confidence compromise';
 
 const PLACEHOLDER_LEGACY = 'No hunter data yet.';
 const PLACEHOLDER_SKIPPED = 'Hunter analysis skipped (no chunks).';
@@ -59,6 +66,13 @@ export function renderHunterSummary(
     summary.skippedChunks > 0
       ? `${summary.totalChunks} chunks scanned (${summary.skippedChunks} skipped)`
       : `${summary.totalChunks} chunks scanned`;
+
+  if ((summary.notScannedChunks ?? 0) > 0) {
+    const badge = document.createElement('span');
+    badge.className = 'hunter-finding-meta-badge';
+    badge.textContent = EARLY_EXIT_BADGE_TEXT;
+    meta.append(' ', badge);
+  }
 
   body.replaceChildren(ul, meta);
   body.className = '';

--- a/src/popup/popup-hunter-findings.test.ts
+++ b/src/popup/popup-hunter-findings.test.ts
@@ -80,3 +80,48 @@ describe('renderHunterSummary (issue #144)', () => {
     expect(body.textContent).toBe('No hunter data yet.');
   });
 });
+
+describe('renderHunterSummary early-exit badge (issue #145)', () => {
+  it('renders early-exit badge when notScannedChunks > 0', () => {
+    const body = makeBody();
+    renderHunterSummary(body, {
+      benign: 1,
+      uncertain: 0,
+      flagged: 1,
+      totalChunks: 4,
+      skippedChunks: 0,
+      notScannedChunks: 2,
+    });
+    const badge = body.querySelector('.hunter-finding-meta-badge');
+    expect(badge).not.toBeNull();
+    expect(badge!.textContent).toBe('Early exit: high-confidence compromise');
+    expect(body.querySelector('.hunter-finding-meta')!.textContent).toContain(
+      '4 chunks scanned',
+    );
+  });
+
+  it('omits early-exit badge when notScannedChunks is 0', () => {
+    const body = makeBody();
+    renderHunterSummary(body, {
+      benign: 3,
+      uncertain: 1,
+      flagged: 0,
+      totalChunks: 4,
+      skippedChunks: 3,
+      notScannedChunks: 0,
+    });
+    expect(body.querySelector('.hunter-finding-meta-badge')).toBeNull();
+  });
+
+  it('omits early-exit badge when notScannedChunks is undefined (legacy verdict)', () => {
+    const body = makeBody();
+    renderHunterSummary(body, {
+      benign: 3,
+      uncertain: 1,
+      flagged: 0,
+      totalChunks: 4,
+      skippedChunks: 3,
+    });
+    expect(body.querySelector('.hunter-finding-meta-badge')).toBeNull();
+  });
+});

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -353,6 +353,16 @@
       font-size: 11px;
       font-style: italic;
     }
+    .hunter-finding-meta-badge {
+      display: inline-block;
+      margin-left: 6px;
+      padding: 1px 6px;
+      border-radius: 3px;
+      background: #7f1d1d;
+      color: #fecaca;
+      font-style: normal;
+      font-weight: 600;
+    }
   </style>
 </head>
 <body>

--- a/src/service-worker/orchestrator.integration.test.ts
+++ b/src/service-worker/orchestrator.integration.test.ts
@@ -474,3 +474,141 @@ describe('analyzeSnapshot evidence-packet routing (issue #118)', () => {
     expect(ctx.capturedMessages.length).toBe(0);
   });
 });
+
+// Issue #145 — orchestrator honors HuntReport.shouldSkipProbes for
+// page-level early-exit on high-confidence compromise.
+
+function buildEarlyExitHuntReport(): HuntReport {
+  const results: HunterResult[] = [
+    {
+      hunterName: 'spider',
+      matched: true,
+      flags: ['spider:override_instruction'],
+      score: 40,
+      confidence: 1,
+      features: [],
+      errorMessage: null,
+    },
+    {
+      hunterName: 'hawk',
+      matched: true,
+      flags: ['hawk:injection_likely'],
+      score: 70,
+      confidence: 0.8,
+      features: [],
+      errorMessage: null,
+    },
+  ];
+  return {
+    results,
+    totalScore: 110,
+    maxConfidence: 1,
+    shouldSkipProbes: true,
+    flags: ['spider:override_instruction', 'hawk:injection_likely'],
+    aggregateError: null,
+  };
+}
+
+describe('analyzeSnapshot early-exit on shouldSkipProbes (issue #145)', () => {
+  beforeEach(() => {
+    runHuntersMock.mockReset();
+    chunkTextMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('short-circuits the chunk loop when shouldSkipProbes fires on chunk 0', async () => {
+    chunkTextMock.mockResolvedValue([
+      buildChunk(0, 'a'),
+      buildChunk(1, 'b'),
+      buildChunk(2, 'c'),
+      buildChunk(3, 'd'),
+    ]);
+    runHuntersMock.mockResolvedValueOnce(buildEarlyExitHuntReport());
+    const ctx = setupChrome([SAMPLE_PROBE_RESULT]);
+
+    const verdict = await analyzeSnapshot(301, snapshotFixture());
+
+    expect(ctx.runProbesCalls.length).toBe(1);
+    expect(ctx.runProbesCalls[0]!.msg.chunkIndex).toBe(0);
+    expect(runHuntersMock).toHaveBeenCalledTimes(1);
+
+    expect(verdict.perChunkAnalysis!.length).toBe(4);
+    expect(verdict.perChunkAnalysis![0]!.probeResults).not.toBeNull();
+    expect(verdict.perChunkAnalysis![0]!.notScanned).toBeUndefined();
+    for (let i = 1; i < 4; i += 1) {
+      const entry = verdict.perChunkAnalysis![i]!;
+      expect(entry.index).toBe(i);
+      expect(entry.probeResults).toBeNull();
+      expect(entry.notScanned).toBe(true);
+    }
+
+    expect(verdict.analysisError).toBe('early_exit_high_confidence');
+  });
+
+  it('short-circuits mid-page when shouldSkipProbes fires on chunk 2 of 4', async () => {
+    chunkTextMock.mockResolvedValue([
+      buildChunk(0, 'a'),
+      buildChunk(1, 'b'),
+      buildChunk(2, 'c'),
+      buildChunk(3, 'd'),
+    ]);
+    runHuntersMock
+      .mockResolvedValueOnce(
+        buildHuntReport([
+          { name: 'spider', matched: true },
+          { name: 'hawk', matched: false },
+        ]),
+      )
+      .mockResolvedValueOnce(
+        buildHuntReport([
+          { name: 'spider', matched: true },
+          { name: 'hawk', matched: false },
+        ]),
+      )
+      .mockResolvedValueOnce(buildEarlyExitHuntReport());
+    const ctx = setupChrome([SAMPLE_PROBE_RESULT]);
+
+    const verdict = await analyzeSnapshot(302, snapshotFixture());
+
+    expect(ctx.runProbesCalls.length).toBe(3);
+    expect(ctx.runProbesCalls.map((c) => c.msg.chunkIndex)).toEqual([0, 1, 2]);
+    expect(runHuntersMock).toHaveBeenCalledTimes(3);
+
+    expect(verdict.perChunkAnalysis!.length).toBe(4);
+    expect(verdict.perChunkAnalysis![0]!.notScanned).toBeUndefined();
+    expect(verdict.perChunkAnalysis![1]!.notScanned).toBeUndefined();
+    expect(verdict.perChunkAnalysis![2]!.notScanned).toBeUndefined();
+    expect(verdict.perChunkAnalysis![3]!.notScanned).toBe(true);
+    expect(verdict.perChunkAnalysis![3]!.probeResults).toBeNull();
+
+    expect(verdict.analysisError).toBe('early_exit_high_confidence');
+  });
+
+  it('does not early-exit when shouldSkipProbes is false on every chunk', async () => {
+    chunkTextMock.mockResolvedValue([
+      buildChunk(0, 'a'),
+      buildChunk(1, 'b'),
+      buildChunk(2, 'c'),
+      buildChunk(3, 'd'),
+    ]);
+    runHuntersMock.mockResolvedValue(
+      buildHuntReport([
+        { name: 'spider', matched: true },
+        { name: 'hawk', matched: false },
+      ]),
+    );
+    const ctx = setupChrome([SAMPLE_PROBE_RESULT]);
+
+    const verdict = await analyzeSnapshot(303, snapshotFixture());
+
+    expect(ctx.runProbesCalls.length).toBe(4);
+    expect(verdict.perChunkAnalysis!.length).toBe(4);
+    verdict.perChunkAnalysis!.forEach((entry) => {
+      expect(entry.notScanned).toBeUndefined();
+    });
+    expect(verdict.analysisError).not.toBe('early_exit_high_confidence');
+  });
+});

--- a/src/service-worker/orchestrator.ts
+++ b/src/service-worker/orchestrator.ts
@@ -2,7 +2,7 @@ import type { PageSnapshot } from '@/types/snapshot.js';
 import type { ProbeResult, SecurityVerdict, WebGPUAdapterMode, ChunkAnalysis } from '@/types/verdict.js';
 import type { PageStamp } from '@/types/page-stamp.js';
 import type { RunProbesMessage, ProbeResultsMessage } from '@/types/messages.js';
-import { MAX_CHUNKS_PER_PAGE } from '@/shared/constants.js';
+import { MAX_CHUNKS_PER_PAGE, EARLY_EXIT_ANALYSIS_ERROR } from '@/shared/constants.js';
 import { chunkText } from '@/hunters/hawk/chunking.js';
 import { runHunters } from '@/hunters/hunt-runner.js';
 import { spiderHunter } from '@/hunters/spider/index.js';
@@ -223,6 +223,11 @@ export async function analyzeSnapshot(
     const perChunkAnalysis: ChunkAnalysis[] = [];
     let canaryId: string | null = null;
     let webgpuAdapterMode: WebGPUAdapterMode | null = null;
+    // Issue #145 — flipped when a chunk's HuntReport.shouldSkipProbes is true,
+    // signalling that subsequent chunks were padded out and the chunk loop
+    // exited early. Folded into aggregateError so popup/storage callers can
+    // distinguish early-exit from a normal completion.
+    let earlyExited = false;
     for (let index = 0; index < chunks.length; index += 1) {
       // Issue #11 — check the signal before dispatching each chunk. A new
       // PAGE_SNAPSHOT arriving mid-analysis flips this flag; reject rather
@@ -283,12 +288,38 @@ export async function analyzeSnapshot(
       if (webgpuAdapterMode === null && chunkAdapterMode !== null) {
         webgpuAdapterMode = chunkAdapterMode;
       }
+
+      // Issue #145 — page-level early-exit. The Hunter pre-pass on this chunk
+      // hit compromise-band confidence+score (HuntReport.shouldSkipProbes);
+      // any further LLM probing is by definition redundant. Pad the remaining
+      // chunks with NOT_SCANNED entries so perChunkAnalysis.length stays
+      // honest (the existing length === chunks.length invariant), then break.
+      if (huntReport.shouldSkipProbes) {
+        const padded = chunks.length - index - 1;
+        for (let pad = index + 1; pad < chunks.length; pad += 1) {
+          perChunkAnalysis.push({
+            index: pad,
+            contentHash: '',
+            tierRouting,
+            probeResults: null,
+            notScanned: true,
+          });
+        }
+        earlyExited = true;
+        log.info(
+          `Chunk ${index}: shouldSkipProbes — early-exit, padded ${padded} chunk(s) as NOT_SCANNED`,
+        );
+        break;
+      }
     }
 
     const mergedResults = mergeProbeResults(allChunkResults);
     const aggregateError = mergeErrors(
-      computeAggregateError(mergedResults),
-      capped ? `chunk_count_capped (${allChunks.length} chunks → kept first ${MAX_CHUNKS_PER_PAGE})` : null,
+      mergeErrors(
+        computeAggregateError(mergedResults),
+        capped ? `chunk_count_capped (${allChunks.length} chunks → kept first ${MAX_CHUNKS_PER_PAGE})` : null,
+      ),
+      earlyExited ? EARLY_EXIT_ANALYSIS_ERROR : null,
     );
     const behavioralFlags = analyzeBehavior(mergedResults);
     const verdict0 = evaluatePolicy(

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -238,3 +238,12 @@ export const STORAGE_KEY_INSTALL_SECRET = 'honeyllm:install-secret';
  * `v !== STAMP_VERSION` as `unknown-version` before touching crypto.
  */
 export const STAMP_VERSION = 1 as const;
+
+/**
+ * Issue #145 — analysisError literal set when the orchestrator short-circuits
+ * the chunk loop because a HuntReport reached compromise-band confidence+score
+ * (HuntReport.shouldSkipProbes). Centralised here so producer (orchestrator)
+ * and consumers (popup, future telemetry) share one source of truth and can
+ * match by full string equality.
+ */
+export const EARLY_EXIT_ANALYSIS_ERROR = 'early_exit_high_confidence';

--- a/src/types/verdict.ts
+++ b/src/types/verdict.ts
@@ -39,6 +39,12 @@ export interface ChunkAnalysis {
   readonly tierRouting: TierRouting;
   // Null when the chunk was routed BENIGN and probes were intentionally skipped.
   readonly probeResults: readonly ProbeResult[] | null;
+  // Issue #145 — true when the chunk loop short-circuited on a prior chunk's
+  // HuntReport.shouldSkipProbes and this entry was padded out so
+  // perChunkAnalysis.length === chunks.length. Hunters never ran on this
+  // chunk; probeResults is null. tierRouting is reused from the trigger
+  // chunk and should be excluded from hunterSummary tier counts.
+  readonly notScanned?: true;
 }
 
 export interface BehavioralFlags {


### PR DESCRIPTION
## Summary

- Completes the #112 keystone trio (#144 popup render ✓, #118 evidence probes ✓, **#145 = final piece**)
- Orchestrator now short-circuits the chunk loop when a chunk's `HuntReport.shouldSkipProbes` fires (compromise-band confidence ≥ 0.75 + score ≥ 65 on at least one Hunter)
- Remaining chunks are padded as `NOT_SCANNED` so the `perChunkAnalysis.length === chunks.length` invariant stays honest; `EARLY_EXIT_ANALYSIS_ERROR` is folded into the verdict; popup renders an "Early exit: high-confidence compromise" badge in the Hunter findings meta line
- Saves up to N-1 chunks × (probes + evidence-review + summarization) of inference budget per high-confidence-COMPROMISED page

Closes #145

## Design choices

- **`TierDecision` left untouched** — added optional `notScanned?: true` field on `ChunkAnalysis` instead. Padded entries are not router decisions; polluting the union would silently broaden every existing exhaustive switch. Storage filters now exclude `notScanned` entries from tier counts to prevent trigger-chunk routing inflation.
- **`EARLY_EXIT_ANALYSIS_ERROR = 'early_exit_high_confidence'`** centralised in `src/shared/constants.ts`. Popup matches by full equality (no payload).
- **`hunterSummary` extension** — new `notScannedChunks: number` field, distinct from `skippedChunks` (which means BENIGN→probes-skipped). Optional on the popup interface; pre-#145 persisted blobs render with no badge via `?? 0`.
- **`mergeErrors` signature unchanged** — nest two calls instead of going variadic. Smaller diff, all existing call sites untouched.
- **Popup variant** — sibling `<span class="hunter-finding-meta-badge">` inside the existing `.hunter-finding-meta` div, mirrors the #144 meta-line pattern. New CSS rule inline in `popup.html`.

## Files changed

| File | Change |
|---|---|
| `src/shared/constants.ts` | + `EARLY_EXIT_ANALYSIS_ERROR` literal |
| `src/types/verdict.ts` | + `ChunkAnalysis.notScanned?: true` |
| `src/service-worker/orchestrator.ts` | early-exit branch + nested `mergeErrors` |
| `src/policy/storage.ts` | `!c.notScanned` filter guards + `notScannedChunks` count |
| `src/popup/hunter-findings.ts` | `HunterSummary.notScannedChunks?` + badge render |
| `src/popup/popup.html` | `.hunter-finding-meta-badge` CSS rule |
| `src/service-worker/orchestrator.integration.test.ts` | +3 tests |
| `src/popup/popup-hunter-findings.test.ts` | +3 tests |

## Test plan

- [x] 3 orchestrator integration tests (RED → GREEN):
  - `short-circuits the chunk loop when shouldSkipProbes fires on chunk 0` (4 chunks → 1 probe call, 3 padded)
  - `short-circuits mid-page when shouldSkipProbes fires on chunk 2 of 4` (3 probe calls, chunk 3 padded)
  - `does not early-exit when shouldSkipProbes is false on every chunk` (regression guard)
- [x] 3 popup hunter-findings tests (RED → GREEN):
  - `renders early-exit badge when notScannedChunks > 0`
  - `omits early-exit badge when notScannedChunks is 0`
  - `omits early-exit badge when notScannedChunks is undefined (legacy verdict)`
- [x] Existing test at `orchestrator.integration.test.ts:294` (`perChunkAnalysis.length always equals chunks.length`) stays green unmodified
- [x] `npm run typecheck` — clean
- [x] `npm test` — **582 / 582 passing** (+6 over 576 baseline)
- [x] `npm run build` — clean
- [ ] Manual smoke (post-merge): load `dist/`, visit a known-COMPROMISED fixture, confirm SW console early-exit log + popup badge
- [ ] Manual regression smoke: visit benign page, confirm badge absent

## Risks (covered)

- **Trigger-chunk routing inflation**: padded entries reuse the trigger's `tierRouting` (UNCERTAIN/FLAGGED). Storage filters now guard with `!c.notScanned` on benign/uncertain/flagged/skippedChunks counts.
- **Pre-#145 persisted verdicts**: lack `notScannedChunks`. Popup uses `?? 0`; no migration needed.
- **Page stamp (#117)**: chunk-loop break leaves stamp pipeline (`ensureInstallSecret` + `generateStamp`) intact at lines 311-318.
- **Testing-mode (#113)**: gates downstream `APPLY_MITIGATION` only; not affected.
- **Evidence-review (#118)**: lives inside `runChunkProbes`. Skipping subsequent chunks is correct — `shouldSkipProbes` only fires when Hunters already have compromise-band evidence on the trigger chunk, so further LLM probing is by definition redundant.