### PR TITLE
feat(phase5-#119): language detection service — Chrome LanguageDetector API

### DIFF
--- a/src/hunters/hawk/chunking.ts
+++ b/src/hunters/hawk/chunking.ts
@@ -18,6 +18,7 @@
  */
 
 import { MAX_CHUNK_CHARS } from '@/shared/constants.js';
+import { sha256Hex } from '@/shared/hash.js';
 import type { Chunk } from '@/types/chunk.js';
 
 const DEFAULT_WINDOW = 50;
@@ -45,15 +46,6 @@ export function chunkByWords(
 
 interface ChunkTextOptions {
   readonly maxChars?: number;
-}
-
-async function sha256Hex(content: string): Promise<string> {
-  const encoder = new TextEncoder();
-  const data = encoder.encode(content);
-  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
-  return Array.from(new Uint8Array(hashBuffer))
-    .map((b) => b.toString(16).padStart(2, '0'))
-    .join('');
 }
 
 const SENTENCE_DELIMITERS = ['. ', '! ', '? ', '.\n'] as const;

--- a/src/hunters/hawk/language-router.test.ts
+++ b/src/hunters/hawk/language-router.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  detectLanguage,
+  MIN_DETECT_CHARS,
+  _resetForTesting,
+  type LanguageRouterDeps,
+} from './language-router.js';
+import type { LanguageDetectionResult } from '@/types/messages.js';
+
+const EN_TEXT =
+  'The quick brown fox jumps over the lazy dog every single morning before dawn.';
+const ES_TEXT =
+  'El veloz murciélago hindú comía feliz cardillo y kiwi mientras navegaba el río oscuro.';
+const ZH_TEXT = '中国是一个拥有悠久历史和灿烂文化的伟大国家位于亚洲东部濒临太平洋。';
+
+function makeDeps(
+  resultByText: (text: string) => LanguageDetectionResult,
+): { deps: LanguageRouterDeps; spy: ReturnType<typeof vi.fn> } {
+  const spy = vi.fn(async (text: string) => resultByText(text));
+  return { deps: { sendDetect: spy }, spy };
+}
+
+describe('detectLanguage', () => {
+  beforeEach(() => {
+    _resetForTesting();
+  });
+
+  afterEach(() => {
+    _resetForTesting();
+  });
+
+  it('returns und for empty input without invoking the detector', async () => {
+    const { deps, spy } = makeDeps(() => {
+      throw new Error('should not be called');
+    });
+    const result = await detectLanguage('', deps);
+    expect(result).toEqual({ lang: 'und', confidence: 0, source: 'chrome-api' });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it(`returns und for text shorter than MIN_DETECT_CHARS (${MIN_DETECT_CHARS})`, async () => {
+    const { deps, spy } = makeDeps(() => {
+      throw new Error('should not be called');
+    });
+    const short = 'a'.repeat(MIN_DETECT_CHARS - 1);
+    const result = await detectLanguage(short, deps);
+    expect(result.lang).toBe('und');
+    expect(result.source).toBe('chrome-api');
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('returns English with chrome-api source', async () => {
+    const { deps } = makeDeps(() => ({
+      lang: 'en',
+      confidence: 0.97,
+      source: 'chrome-api',
+    }));
+    const result = await detectLanguage(EN_TEXT, deps);
+    expect(result.lang).toBe('en');
+    expect(result.confidence).toBeGreaterThan(0.9);
+    expect(result.source).toBe('chrome-api');
+  });
+
+  it('returns Spanish with chrome-api source', async () => {
+    const { deps } = makeDeps(() => ({
+      lang: 'es',
+      confidence: 0.94,
+      source: 'chrome-api',
+    }));
+    const result = await detectLanguage(ES_TEXT, deps);
+    expect(result.lang).toBe('es');
+    expect(result.source).toBe('chrome-api');
+  });
+
+  it('returns Chinese (zh) with chrome-api source', async () => {
+    const { deps } = makeDeps(() => ({
+      lang: 'zh',
+      confidence: 0.99,
+      source: 'chrome-api',
+    }));
+    const result = await detectLanguage(ZH_TEXT, deps);
+    expect(result.lang).toBe('zh');
+    expect(result.source).toBe('chrome-api');
+  });
+
+  it('caches by content: same text twice → detector invoked once', async () => {
+    const { deps, spy } = makeDeps(() => ({
+      lang: 'en',
+      confidence: 0.97,
+      source: 'chrome-api',
+    }));
+    await detectLanguage(EN_TEXT, deps);
+    await detectLanguage(EN_TEXT, deps);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('cache miss for distinct inputs: detector invoked twice', async () => {
+    const { deps, spy } = makeDeps((text) =>
+      text === EN_TEXT
+        ? { lang: 'en', confidence: 0.95, source: 'chrome-api' }
+        : { lang: 'es', confidence: 0.92, source: 'chrome-api' },
+    );
+    await detectLanguage(EN_TEXT, deps);
+    await detectLanguage(ES_TEXT, deps);
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it('preserves xlm-roberta source on the fallback path', async () => {
+    const { deps } = makeDeps(() => ({
+      lang: 'fr',
+      confidence: 0.81,
+      source: 'xlm-roberta',
+    }));
+    const longFrench = 'Voici un texte assez long pour franchir le seuil de détection.';
+    const result = await detectLanguage(longFrench, deps);
+    expect(result.source).toBe('xlm-roberta');
+  });
+
+  it('returns und with chrome-api source when the detector rejects (graceful degradation)', async () => {
+    const { deps } = makeDeps(() => {
+      throw new Error('detector exploded');
+    });
+    const result = await detectLanguage(EN_TEXT, deps);
+    expect(result.lang).toBe('und');
+    expect(result.confidence).toBe(0);
+    expect(result.source).toBe('chrome-api');
+  });
+
+  it('does not cache failed lookups: a second call after rejection retries', async () => {
+    let attempt = 0;
+    const spy = vi.fn(async () => {
+      attempt += 1;
+      if (attempt === 1) throw new Error('first attempt fails');
+      return { lang: 'en', confidence: 0.95, source: 'chrome-api' as const };
+    });
+    const deps: LanguageRouterDeps = { sendDetect: spy };
+    const first = await detectLanguage(EN_TEXT, deps);
+    expect(first.lang).toBe('und');
+    const second = await detectLanguage(EN_TEXT, deps);
+    expect(second.lang).toBe('en');
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it('_resetForTesting clears the cache', async () => {
+    const { deps, spy } = makeDeps(() => ({
+      lang: 'en',
+      confidence: 0.97,
+      source: 'chrome-api',
+    }));
+    await detectLanguage(EN_TEXT, deps);
+    _resetForTesting();
+    await detectLanguage(EN_TEXT, deps);
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it('single-flight: concurrent calls for the same text invoke detector once', async () => {
+    let resolveDetect!: (r: LanguageDetectionResult) => void;
+    const spy = vi.fn(
+      () =>
+        new Promise<LanguageDetectionResult>((resolve) => {
+          resolveDetect = resolve;
+        }),
+    );
+    const deps: LanguageRouterDeps = { sendDetect: spy };
+    const a = detectLanguage(EN_TEXT, deps);
+    const b = detectLanguage(EN_TEXT, deps);
+    // Wait for both calls to register in the inflight map (each awaits
+    // sha256Hex first), then resolve the shared detector promise.
+    await vi.waitFor(() => expect(spy).toHaveBeenCalledTimes(1));
+    resolveDetect({ lang: 'en', confidence: 0.95, source: 'chrome-api' });
+    const [ra, rb] = await Promise.all([a, b]);
+    expect(ra).toEqual(rb);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses chrome.runtime.sendMessage when deps are omitted (production default)', async () => {
+    const sendMessage = vi.fn(async (msg: unknown) => {
+      const m = msg as { type: string; text: string };
+      expect(m.type).toBe('DETECT_LANGUAGE');
+      expect(typeof m.text).toBe('string');
+      return {
+        type: 'LANGUAGE_RESULT' as const,
+        result: { lang: 'en', confidence: 0.95, source: 'chrome-api' as const },
+      };
+    });
+    vi.stubGlobal('chrome', { runtime: { sendMessage } });
+    try {
+      const result = await detectLanguage(EN_TEXT);
+      expect(result).toEqual({ lang: 'en', confidence: 0.95, source: 'chrome-api' });
+      expect(sendMessage).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});

--- a/src/hunters/hawk/language-router.ts
+++ b/src/hunters/hawk/language-router.ts
@@ -1,0 +1,66 @@
+import { sha256Hex } from '@/shared/hash.js';
+import type {
+  DetectLanguageMessage,
+  LanguageDetectionResult,
+  LanguageResultMessage,
+} from '@/types/messages.js';
+
+export type { LanguageDetectionResult } from '@/types/messages.js';
+
+export const MIN_DETECT_CHARS = 20;
+
+const UND_CHROME: LanguageDetectionResult = {
+  lang: 'und',
+  confidence: 0,
+  source: 'chrome-api',
+};
+
+export interface LanguageRouterDeps {
+  readonly sendDetect: (text: string) => Promise<LanguageDetectionResult>;
+}
+
+const cache = new Map<string, LanguageDetectionResult>();
+const inflight = new Map<string, Promise<LanguageDetectionResult>>();
+
+async function defaultSendDetect(text: string): Promise<LanguageDetectionResult> {
+  const message: DetectLanguageMessage = { type: 'DETECT_LANGUAGE', text };
+  const reply = (await chrome.runtime.sendMessage(message)) as LanguageResultMessage;
+  return reply.result;
+}
+
+const defaultDeps: LanguageRouterDeps = { sendDetect: defaultSendDetect };
+
+export async function detectLanguage(
+  text: string,
+  deps: LanguageRouterDeps = defaultDeps,
+): Promise<LanguageDetectionResult> {
+  if (text.length < MIN_DETECT_CHARS) return UND_CHROME;
+
+  const key = await sha256Hex(text);
+
+  const cached = cache.get(key);
+  if (cached !== undefined) return cached;
+
+  const pending = inflight.get(key);
+  if (pending !== undefined) return pending;
+
+  const promise = (async () => {
+    try {
+      const result = await deps.sendDetect(text);
+      cache.set(key, result);
+      return result;
+    } catch {
+      return UND_CHROME;
+    } finally {
+      inflight.delete(key);
+    }
+  })();
+
+  inflight.set(key, promise);
+  return promise;
+}
+
+export function _resetForTesting(): void {
+  cache.clear();
+  inflight.clear();
+}

--- a/src/offscreen/index.ts
+++ b/src/offscreen/index.ts
@@ -1,5 +1,6 @@
 import type {
   HoneyLLMMessage,
+  LanguageResultMessage,
   ProbeResultsMessage,
   ProbeDirectResultMessage,
 } from '@/types/messages.js';
@@ -8,6 +9,7 @@ import { isTestModeEnabled } from '@/shared/test-mode.js';
 import { initEngine, generateCompletion, getLoadedModelId, getLoadedCanaryId, getWebGPUAdapterInfo } from './engine.js';
 import { runProbes } from './probe-runner.js';
 import { runDirectProbe, type DirectProbeDeps } from './direct-probe.js';
+import { handleDetectLanguage } from './lang-detect-engine.js';
 
 const log = createLogger('Offscreen');
 
@@ -88,6 +90,27 @@ chrome.runtime.onMessage.addListener((message: HoneyLLMMessage, _sender, sendRes
       .catch((err: unknown) => {
         log.error('runDirectProbe rejected unexpectedly', err);
         sendResponse(buildDirectRejectionResult(message, err));
+      });
+    return true; // keep channel open for async sendResponse
+  }
+
+  // Issue #119 (N14a) — language detection RPC. Replies via sendResponse
+  // so the SW-side `language-router.ts` can `await chrome.runtime
+  // .sendMessage(...)`. handleDetectLanguage is total: it never throws,
+  // returning a graceful `und` result on any path.
+  if (message.type === 'DETECT_LANGUAGE') {
+    handleDetectLanguage(message.text)
+      .then((result) => {
+        const reply: LanguageResultMessage = { type: 'LANGUAGE_RESULT', result };
+        sendResponse(reply);
+      })
+      .catch((err: unknown) => {
+        log.error('handleDetectLanguage rejected unexpectedly', err);
+        const reply: LanguageResultMessage = {
+          type: 'LANGUAGE_RESULT',
+          result: { lang: 'und', confidence: 0, source: 'chrome-api' },
+        };
+        sendResponse(reply);
       });
     return true; // keep channel open for async sendResponse
   }

--- a/src/offscreen/lang-detect-engine.test.ts
+++ b/src/offscreen/lang-detect-engine.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { handleDetectLanguage, _resetForTesting } from './lang-detect-engine.js';
+
+describe('handleDetectLanguage', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    _resetForTesting();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    _resetForTesting();
+  });
+
+  it('falls through to xlm-roberta stub when LanguageDetector is absent', async () => {
+    const result = await handleDetectLanguage('A long enough English sentence to detect.');
+    expect(result).toEqual({ lang: 'und', confidence: 0, source: 'xlm-roberta' });
+  });
+
+  it('falls through when availability returns "unavailable"', async () => {
+    vi.stubGlobal('LanguageDetector', {
+      availability: vi.fn(async () => 'unavailable'),
+      create: vi.fn(),
+    });
+    const result = await handleDetectLanguage('A long enough English sentence to detect.');
+    expect(result.source).toBe('xlm-roberta');
+    expect(result.lang).toBe('und');
+  });
+
+  it('falls through when create() throws', async () => {
+    vi.stubGlobal('LanguageDetector', {
+      availability: vi.fn(async () => 'available'),
+      create: vi.fn(async () => {
+        throw new Error('create exploded');
+      }),
+    });
+    const result = await handleDetectLanguage('A long enough English sentence to detect.');
+    expect(result.source).toBe('xlm-roberta');
+    expect(result.lang).toBe('und');
+  });
+
+  it('returns top-ranked Chrome detection result on the happy path', async () => {
+    const detectSpy = vi.fn(async () => [
+      { detectedLanguage: 'en', confidence: 0.97 },
+      { detectedLanguage: 'fr', confidence: 0.02 },
+    ]);
+    vi.stubGlobal('LanguageDetector', {
+      availability: vi.fn(async () => 'available'),
+      create: vi.fn(async () => ({ detect: detectSpy })),
+    });
+    const result = await handleDetectLanguage('A long enough English sentence to detect.');
+    expect(result).toEqual({ lang: 'en', confidence: 0.97, source: 'chrome-api' });
+    expect(detectSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/offscreen/lang-detect-engine.ts
+++ b/src/offscreen/lang-detect-engine.ts
@@ -1,0 +1,107 @@
+import { createLogger } from '@/shared/logger.js';
+import type { LanguageDetectionResult } from '@/types/messages.js';
+
+const log = createLogger('LangDetect');
+
+const UND_CHROME: LanguageDetectionResult = {
+  lang: 'und',
+  confidence: 0,
+  source: 'chrome-api',
+};
+
+const UND_XLM: LanguageDetectionResult = {
+  lang: 'und',
+  confidence: 0,
+  source: 'xlm-roberta',
+};
+
+interface ChromeLanguageDetectorResult {
+  readonly detectedLanguage: string;
+  readonly confidence: number;
+}
+
+interface ChromeLanguageDetector {
+  detect(text: string): Promise<readonly ChromeLanguageDetectorResult[]>;
+}
+
+interface ChromeLanguageDetectorAPI {
+  availability(): Promise<'available' | 'downloadable' | 'downloading' | 'unavailable'>;
+  create(): Promise<ChromeLanguageDetector>;
+}
+
+function getChromeLanguageDetector(): ChromeLanguageDetectorAPI | null {
+  const api = (globalThis as unknown as { LanguageDetector?: ChromeLanguageDetectorAPI })
+    .LanguageDetector;
+  return api ?? null;
+}
+
+let chromeDetectorInstance: ChromeLanguageDetector | null = null;
+let chromeDetectorInitPromise: Promise<ChromeLanguageDetector | null> | null = null;
+
+async function getOrInitChromeDetector(
+  api: ChromeLanguageDetectorAPI,
+): Promise<ChromeLanguageDetector | null> {
+  if (chromeDetectorInstance !== null) return chromeDetectorInstance;
+  if (chromeDetectorInitPromise !== null) return chromeDetectorInitPromise;
+
+  chromeDetectorInitPromise = (async () => {
+    try {
+      const availability = await api.availability();
+      if (availability === 'unavailable') return null;
+      const created = await api.create();
+      chromeDetectorInstance = created;
+      return created;
+    } catch (err) {
+      log.warn('LanguageDetector.create failed', err);
+      return null;
+    } finally {
+      chromeDetectorInitPromise = null;
+    }
+  })();
+
+  return chromeDetectorInitPromise;
+}
+
+async function getOrInitXlm(): Promise<never> {
+  // Issue #119 ships the Chrome `LanguageDetector` path only. The
+  // transformers.js xlm-roberta fallback is tracked in a follow-up
+  // issue (filed after #119 merges). Until that ships, this throws so
+  // the message handler returns the `und/xlm-roberta` graceful-
+  // degradation result when the Chrome API is absent.
+  throw new Error('xlm-roberta path not yet implemented — see follow-up issue');
+}
+
+export async function handleDetectLanguage(text: string): Promise<LanguageDetectionResult> {
+  const api = getChromeLanguageDetector();
+  if (api !== null) {
+    try {
+      const detector = await getOrInitChromeDetector(api);
+      if (detector !== null) {
+        const results = await detector.detect(text);
+        const top = results[0];
+        if (top !== undefined && top.detectedLanguage.length > 0) {
+          return {
+            lang: top.detectedLanguage,
+            confidence: top.confidence,
+            source: 'chrome-api',
+          };
+        }
+        return UND_CHROME;
+      }
+    } catch (err) {
+      log.warn('Chrome LanguageDetector path failed', err);
+    }
+  }
+
+  try {
+    await getOrInitXlm();
+  } catch {
+    // Expected: stub always throws until the xlm-roberta follow-up ships.
+  }
+  return UND_XLM;
+}
+
+export function _resetForTesting(): void {
+  chromeDetectorInstance = null;
+  chromeDetectorInitPromise = null;
+}

--- a/src/shared/hash.ts
+++ b/src/shared/hash.ts
@@ -1,0 +1,8 @@
+export async function sha256Hex(content: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(content);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  return Array.from(new Uint8Array(hashBuffer))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -32,7 +32,14 @@ export type MessageType =
   // Issue #114 (N3) — generic popup rescan. Re-runs the orchestrator
   // pipeline against the active tab without forcing mitigations; the
   // testing-mode gate in dispatchVerdictMessages applies normally.
-  | 'RESCAN_PAGE';
+  | 'RESCAN_PAGE'
+  // Issue #119 (N14a) — language detection RPC. SW → offscreen request
+  // with the chunk text; offscreen replies via sendResponse with a
+  // LanguageResultMessage. The Chrome `LanguageDetector` API runs in
+  // offscreen (DOM context); the SW-side `language-router.ts` caches by
+  // sha256(text) so a repeated chunk doesn't re-cross the boundary.
+  | 'DETECT_LANGUAGE'
+  | 'LANGUAGE_RESULT';
 
 interface BaseMessage {
   readonly type: MessageType;
@@ -218,6 +225,28 @@ export interface RescanPageMessage extends BaseMessage {
   readonly tabId: number;
 }
 
+// Issue #119 (N14a) — language detection RPC. The `source` field
+// distinguishes the Chrome built-in `LanguageDetector` API path from the
+// transformers.js xlm-roberta fallback. `lang` follows the Chrome API's
+// BCP-47 shape (`en`, `es`, `zh`, …); `und` is the ISO 639-3 sentinel
+// for "undetermined" used when both detection paths fail or input is too
+// short to be meaningful.
+export interface LanguageDetectionResult {
+  readonly lang: string;
+  readonly confidence: number;
+  readonly source: 'chrome-api' | 'xlm-roberta';
+}
+
+export interface DetectLanguageMessage extends BaseMessage {
+  readonly type: 'DETECT_LANGUAGE';
+  readonly text: string;
+}
+
+export interface LanguageResultMessage extends BaseMessage {
+  readonly type: 'LANGUAGE_RESULT';
+  readonly result: LanguageDetectionResult;
+}
+
 export type HoneyLLMMessage =
   | PageSnapshotMessage
   | RunProbesMessage
@@ -236,4 +265,6 @@ export type HoneyLLMMessage =
   | VerifyStampResultMessage
   | RescanWithMitigationMessage
   | TriggerRescanMessage
-  | RescanPageMessage;
+  | RescanPageMessage
+  | DetectLanguageMessage
+  | LanguageResultMessage;


### PR DESCRIPTION
## Summary

- Ships **language-detection service** at `src/hunters/hawk/language-router.ts` with public `detectLanguage(text): Promise<LanguageDetectionResult>` API.
- Wires the **Chrome built-in `LanguageDetector` API** path end-to-end via offscreen RPC (feature-detect → `availability()` → `create()` → `detect()`).
- transformers.js xlm-roberta fallback is **stubbed** with a clear TODO; throws are caught and the handler returns `und/xlm-roberta` graceful-degradation. Tracked in a follow-up issue (filed after merge).

Closes #119.

## Scope decision

The original issue's AC2 calls for a transformers.js fallback for non-Chrome contexts (Browse MCP server, Local Proxy). Those consumers don't exist in the repo yet, and the fallback would add ~280MB runtime model download, ~2.5MB JS, CSP `worker-src` changes, and CDN trust concerns. After ratification with the user (AskUserQuestion in the planning round), this PR ships **Chrome-API-only with the fallback skeleton-stubbed** so the service's API contract is in place for future N4b/N1 consumers without paying the bundle/CDN/CSP costs before any consumer needs them.

A follow-up issue will be filed after this merges to track the real transformers.js implementation.

## Architecture

```
Service Worker:                                  Offscreen:
  hunters/hawk/language-router.ts  [NEW]           lang-detect-engine.ts  [NEW]
    detectLanguage(text)                             handleDetectLanguage(text)
      ├─ < MIN_DETECT_CHARS → und/chrome-api          ├─ 'LanguageDetector' in self?
      ├─ cache hit → return                           │   ├─ availability() != 'unavailable'?
      ├─ inflight hit → return promise                │   │   ├─ create() + detect() → result
      └─ chrome.runtime.sendMessage(DETECT_LANGUAGE)  │   │   └─ throws → fall through
            await reply ──────────►                   │   └─ unavailable → fall through
            cache + return                            └─ getOrInitXlm() (STUB throws)
                                                          → caught → und/xlm-roberta
```

Key boundary: `language-router.ts` is SW-side, pure coordination + cache, fully Node-testable via `LanguageRouterDeps` injection. `lang-detect-engine.ts` is offscreen-side, owns DOM/WebGPU access. Cross-boundary via two new message types `DETECT_LANGUAGE` / `LANGUAGE_RESULT` mirroring the existing `RUN_PROBES` / `PROBE_RESULTS` round-trip.

## Files

**New**
- `src/shared/hash.ts` — `sha256Hex` extracted from `chunking.ts` for reuse.
- `src/hunters/hawk/language-router.ts` — public API, in-memory cache (`Map<sha256Hex, result>`), single-flight via inflight map, `MIN_DETECT_CHARS = 20` gate.
- `src/hunters/hawk/language-router.test.ts` — 13 vitest tests.
- `src/offscreen/lang-detect-engine.ts` — Chrome `LanguageDetector` path + xlm-roberta stub.
- `src/offscreen/lang-detect-engine.test.ts` — 4 vitest tests.

**Modified**
- `src/hunters/hawk/chunking.ts` — imports `sha256Hex` from shared instead of defining locally. Behaviour identical.
- `src/types/messages.ts` — adds `DETECT_LANGUAGE` and `LANGUAGE_RESULT` to `MessageType` union, plus `DetectLanguageMessage`, `LanguageResultMessage`, and `LanguageDetectionResult` interfaces.
- `src/offscreen/index.ts` — registers `DETECT_LANGUAGE` handler that calls `handleDetectLanguage` and replies via `sendResponse`.

**Not changed (deferred to follow-up issue)**
- `package.json` — `@huggingface/transformers` not added; the stub never loads it.
- `manifest.json` — no CSP changes; WASM workers only matter when transformers.js actually runs.

## Test plan

- [x] `npm run typecheck` green
- [x] `npm test` — 599 passing (582 baseline + 17 new) across 47 files
- [x] `npm run build` — all 6 entry bundles produced
- [x] Refactor `sha256Hex` extraction is behaviour-identical; existing chunking tests preserved
- [x] Service is not yet wired into the verdict flow, so no UI / detection regression risk on this PR — manual smoke deferred to consumer-issue PRs (N4b / N1)

## Acceptance criteria coverage

- [x] AC1 — Chrome `LanguageDetector` API used when available (zero model download for Chrome).
- [ ] AC2 — transformers.js fallback wired end-to-end. **Deferred to follow-up issue**; current behaviour: graceful `und/xlm-roberta` when Chrome API absent.
- [x] AC3 — Detection result cached per `sha256(text)` chunk hash.
- [x] AC4 — 100+ language coverage (Chrome `LanguageDetector` covers 100+ languages via CLD3 internally).
- [x] AC5 — Tests cover EN/ES/ZH-CN minimum.

## Out of scope (explicit non-goals)

- Hunter interface implementation / orchestrator hunter-list registration — service is consumed by future N4b / N1 work.
- transformers.js fallback runtime — stub only; tracked in follow-up.
- Hawk chunker dialect-aware boundaries (N4b) — separate issue.
- Tier-router dialect packs — separate issue.