### PR TITLE
fix(harness-#93): replace localStorage sweep-lock with Web Locks API

### DIFF
--- a/harnesses/index.js
+++ b/harnesses/index.js
@@ -170,38 +170,29 @@ function deriveAgentOutcome(response, cls) {
   if (refusalRx.test(trimmed)) return "refused";
   return "partial";
 }
-function acquireSweepLock(kind) {
-  const key = SWEEP_LOCK_PREFIX + kind;
-  const existing = localStorage.getItem(key);
-  if (existing !== null) {
-    try {
-      const parsed = JSON.parse(existing);
-      if (parsed !== null && typeof parsed === "object" && "expiresAt" in parsed) {
-        const expiresAt2 = parsed.expiresAt;
-        if (Date.now() < expiresAt2) return false;
+async function acquireSweepLock(kind) {
+  const name = SWEEP_LOCK_PREFIX + kind;
+  return new Promise((resolveOuter) => {
+    void navigator.locks.request(
+      name,
+      { ifAvailable: true },
+      (lock) => {
+        if (lock === null) {
+          resolveOuter(null);
+          return;
+        }
+        return new Promise((release) => {
+          resolveOuter(() => release());
+        });
       }
-    } catch {
-    }
-  }
-  const expiresAt = Date.now() + 15 * 6e4;
-  localStorage.setItem(key, JSON.stringify({ acquiredAt: Date.now(), expiresAt }));
-  return true;
+    );
+  });
 }
-function releaseSweepLock(kind) {
-  localStorage.removeItem(SWEEP_LOCK_PREFIX + kind);
-}
-function isSweepLocked(kind) {
-  const raw = localStorage.getItem(SWEEP_LOCK_PREFIX + kind);
-  if (raw === null) return false;
-  try {
-    const parsed = JSON.parse(raw);
-    if (parsed !== null && typeof parsed === "object" && "expiresAt" in parsed) {
-      const expiresAt = parsed.expiresAt;
-      return Date.now() < expiresAt;
-    }
-  } catch {
-  }
-  return false;
+async function isSweepLocked(kind) {
+  const name = SWEEP_LOCK_PREFIX + kind;
+  const snapshot = await navigator.locks.query();
+  const held = snapshot.held ?? [];
+  return held.some((lock) => lock.name === name);
 }
 function unavailable() {
   return { available: false, analysing: false, inFlightCount: 0, inFlightTabIds: [] };
@@ -764,7 +755,7 @@ async function detectNanoAvailability() {
 async function refreshEngineStrip() {
   const lockChip = document.getElementById("nano-lock");
   if (lockChip !== null) {
-    const locked = isSweepLocked("nano");
+    const locked = await isSweepLocked("nano");
     lockChip.textContent = locked ? "Lock: HELD (other tab?)" : "Lock: free";
     lockChip.className = `engine-chip ${locked ? "busy" : "live"}`;
   }
@@ -782,12 +773,12 @@ async function refreshEngineStrip() {
     navExt.textContent = !status.available ? "ext: unreach" : status.analysing ? "ext: busy" : "ext: idle";
     navExt.className = `nav-pill ${!status.available ? "err" : status.analysing ? "warn" : "ok"}`;
   }
-  updateContentionBanner(status);
+  await updateContentionBanner(status);
 }
-function updateContentionBanner(status) {
+async function updateContentionBanner(status) {
   const banner = document.getElementById("nano-warn");
   const reason = document.getElementById("nano-warn-reason");
-  const locked = isSweepLocked("nano");
+  const locked = await isSweepLocked("nano");
   const extBusy = status.available && status.analysing;
   const anyContention = locked || extBusy;
   if (banner === null) return;
@@ -861,7 +852,8 @@ async function doSweep(resume) {
     showNanoError("window.LanguageModel is absent in this browser.");
     return;
   }
-  if (!acquireSweepLock("nano")) {
+  const release = await acquireSweepLock("nano");
+  if (release === null) {
     showNanoError("Another sweep is already running (possibly in a different tab). Close that tab and click Start again.");
     return;
   }
@@ -879,7 +871,7 @@ async function doSweep(resume) {
   const plannedTotal = totalCells * replicates;
   const resumeFrom = resume ? currentResults.length : 0;
   if (resumeFrom >= plannedTotal) {
-    releaseSweepLock("nano");
+    release();
     if (startBtn !== null) startBtn.disabled = false;
     const resumeBtn = document.getElementById("resume-btn");
     if (resumeBtn !== null) resumeBtn.style.display = "none";
@@ -910,7 +902,7 @@ async function doSweep(resume) {
     showNanoError(`Sweep aborted: ${msg}`);
     setStatus("s2.2", "fail");
   } finally {
-    releaseSweepLock("nano");
+    release();
     void refreshEngineStrip();
   }
 }
@@ -1230,8 +1222,6 @@ function clearAll() {
   if (!confirm("Clear all recorded results? (Cannot be undone.)")) return;
   state = {};
   saveState(state);
-  releaseSweepLock("nano");
-  releaseSweepLock("summarizer");
   location.reload();
 }
 function updateNavProgress() {

--- a/harnesses/index.ts
+++ b/harnesses/index.ts
@@ -19,7 +19,6 @@ import {
   classifyAgentResponse,
   deriveAgentOutcome,
   acquireSweepLock,
-  releaseSweepLock,
   isSweepLocked,
   pingExtension,
   currentRoute,
@@ -422,7 +421,7 @@ async function detectNanoAvailability(): Promise<void> {
 async function refreshEngineStrip(): Promise<void> {
   const lockChip = document.getElementById('nano-lock');
   if (lockChip !== null) {
-    const locked = isSweepLocked('nano');
+    const locked = await isSweepLocked('nano');
     lockChip.textContent = locked ? 'Lock: HELD (other tab?)' : 'Lock: free';
     lockChip.className = `engine-chip ${locked ? 'busy' : 'live'}`;
   }
@@ -444,13 +443,13 @@ async function refreshEngineStrip(): Promise<void> {
     navExt.textContent = !status.available ? 'ext: unreach' : status.analysing ? 'ext: busy' : 'ext: idle';
     navExt.className = `nav-pill ${!status.available ? 'err' : status.analysing ? 'warn' : 'ok'}`;
   }
-  updateContentionBanner(status);
+  await updateContentionBanner(status);
 }
 
-function updateContentionBanner(status: ExtensionStatus): void {
+async function updateContentionBanner(status: ExtensionStatus): Promise<void> {
   const banner = document.getElementById('nano-warn');
   const reason = document.getElementById('nano-warn-reason');
-  const locked = isSweepLocked('nano');
+  const locked = await isSweepLocked('nano');
   const extBusy = status.available && status.analysing;
   const anyContention = locked || extBusy;
   if (banner === null) return;
@@ -530,7 +529,8 @@ async function doSweep(resume: boolean): Promise<void> {
     showNanoError('window.LanguageModel is absent in this browser.');
     return;
   }
-  if (!acquireSweepLock('nano')) {
+  const release = await acquireSweepLock('nano');
+  if (release === null) {
     showNanoError('Another sweep is already running (possibly in a different tab). Close that tab and click Start again.');
     return;
   }
@@ -550,7 +550,7 @@ async function doSweep(resume: boolean): Promise<void> {
   const plannedTotal = totalCells * replicates;
   const resumeFrom = resume ? currentResults.length : 0;
   if (resumeFrom >= plannedTotal) {
-    releaseSweepLock('nano');
+    release();
     if (startBtn !== null) startBtn.disabled = false;
     const resumeBtn = document.getElementById('resume-btn');
     if (resumeBtn !== null) resumeBtn.style.display = 'none';
@@ -582,7 +582,7 @@ async function doSweep(resume: boolean): Promise<void> {
     showNanoError(`Sweep aborted: ${msg}`);
     setStatus('s2.2', 'fail');
   } finally {
-    releaseSweepLock('nano');
+    release();
     void refreshEngineStrip();
   }
 }
@@ -935,8 +935,9 @@ function clearAll(): void {
   if (!confirm('Clear all recorded results? (Cannot be undone.)')) return;
   state = {};
   saveState(state);
-  releaseSweepLock('nano');
-  releaseSweepLock('summarizer');
+  // Sweep locks held by THIS tab auto-release on the location.reload below
+  // (Web Locks API releases on document unload). Locks held by OTHER tabs
+  // can't be force-released cross-tab — that's the safety guarantee.
   location.reload();
 }
 

--- a/harnesses/lib/harness-state.test.ts
+++ b/harnesses/lib/harness-state.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { loadState, saveState, STORAGE_KEY } from './harness-state.js';
+import { loadState, saveState, STORAGE_KEY, acquireSweepLock, isSweepLocked, SWEEP_LOCK_PREFIX } from './harness-state.js';
 
 interface MockStorage {
   store: Map<string, string>;
@@ -38,9 +38,53 @@ function makeMockStorage(): MockStorage {
 let mockStorage: MockStorage;
 let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
 
+interface LockRequestOptions {
+  readonly ifAvailable?: boolean;
+}
+type LockCallback = (lock: { readonly name: string } | null) => Promise<unknown> | unknown;
+interface MockLockManager {
+  readonly held: Set<string>;
+  request(name: string, options: LockRequestOptions, callback: LockCallback): Promise<unknown>;
+  query(): Promise<{ held: ReadonlyArray<{ name: string }>; pending: ReadonlyArray<unknown> }>;
+}
+
+function makeMockLockManager(): MockLockManager {
+  const held = new Set<string>();
+  return {
+    held,
+    async request(name, options, callback): Promise<unknown> {
+      if (held.has(name)) {
+        if (options.ifAvailable === true) {
+          return await callback(null);
+        }
+        // Without ifAvailable, real Web Locks API would queue. Tests don't
+        // exercise that path; surface it loudly so we don't accidentally
+        // depend on queueing semantics.
+        throw new Error('mock: lock contention without ifAvailable not supported in tests');
+      }
+      held.add(name);
+      try {
+        return await callback({ name });
+      } finally {
+        held.delete(name);
+      }
+    },
+    async query() {
+      return {
+        held: [...held].map((name) => ({ name })),
+        pending: [],
+      };
+    },
+  };
+}
+
+let mockLocks: MockLockManager;
+
 beforeEach(() => {
   mockStorage = makeMockStorage();
   vi.stubGlobal('localStorage', mockStorage);
+  mockLocks = makeMockLockManager();
+  vi.stubGlobal('navigator', { locks: mockLocks });
   consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 });
 
@@ -193,5 +237,67 @@ describe('saveState — PRS-3: localStorage write failures', () => {
       expect.any(Error),
     );
     expect(mockStorage.store.has(STORAGE_KEY)).toBe(false);
+  });
+});
+
+describe('acquireSweepLock', () => {
+  it('returns a release function when the lock is free', async () => {
+    const release = await acquireSweepLock('nano');
+    expect(release).not.toBeNull();
+    expect(typeof release).toBe('function');
+    expect(mockLocks.held.has(`${SWEEP_LOCK_PREFIX}nano`)).toBe(true);
+    release!();
+    // Web Locks API resolves the held promise asynchronously; give the
+    // microtask queue a tick so the release propagates before assertion.
+    await Promise.resolve();
+    expect(mockLocks.held.has(`${SWEEP_LOCK_PREFIX}nano`)).toBe(false);
+  });
+
+  it('returns null when the lock is already held', async () => {
+    mockLocks.held.add(`${SWEEP_LOCK_PREFIX}nano`);
+    const release = await acquireSweepLock('nano');
+    expect(release).toBeNull();
+  });
+
+  it('isolates nano vs summarizer locks', async () => {
+    const nanoRelease = await acquireSweepLock('nano');
+    expect(nanoRelease).not.toBeNull();
+    const sumRelease = await acquireSweepLock('summarizer');
+    expect(sumRelease).not.toBeNull();
+    nanoRelease!();
+    sumRelease!();
+    await Promise.resolve();
+    expect(mockLocks.held.size).toBe(0);
+  });
+
+  it('release is idempotent in the sense that double-call does not blow up', async () => {
+    const release = await acquireSweepLock('nano');
+    expect(release).not.toBeNull();
+    release!();
+    // Calling the release twice is a no-op for the second call (the
+    // underlying promise has already resolved). The test asserts no throw.
+    expect(() => release!()).not.toThrow();
+  });
+});
+
+describe('isSweepLocked', () => {
+  it('returns false when no locks are held', async () => {
+    expect(await isSweepLocked('nano')).toBe(false);
+    expect(await isSweepLocked('summarizer')).toBe(false);
+  });
+
+  it('returns true for the kind that is held', async () => {
+    mockLocks.held.add(`${SWEEP_LOCK_PREFIX}nano`);
+    expect(await isSweepLocked('nano')).toBe(true);
+    expect(await isSweepLocked('summarizer')).toBe(false);
+  });
+
+  it('reflects state changes after acquire and release', async () => {
+    expect(await isSweepLocked('nano')).toBe(false);
+    const release = await acquireSweepLock('nano');
+    expect(await isSweepLocked('nano')).toBe(true);
+    release!();
+    await Promise.resolve();
+    expect(await isSweepLocked('nano')).toBe(false);
   });
 });

--- a/harnesses/lib/harness-state.ts
+++ b/harnesses/lib/harness-state.ts
@@ -280,38 +280,51 @@ export function deriveAgentOutcome(response: string, cls: AgentClassification): 
 
 // ---------- Sweep locks ----------
 
-export function acquireSweepLock(kind: 'nano' | 'summarizer'): boolean {
-  const key = SWEEP_LOCK_PREFIX + kind;
-  const existing = localStorage.getItem(key);
-  if (existing !== null) {
-    try {
-      const parsed: unknown = JSON.parse(existing);
-      if (parsed !== null && typeof parsed === 'object' && 'expiresAt' in parsed) {
-        const expiresAt = (parsed as { expiresAt: number }).expiresAt;
-        if (Date.now() < expiresAt) return false;
-      }
-    } catch { /* stale entry — overwrite */ }
-  }
-  const expiresAt = Date.now() + 15 * 60_000; // 15 min max sweep
-  localStorage.setItem(key, JSON.stringify({ acquiredAt: Date.now(), expiresAt }));
-  return true;
+// Backed by Web Locks API. The previous localStorage+TTL implementation was
+// not safe across tabs (no compare-and-swap; both racing tabs read null and
+// both wrote, so both sweeps ran), and the TTL produced its own failure mode
+// (long sweeps could outlive their lock). navigator.locks gives us
+// browser-enforced exclusivity and auto-release on tab close, removing both
+// concerns. Issue #93.
+
+/**
+ * Acquire the sweep lock for a given engine kind. Resolves to a release
+ * function on success, or `null` if another holder (typically another tab)
+ * already has the lock. Callers MUST invoke the returned release on every
+ * exit path; the lock also auto-releases when the tab unloads.
+ */
+export async function acquireSweepLock(kind: 'nano' | 'summarizer'): Promise<(() => void) | null> {
+  const name = SWEEP_LOCK_PREFIX + kind;
+  return new Promise<(() => void) | null>((resolveOuter) => {
+    void navigator.locks.request(
+      name,
+      { ifAvailable: true },
+      (lock): Promise<void> | void => {
+        if (lock === null) {
+          resolveOuter(null);
+          return;
+        }
+        // Hold the lock until the caller fires the release. The callback's
+        // returned promise is what keeps the lock alive in the API; resolving
+        // it releases.
+        return new Promise<void>((release) => {
+          resolveOuter(() => release());
+        });
+      },
+    );
+  });
 }
 
-export function releaseSweepLock(kind: 'nano' | 'summarizer'): void {
-  localStorage.removeItem(SWEEP_LOCK_PREFIX + kind);
-}
-
-export function isSweepLocked(kind: 'nano' | 'summarizer'): boolean {
-  const raw = localStorage.getItem(SWEEP_LOCK_PREFIX + kind);
-  if (raw === null) return false;
-  try {
-    const parsed: unknown = JSON.parse(raw);
-    if (parsed !== null && typeof parsed === 'object' && 'expiresAt' in parsed) {
-      const expiresAt = (parsed as { expiresAt: number }).expiresAt;
-      return Date.now() < expiresAt;
-    }
-  } catch { /* invalid — treat as unlocked */ }
-  return false;
+/**
+ * Returns true iff the sweep lock for `kind` is currently held (by this tab
+ * or any other). Used for advisory UI hints — the contention banner and the
+ * lock chip on the Nano harness.
+ */
+export async function isSweepLocked(kind: 'nano' | 'summarizer'): Promise<boolean> {
+  const name = SWEEP_LOCK_PREFIX + kind;
+  const snapshot = await navigator.locks.query();
+  const held = snapshot.held ?? [];
+  return held.some((lock) => lock.name === name);
 }
 
 // ---------- Extension status heartbeat ----------


### PR DESCRIPTION
Closes #93.

Fixes the cross-tab race in the sweep-lock state machine (SWL-1 from the 2026-04-23 harness review). The previous localStorage+TTL implementation had no compare-and-swap primitive, so two tabs racing on `acquireSweepLock('nano')` both read null, both wrote, and both sweeps ran — contending for the Nano Prompt API session the lock was meant to serialize.

## Approach

Replace the implementation with `navigator.locks`:

- Browser-enforced exclusivity. Cross-tab contention blocks deterministically.
- Auto-release on tab close. Removes the SWL-4 failure mode where a long sweep could outlive its 15-minute TTL.

API shape changes (issue #93 anticipated these):

| Function | Before | After |
|---|---|---|
| `acquireSweepLock(kind)` | `boolean` | `Promise<(() => void) \| null>` — release handle or null |
| `isSweepLocked(kind)` | `boolean` | `Promise<boolean>` — uses `navigator.locks.query()` |
| `releaseSweepLock(kind)` | `void` | **removed** — release is the returned handle |

7 caller updates in `harnesses/index.ts` (full call-site list in commit message). The previously-redundant explicit `releaseSweepLock` calls in `clearAll` are dropped because the immediately-following `location.reload()` triggers Web Locks auto-release for any locks held by this tab. Cross-tab locks remain — that's the safety guarantee.

## What this PR is NOT doing

- Does not touch `acquireSweepLock`'s public name or kind enum (`'nano' | 'summarizer'`) — drop-in for callers other than the API-shape change.
- Does not add new fixture pages or change `harnesses/nano-harness.ts` (no callers there).
- Does not refactor the broader contention-banner UI (`#95` territory, already merged via PR #101).

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 606 tests pass (47 files); +7 new sweep-lock tests
- [x] `npm run build` clean
- [x] `npm run harness:build` + `git diff --exit-code harnesses/index.js harnesses/nano-harness.js` clean (bundle in sync, per #107 CI drift check)
- [x] New tests cover: acquire-when-free, acquire-when-held (returns null), cross-kind isolation (nano vs summarizer), double-call release safety, isSweepLocked state transitions across acquire and release.

## Cross-references

- Refs **#14** (Nano replicate-sampling uses this lock) — not closed; manual replicate sweep testing pending.
- Surfaced from the same 2026-04-23 harness review session as `#94` (PR #105, merged), `#95` (PR #101, merged), `#96` (PR #102), `#97` (PR #99, merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)