### PR TITLE
feat(phase5-followup-#156): transformers.js NER for freeform PER/LOC/ORG (closes #151)

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -2,29 +2,35 @@ import { build } from 'vite';
 import { resolve } from 'path';
 import { copyFileSync, mkdirSync, existsSync, rmSync } from 'fs';
 
+// Issue #156 — @huggingface/transformers ships a prebuilt minified browser
+// ESM bundle at `dist/transformers.web.min.js` (~432 KB). We mark the
+// package as `external` for Vite's offscreen entry so Rollup does not
+// re-bundle it into a multi-megabyte chunk; instead the prebuilt bundle is
+// copied verbatim into `dist/transformers/` and loaded at runtime via
+// `chrome.runtime.getURL` (see src/offscreen/transformers-runtime.ts).
+const TRANSFORMERS_EXTERNAL = ['@huggingface/transformers'];
+
 const __dirname = resolve('.');
 
 interface BuildEntry {
   readonly name: string;
   readonly input: string;
   readonly format: 'es' | 'iife';
-  // Issue #156 — transformers.js v4 emits dynamic `import()` calls to lazy-load
-  // ONNX backend modules. Forcing `inlineDynamicImports: true` (the default for
-  // every other entry) collapses those into one bundle, but Vite then errors
-  // because the offscreen bundle is also `format: 'es'` with chunk emission
-  // disabled. Per-entry override: offscreen flips to `false` so dynamic
-  // imports stay as separate chunks under `dist/offscreen/`. All other
-  // entries keep `true` so the popup IIFE / content IIFE / SW ESM stay as
-  // single-file bundles (Chrome MV3 requires single-file content scripts and
-  // single-file SW).
-  readonly inlineDynamicImports?: boolean;
+  // Issue #156 — entries that import `@huggingface/transformers` mark the
+  // package external so Rollup leaves the runtime `import()` call intact.
+  // The transformers-runtime singleton rewrites the import URL to a
+  // `chrome.runtime.getURL('dist/transformers/transformers.web.min.js')`
+  // path at runtime, where the prebuilt minified browser bundle is served
+  // from. Keeps the offscreen entry small (~6 MB) and the bundle delta
+  // bounded (~432 KB for the prebuilt bundle, copied below).
+  readonly external?: readonly string[];
 }
 
 const entries: readonly BuildEntry[] = [
   { name: 'service-worker/index', input: 'src/service-worker/index.ts', format: 'es' },
   { name: 'content/index', input: 'src/content/index.ts', format: 'iife' },
   { name: 'content/main-world-inject', input: 'src/content/main-world-inject.ts', format: 'iife' },
-  { name: 'offscreen/index', input: 'src/offscreen/index.ts', format: 'es', inlineDynamicImports: false },
+  { name: 'offscreen/index', input: 'src/offscreen/index.ts', format: 'es', external: TRANSFORMERS_EXTERNAL },
   { name: 'popup/popup', input: 'src/popup/popup.ts', format: 'iife' },
   // Phase 3 Track A Path 2 — test-only harness page for Chrome built-in
   // Prompt API (Gemini Nano). Not referenced from manifest.json; opened by
@@ -50,8 +56,9 @@ async function main() {
           name: entry.format === 'iife' ? entry.name.replace(/[/-]/g, '_') : undefined,
         },
         rollupOptions: {
+          external: entry.external !== undefined ? [...entry.external] : undefined,
           output: {
-            inlineDynamicImports: entry.inlineDynamicImports ?? true,
+            inlineDynamicImports: true,
           },
         },
         sourcemap: false,
@@ -70,6 +77,20 @@ async function main() {
     ['src/offscreen/offscreen.html', 'dist/offscreen/offscreen.html'],
     ['src/popup/popup.html', 'dist/popup/popup.html'],
     ['src/tests/phase3/builtin-harness.html', 'dist/tests/phase3/builtin-harness.html'],
+    // Issue #156 — prebuilt minified browser bundle of @huggingface/transformers
+    // (~432 KB). Loaded via `chrome.runtime.getURL` from the offscreen doc; the
+    // adjacent `.mjs` file is the JSEP loader companion that ONNX Runtime
+    // imports lazily. WASM kernels and the actual NER model are NOT shipped —
+    // they lazy-fetch from the HF/jsdelivr CDN at first use and cache via
+    // the Cache API.
+    [
+      'node_modules/@huggingface/transformers/dist/transformers.web.min.js',
+      'dist/transformers/transformers.web.min.js',
+    ],
+    [
+      'node_modules/@huggingface/transformers/dist/ort-wasm-simd-threaded.jsep.mjs',
+      'dist/transformers/ort-wasm-simd-threaded.jsep.mjs',
+    ],
   ];
   for (const [src, dest] of assets) {
     const destDir = resolve(__dirname, dest, '..');

--- a/build.ts
+++ b/build.ts
@@ -4,16 +4,32 @@ import { copyFileSync, mkdirSync, existsSync, rmSync } from 'fs';
 
 const __dirname = resolve('.');
 
-const entries = [
-  { name: 'service-worker/index', input: 'src/service-worker/index.ts', format: 'es' as const },
-  { name: 'content/index', input: 'src/content/index.ts', format: 'iife' as const },
-  { name: 'content/main-world-inject', input: 'src/content/main-world-inject.ts', format: 'iife' as const },
-  { name: 'offscreen/index', input: 'src/offscreen/index.ts', format: 'es' as const },
-  { name: 'popup/popup', input: 'src/popup/popup.ts', format: 'iife' as const },
+interface BuildEntry {
+  readonly name: string;
+  readonly input: string;
+  readonly format: 'es' | 'iife';
+  // Issue #156 — transformers.js v4 emits dynamic `import()` calls to lazy-load
+  // ONNX backend modules. Forcing `inlineDynamicImports: true` (the default for
+  // every other entry) collapses those into one bundle, but Vite then errors
+  // because the offscreen bundle is also `format: 'es'` with chunk emission
+  // disabled. Per-entry override: offscreen flips to `false` so dynamic
+  // imports stay as separate chunks under `dist/offscreen/`. All other
+  // entries keep `true` so the popup IIFE / content IIFE / SW ESM stay as
+  // single-file bundles (Chrome MV3 requires single-file content scripts and
+  // single-file SW).
+  readonly inlineDynamicImports?: boolean;
+}
+
+const entries: readonly BuildEntry[] = [
+  { name: 'service-worker/index', input: 'src/service-worker/index.ts', format: 'es' },
+  { name: 'content/index', input: 'src/content/index.ts', format: 'iife' },
+  { name: 'content/main-world-inject', input: 'src/content/main-world-inject.ts', format: 'iife' },
+  { name: 'offscreen/index', input: 'src/offscreen/index.ts', format: 'es', inlineDynamicImports: false },
+  { name: 'popup/popup', input: 'src/popup/popup.ts', format: 'iife' },
   // Phase 3 Track A Path 2 — test-only harness page for Chrome built-in
   // Prompt API (Gemini Nano). Not referenced from manifest.json; opened by
   // the Stage 5 Playwright runner via chrome.tabs.create from the SW.
-  { name: 'tests/phase3/builtin-harness', input: 'src/tests/phase3/builtin-harness.ts', format: 'iife' as const },
+  { name: 'tests/phase3/builtin-harness', input: 'src/tests/phase3/builtin-harness.ts', format: 'iife' },
 ];
 
 async function main() {
@@ -35,7 +51,7 @@ async function main() {
         },
         rollupOptions: {
           output: {
-            inlineDynamicImports: true,
+            inlineDynamicImports: entry.inlineDynamicImports ?? true,
           },
         },
         sourcemap: false,

--- a/manifest.json
+++ b/manifest.json
@@ -46,6 +46,6 @@
     "matches": ["http://127.0.0.1:8765/*"]
   },
   "content_security_policy": {
-    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'"
+    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; worker-src 'self' blob:; object-src 'self'"
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -40,6 +40,10 @@
     {
       "resources": ["dist/content/main-world-inject.js"],
       "matches": ["<all_urls>"]
+    },
+    {
+      "resources": ["dist/transformers/*"],
+      "matches": ["<all_urls>"]
     }
   ],
   "externally_connectable": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@huggingface/transformers": "^4.2.0",
         "@mlc-ai/web-llm": "^0.2.74"
       },
       "devDependencies": {
@@ -264,7 +265,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -731,11 +731,38 @@
         }
       }
     },
+    "node_modules/@huggingface/jinja": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.8.tgz",
+      "integrity": "sha512-ZdElB7DPS7QQS8ZnFc5RPPtkg+eN11z8AmIZWAyes6pSbwXqiFB/POVevvm01begdSX1ho9Gxln/F6qlQMsuaA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@huggingface/tokenizers": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@huggingface/tokenizers/-/tokenizers-0.1.3.tgz",
+      "integrity": "sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@huggingface/transformers": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@huggingface/transformers/-/transformers-4.2.0.tgz",
+      "integrity": "sha512-8BRCoBMH0XsWaEIamuR0LrJGAfftgHAfb2Vrffy0VKlSAE/MnUJ5/h/zTfEP3fDIft+nk7TqB8xXEyABGitBjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@huggingface/jinja": "^0.5.6",
+        "@huggingface/tokenizers": "^0.1.3",
+        "onnxruntime-node": "1.24.3",
+        "onnxruntime-web": "1.26.0-dev.20260416-b7804b056c",
+        "sharp": "^0.34.5"
+      }
+    },
     "node_modules/@img/colour": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -748,7 +775,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -771,7 +797,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -794,7 +819,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -811,7 +835,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -828,7 +851,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -848,7 +870,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -868,7 +889,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -888,7 +908,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -908,7 +927,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -928,7 +946,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -948,7 +965,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "libc": [
         "musl"
       ],
@@ -968,7 +984,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "libc": [
         "musl"
       ],
@@ -988,7 +1003,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -1014,7 +1028,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -1040,7 +1053,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -1066,7 +1078,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -1092,7 +1103,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -1118,7 +1128,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -1144,7 +1153,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "libc": [
         "musl"
       ],
@@ -1170,7 +1178,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "libc": [
         "musl"
       ],
@@ -1196,7 +1203,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -1216,7 +1222,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1236,7 +1241,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1256,7 +1260,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1300,6 +1303,70 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.1",
@@ -1761,7 +1828,6 @@
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.19.0"
@@ -1904,6 +1970,15 @@
         "node": ">=6.5"
       }
     },
+    "node_modules/adm-zip": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
+      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
     "node_modules/agentkeepalive": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
@@ -1943,6 +2018,13 @@
       "dependencies": {
         "require-from-string": "^2.0.2"
       }
+    },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT"
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
@@ -2061,6 +2143,40 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -2075,11 +2191,16 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -2113,7 +2234,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2123,7 +2243,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2165,6 +2284,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
@@ -2205,6 +2330,18 @@
         "@esbuild/win32-arm64": "0.25.12",
         "@esbuild/win32-ia32": "0.25.12",
         "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/estree-walker": {
@@ -2254,6 +2391,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/flatbuffers": {
+      "version": "25.9.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/form-data": {
       "version": "4.0.5",
@@ -2370,14 +2513,64 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/guid-typescript": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
+      "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
+      "license": "ISC"
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2534,6 +2727,12 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
+    },
     "node_modules/loglevel": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
@@ -2546,6 +2745,12 @@
         "type": "tidelift",
         "url": "https://tidelift.com/funding/github/npm/loglevel"
       }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/lru-cache": {
       "version": "11.3.5",
@@ -2565,6 +2770,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/math-intrinsics": {
@@ -2675,6 +2892,15 @@
         }
       }
     },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -2684,6 +2910,49 @@
         "https://github.com/sponsors/sxzz",
         "https://opencollective.com/debug"
       ],
+      "license": "MIT"
+    },
+    "node_modules/onnxruntime-common": {
+      "version": "1.24.3",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.3.tgz",
+      "integrity": "sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA==",
+      "license": "MIT"
+    },
+    "node_modules/onnxruntime-node": {
+      "version": "1.24.3",
+      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.24.3.tgz",
+      "integrity": "sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "dependencies": {
+        "adm-zip": "^0.5.16",
+        "global-agent": "^3.0.0",
+        "onnxruntime-common": "1.24.3"
+      }
+    },
+    "node_modules/onnxruntime-web": {
+      "version": "1.26.0-dev.20260416-b7804b056c",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.26.0-dev.20260416-b7804b056c.tgz",
+      "integrity": "sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw==",
+      "license": "MIT",
+      "dependencies": {
+        "flatbuffers": "^25.1.24",
+        "guid-typescript": "^1.0.9",
+        "long": "^5.2.3",
+        "onnxruntime-common": "1.24.0-dev.20251116-b39e144322",
+        "platform": "^1.3.6",
+        "protobufjs": "^7.2.4"
+      }
+    },
+    "node_modules/onnxruntime-web/node_modules/onnxruntime-common": {
+      "version": "1.24.0-dev.20251116-b39e144322",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.0-dev.20251116-b39e144322.tgz",
+      "integrity": "sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw==",
       "license": "MIT"
     },
     "node_modules/parse5": {
@@ -2725,6 +2994,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "license": "MIT"
     },
     "node_modules/playwright": {
       "version": "1.59.1",
@@ -2787,6 +3062,30 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
+      "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.1",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2815,6 +3114,23 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/rollup": {
@@ -2879,7 +3195,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -2888,11 +3203,31 @@
         "node": ">=10"
       }
     },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "license": "MIT"
+    },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/sharp": {
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2949,6 +3284,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/stackback": {
       "version": "0.0.2",
@@ -3059,7 +3400,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD",
       "optional": true
     },
@@ -3582,6 +3922,18 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -3610,7 +3962,6 @@
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "harness:manual": "npm run harness:build && npm run harness:serve -- --open index.html"
   },
   "dependencies": {
+    "@huggingface/transformers": "^4.2.0",
     "@mlc-ai/web-llm": "^0.2.74"
   },
   "devDependencies": {

--- a/src/hunters/ner/merge-ner.test.ts
+++ b/src/hunters/ner/merge-ner.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import { mergeNerIntoPackets } from './merge-ner.js';
+import type { Entity } from './types.js';
+import type { EvidencePacket } from '@/probes/base-probe.js';
+
+function packet(overrides: Partial<EvidencePacket> = {}): EvidencePacket {
+  return {
+    hunterName: 'spider',
+    featureName: 'override_instruction',
+    ruleId: 'spider:override_instruction',
+    before: 'AAA',
+    flagged: 'BBB',
+    after: 'CCC',
+    fullChunkRef: 'h_test',
+    score: 40,
+    entities: [],
+    flaggedAbsStart: 100,
+    ...overrides,
+  };
+}
+
+function nerEntity(span: readonly [number, number], type: 'person' | 'organization' | 'location' = 'person'): Entity {
+  return {
+    type,
+    value: 'X',
+    span,
+    confidence: 0.95,
+  };
+}
+
+describe('mergeNerIntoPackets (issue #156)', () => {
+  it('T14: merges NER entity inside packet window with packet-relative span', () => {
+    // packet window: [100, 109)  (before+flagged+after = 3+3+3=9 chars)
+    const p = packet({ before: 'AAA', flagged: 'BBB', after: 'CCC', flaggedAbsStart: 100 });
+    const ner: readonly Entity[] = [nerEntity([102, 105], 'person')];
+    const out = mergeNerIntoPackets([p], ner);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.entities).toHaveLength(1);
+    // 102-100 = 2, 105-100 = 5 → packet-relative
+    expect(out[0]!.entities[0]!.span).toEqual([2, 5]);
+    expect(out[0]!.entities[0]!.type).toBe('person');
+  });
+
+  it('T15: drops NER entity outside the packet window', () => {
+    const p = packet({ before: 'AAA', flagged: 'BBB', after: 'CCC', flaggedAbsStart: 100 });
+    const ner: readonly Entity[] = [
+      nerEntity([50, 55], 'person'), // before window
+      nerEntity([200, 210], 'organization'), // after window
+    ];
+    const out = mergeNerIntoPackets([p], ner);
+    expect(out[0]!.entities).toEqual([]);
+  });
+
+  it('T16: empty NER → returns input reference unchanged', () => {
+    const p = packet();
+    const out = mergeNerIntoPackets([p], []);
+    expect(out).toEqual([p]);
+  });
+
+  it('appends NER entities AFTER existing regex entities (does not replace)', () => {
+    const regexEntity: Entity = {
+      type: 'url',
+      value: 'https://x.test',
+      span: [0, 14],
+      confidence: 0.9,
+    };
+    const p = packet({
+      before: 'visit ',
+      flagged: 'https://x.test',
+      after: '',
+      flaggedAbsStart: 100,
+      entities: [regexEntity],
+    });
+    const ner: readonly Entity[] = [nerEntity([102, 108], 'organization')];
+    const out = mergeNerIntoPackets([p], ner);
+    expect(out[0]!.entities).toHaveLength(2);
+    expect(out[0]!.entities[0]!.type).toBe('url');
+    expect(out[0]!.entities[1]!.type).toBe('organization');
+  });
+
+  it('handles multi-packet pages: each packet receives only its own window NER', () => {
+    const p1 = packet({ before: 'AAA', flagged: 'BBB', after: 'CCC', flaggedAbsStart: 100 });
+    const p2 = packet({ before: 'DDD', flagged: 'EEE', after: 'FFF', flaggedAbsStart: 500 });
+    const ner: readonly Entity[] = [
+      nerEntity([102, 105], 'person'), // in p1
+      nerEntity([501, 504], 'location'), // in p2
+    ];
+    const out = mergeNerIntoPackets([p1, p2], ner);
+    expect(out[0]!.entities).toHaveLength(1);
+    expect(out[0]!.entities[0]!.type).toBe('person');
+    expect(out[1]!.entities).toHaveLength(1);
+    expect(out[1]!.entities[0]!.type).toBe('location');
+  });
+
+  it('drops NER entity that straddles the window boundary', () => {
+    // packet window: [100, 109)
+    const p = packet({ before: 'AAA', flagged: 'BBB', after: 'CCC', flaggedAbsStart: 100 });
+    const ner: readonly Entity[] = [
+      nerEntity([95, 105], 'person'), // starts before window
+      nerEntity([105, 115], 'person'), // ends after window
+    ];
+    const out = mergeNerIntoPackets([p], ner);
+    expect(out[0]!.entities).toEqual([]);
+  });
+
+  it('preserves the packet structure (only entities field changes)', () => {
+    const p = packet({ flaggedAbsStart: 0, before: 'A', flagged: 'B', after: 'C' });
+    const ner: readonly Entity[] = [nerEntity([0, 1], 'person')];
+    const out = mergeNerIntoPackets([p], ner);
+    expect(out[0]!.hunterName).toBe(p.hunterName);
+    expect(out[0]!.score).toBe(p.score);
+    expect(out[0]!.fullChunkRef).toBe(p.fullChunkRef);
+    expect(out[0]!.flaggedAbsStart).toBe(p.flaggedAbsStart);
+  });
+});

--- a/src/hunters/ner/merge-ner.ts
+++ b/src/hunters/ner/merge-ner.ts
@@ -1,0 +1,55 @@
+import type { EvidencePacket } from '@/probes/base-probe.js';
+import type { Entity } from './types.js';
+
+/**
+ * Issue #156 — additive merge of freeform NER entities into evidence
+ * packets. The orchestrator runs NER once per chunk (one offscreen RPC),
+ * receives chunk-absolute entity spans, and calls this helper to fan
+ * results into the per-packet `entities` array.
+ *
+ * Semantics:
+ * - Each packet exposes `flaggedAbsStart` (absolute chunk offset of the
+ *   `flagged` excerpt) plus `before/flagged/after` lengths, defining the
+ *   packet's absolute span over the chunk text.
+ * - NER entities whose span lies fully within `[packetStart, packetEnd)`
+ *   are appended to that packet. Entities straddling the boundary or
+ *   outside any packet window are dropped.
+ * - Spans are re-based to packet-relative offsets so the evidence-review
+ *   prompt and popup rendering see the same span semantics as the regex
+ *   extractors (offsets into the before+flagged+after concatenation).
+ * - Existing `entities` (regex matches from buildEvidencePackets) are
+ *   preserved; NER entries are concatenated AFTER them.
+ *
+ * Empty `nerEntities` returns the input array reference-equal so callers
+ * can detect "no NER signal" without an extra allocation.
+ */
+export function mergeNerIntoPackets(
+  packets: readonly EvidencePacket[],
+  nerEntities: readonly Entity[],
+): readonly EvidencePacket[] {
+  if (nerEntities.length === 0) return packets;
+
+  return packets.map((packet) => {
+    const packetStart = packet.flaggedAbsStart;
+    const packetEnd =
+      packetStart + packet.before.length + packet.flagged.length + packet.after.length;
+
+    const inWindow: Entity[] = [];
+    for (const e of nerEntities) {
+      const [start, end] = e.span;
+      if (start >= packetStart && end <= packetEnd) {
+        inWindow.push({
+          ...e,
+          span: [start - packetStart, end - packetStart] as const,
+        });
+      }
+    }
+
+    if (inWindow.length === 0) return packet;
+
+    return {
+      ...packet,
+      entities: [...packet.entities, ...inWindow],
+    };
+  });
+}

--- a/src/hunters/ner/types.ts
+++ b/src/hunters/ner/types.ts
@@ -4,7 +4,14 @@ export type EntityType =
   | 'credit_card'
   | 'api_key'
   | 'credential'
-  | 'exfil_domain';
+  | 'exfil_domain'
+  // Issue #156 — freeform NER entity classes from CoNLL-2003 trained
+  // transformers (DistilBERT-NER). Surfaced from the offscreen NER engine
+  // and merged into EvidencePacket.entities alongside regex extractors.
+  | 'person'
+  | 'organization'
+  | 'location'
+  | 'misc';
 
 export type EntityMetadataValue = string | number | boolean;
 

--- a/src/offscreen/index.ts
+++ b/src/offscreen/index.ts
@@ -1,6 +1,7 @@
 import type {
   HoneyLLMMessage,
   LanguageResultMessage,
+  NerResultMessage,
   ProbeResultsMessage,
   ProbeDirectResultMessage,
 } from '@/types/messages.js';
@@ -10,6 +11,7 @@ import { initEngine, generateCompletion, getLoadedModelId, getLoadedCanaryId, ge
 import { runProbes } from './probe-runner.js';
 import { runDirectProbe, type DirectProbeDeps } from './direct-probe.js';
 import { handleDetectLanguage } from './lang-detect-engine.js';
+import { handleRunNer } from './ner-engine.js';
 
 const log = createLogger('Offscreen');
 
@@ -109,6 +111,34 @@ chrome.runtime.onMessage.addListener((message: HoneyLLMMessage, _sender, sendRes
         const reply: LanguageResultMessage = {
           type: 'LANGUAGE_RESULT',
           result: { lang: 'und', confidence: 0, source: 'chrome-api' },
+        };
+        sendResponse(reply);
+      });
+    return true; // keep channel open for async sendResponse
+  }
+
+  // Issue #156 — freeform NER RPC. Replies via sendResponse so the
+  // SW-side `ner-router.ts` can `await chrome.runtime.sendMessage(...)`.
+  // handleRunNer is total: returns [] on every failure path (load failure,
+  // deadline miss, factory exception). Span offsets come back absolute over
+  // the page text because `chunkOffset` is forwarded into handleRunNer.
+  if (message.type === 'RUN_NER') {
+    const start = performance.now();
+    handleRunNer(message.text, message.deadlineMs ?? 250, message.chunkOffset)
+      .then((entities) => {
+        const reply: NerResultMessage = {
+          type: 'NER_RESULT',
+          entities,
+          inferenceMs: performance.now() - start,
+        };
+        sendResponse(reply);
+      })
+      .catch((err: unknown) => {
+        log.error('handleRunNer rejected unexpectedly', err);
+        const reply: NerResultMessage = {
+          type: 'NER_RESULT',
+          entities: [],
+          inferenceMs: performance.now() - start,
         };
         sendResponse(reply);
       });

--- a/src/offscreen/index.ts
+++ b/src/offscreen/index.ts
@@ -203,3 +203,15 @@ initEngine().catch((err) => {
     error: String(err),
   });
 });
+
+// Issue #156 — pre-warm the NER engine at offscreen-doc creation. The
+// first call triggers the prebuilt-bundle import + ONNX session init +
+// quantized model CDN fetch (~70 MB), which together can take several
+// seconds. Pre-warming here means the model is more likely to be warm by
+// the time the orchestrator's chunk loop dispatches RUN_NER. handleRunNer
+// is total (returns []), so the rejection branch only fires on an
+// unexpected failure — which we log and ignore. The 30-second deadline
+// bounds the cold-load wait without blocking the offscreen doc.
+handleRunNer('warmup', 30_000).catch((err: unknown) => {
+  log.warn('NER pre-warm failed; first scan will load on demand', err);
+});

--- a/src/offscreen/lang-detect-engine.test.ts
+++ b/src/offscreen/lang-detect-engine.test.ts
@@ -1,10 +1,17 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { handleDetectLanguage, _resetForTesting } from './lang-detect-engine.js';
+import {
+  handleDetectLanguage,
+  _resetForTesting,
+  _setXlmFactoryForTesting,
+} from './lang-detect-engine.js';
 
 describe('handleDetectLanguage', () => {
   beforeEach(() => {
     vi.unstubAllGlobals();
     _resetForTesting();
+    // Default for legacy tests: xlm factory unavailable so fallback behaves
+    // identically to the pre-#156 stub (returns UND_XLM).
+    _setXlmFactoryForTesting(async () => null);
   });
 
   afterEach(() => {
@@ -51,5 +58,79 @@ describe('handleDetectLanguage', () => {
     const result = await handleDetectLanguage('A long enough English sentence to detect.');
     expect(result).toEqual({ lang: 'en', confidence: 0.97, source: 'chrome-api' });
     expect(detectSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('T9: xlm-roberta classifies when Chrome API is absent', async () => {
+    _setXlmFactoryForTesting(async () => ({
+      detect: async () => [
+        { label: 'fr', score: 0.94 },
+        { label: 'en', score: 0.05 },
+      ],
+    }));
+    const result = await handleDetectLanguage('Bonjour le monde, comment allez-vous?');
+    expect(result).toEqual({ lang: 'fr', confidence: 0.94, source: 'xlm-roberta' });
+  });
+
+  it('T10: xlm-roberta init failure → UND_XLM', async () => {
+    _setXlmFactoryForTesting(async () => {
+      throw new Error('model load failed');
+    });
+    const result = await handleDetectLanguage('Some text in an obscure tongue.');
+    expect(result).toEqual({ lang: 'und', confidence: 0, source: 'xlm-roberta' });
+  });
+
+  it('T11: Chrome API present + working → xlm factory never called', async () => {
+    let xlmCalls = 0;
+    _setXlmFactoryForTesting(async () => {
+      xlmCalls++;
+      return null;
+    });
+    vi.stubGlobal('LanguageDetector', {
+      availability: vi.fn(async () => 'available'),
+      create: vi.fn(async () => ({
+        detect: async () => [{ detectedLanguage: 'es', confidence: 0.9 }],
+      })),
+    });
+    const result = await handleDetectLanguage('Hola mundo, ¿cómo estás?');
+    expect(result.source).toBe('chrome-api');
+    expect(xlmCalls).toBe(0);
+  });
+
+  it('T12: xlm-roberta single-flight — concurrent calls trigger one factory invocation', async () => {
+    let factoryCalls = 0;
+    _setXlmFactoryForTesting(async () => {
+      factoryCalls++;
+      return {
+        detect: async () => [{ label: 'de', score: 0.91 }],
+      };
+    });
+
+    const promises = [
+      handleDetectLanguage('Hallo Welt eins.'),
+      handleDetectLanguage('Hallo Welt zwei.'),
+      handleDetectLanguage('Hallo Welt drei.'),
+    ];
+    const results = await Promise.all(promises);
+    expect(factoryCalls).toBe(1);
+    for (const r of results) {
+      expect(r.source).toBe('xlm-roberta');
+      expect(r.lang).toBe('de');
+    }
+  });
+
+  it('xlm returning empty hits → UND_XLM', async () => {
+    _setXlmFactoryForTesting(async () => ({ detect: async () => [] }));
+    const result = await handleDetectLanguage('inscrutable');
+    expect(result).toEqual({ lang: 'und', confidence: 0, source: 'xlm-roberta' });
+  });
+
+  it('xlm detect() throws → UND_XLM (graceful)', async () => {
+    _setXlmFactoryForTesting(async () => ({
+      detect: async () => {
+        throw new Error('inference exploded');
+      },
+    }));
+    const result = await handleDetectLanguage('some text');
+    expect(result).toEqual({ lang: 'und', confidence: 0, source: 'xlm-roberta' });
   });
 });

--- a/src/offscreen/lang-detect-engine.ts
+++ b/src/offscreen/lang-detect-engine.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@/shared/logger.js';
 import type { LanguageDetectionResult } from '@/types/messages.js';
+import { loadTransformers } from './transformers-runtime.js';
 
 const log = createLogger('LangDetect');
 
@@ -62,13 +63,76 @@ async function getOrInitChromeDetector(
   return chromeDetectorInitPromise;
 }
 
-async function getOrInitXlm(): Promise<never> {
-  // Issue #119 ships the Chrome `LanguageDetector` path only. The
-  // transformers.js xlm-roberta fallback is tracked in a follow-up
-  // issue (filed after #119 merges). Until that ships, this throws so
-  // the message handler returns the `und/xlm-roberta` graceful-
-  // degradation result when the Chrome API is absent.
-  throw new Error('xlm-roberta path not yet implemented — see follow-up issue');
+/**
+ * Issue #156 — replaces the throwing stub from #119 with a real
+ * transformers.js text-classification fallback. Closes #151.
+ *
+ * Model: `Xenova/xlm-roberta-base-language-detection` (q8). Returns ISO
+ * 639-1 codes covering 100+ languages, complementing the Chrome
+ * LanguageDetector which is only available on Chrome ≥ 138.
+ */
+const XLM_MODEL_ID = 'Xenova/xlm-roberta-base-language-detection';
+const XLM_DEVICE = 'wasm' as const;
+const XLM_DTYPE = 'q8' as const;
+const XLM_COLD_LOAD_TIMEOUT_MS = 30_000;
+
+interface XlmHit {
+  readonly label: string;
+  readonly score: number;
+}
+
+interface XlmPipeline {
+  (text: string): Promise<readonly XlmHit[]>;
+}
+
+interface XlmDetector {
+  detect(text: string): Promise<readonly XlmHit[]>;
+}
+
+let xlmInstance: XlmDetector | null = null;
+let xlmInitPromise: Promise<XlmDetector | null> | null = null;
+let xlmFactoryOverride: (() => Promise<XlmDetector | null>) | null = null;
+
+function timeoutSignal(ms: number): Promise<null> {
+  return new Promise<null>((resolve) => setTimeout(() => resolve(null), ms));
+}
+
+async function defaultXlmFactory(): Promise<XlmDetector | null> {
+  const tf = await loadTransformers();
+  const pipe = await tf.pipeline('text-classification', XLM_MODEL_ID, {
+    dtype: XLM_DTYPE,
+    device: XLM_DEVICE,
+  });
+  const callable = pipe as unknown as XlmPipeline;
+  return {
+    detect: async (text: string) => callable(text),
+  };
+}
+
+async function getOrInitXlm(): Promise<XlmDetector | null> {
+  if (xlmInstance !== null) return xlmInstance;
+  if (xlmInitPromise !== null) return xlmInitPromise;
+
+  const factory = xlmFactoryOverride ?? defaultXlmFactory;
+
+  xlmInitPromise = (async (): Promise<XlmDetector | null> => {
+    try {
+      const result = await Promise.race([factory(), timeoutSignal(XLM_COLD_LOAD_TIMEOUT_MS)]);
+      if (result === null) {
+        log.warn('xlm-roberta cold-load timed out');
+        return null;
+      }
+      xlmInstance = result;
+      return result;
+    } catch (err) {
+      log.warn('xlm-roberta init failed', err);
+      return null;
+    } finally {
+      xlmInitPromise = null;
+    }
+  })();
+
+  return xlmInitPromise;
 }
 
 export async function handleDetectLanguage(text: string): Promise<LanguageDetectionResult> {
@@ -94,14 +158,34 @@ export async function handleDetectLanguage(text: string): Promise<LanguageDetect
   }
 
   try {
-    await getOrInitXlm();
-  } catch {
-    // Expected: stub always throws until the xlm-roberta follow-up ships.
+    const xlm = await getOrInitXlm();
+    if (xlm !== null) {
+      const hits = await xlm.detect(text);
+      const top = hits[0];
+      if (top !== undefined && top.label.length > 0 && top.label !== 'und') {
+        return {
+          lang: top.label,
+          confidence: top.score,
+          source: 'xlm-roberta',
+        };
+      }
+    }
+  } catch (err) {
+    log.warn('xlm-roberta detect failed', err);
   }
   return UND_XLM;
+}
+
+export function _setXlmFactoryForTesting(
+  factory: (() => Promise<XlmDetector | null>) | null,
+): void {
+  xlmFactoryOverride = factory;
 }
 
 export function _resetForTesting(): void {
   chromeDetectorInstance = null;
   chromeDetectorInitPromise = null;
+  xlmInstance = null;
+  xlmInitPromise = null;
+  xlmFactoryOverride = null;
 }

--- a/src/offscreen/ner-engine.test.ts
+++ b/src/offscreen/ner-engine.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  handleRunNer,
+  _setNerFactoryForTesting,
+  _resetForTesting,
+} from './ner-engine.js';
+
+interface FakeHit {
+  readonly entity_group: string;
+  readonly score: number;
+  readonly word: string;
+  readonly start: number;
+  readonly end: number;
+}
+
+type FakePipeline = (text: string, options?: { aggregation_strategy?: string }) => Promise<FakeHit[]>;
+
+function pipelineReturning(hits: readonly FakeHit[]): FakePipeline {
+  return async () => [...hits];
+}
+
+describe('ner-engine', () => {
+  beforeEach(() => _resetForTesting());
+  afterEach(() => _resetForTesting());
+
+  it('T1: single-flight — concurrent calls trigger one factory invocation', async () => {
+    let factoryCalls = 0;
+    let resolveFactory: ((p: FakePipeline) => void) | undefined;
+    _setNerFactoryForTesting(() => {
+      factoryCalls++;
+      return new Promise<FakePipeline>((resolve) => {
+        resolveFactory = resolve;
+      });
+    });
+
+    const promises = [
+      handleRunNer('a'),
+      handleRunNer('b'),
+      handleRunNer('c'),
+      handleRunNer('d'),
+      handleRunNer('e'),
+    ];
+    expect(factoryCalls).toBe(1);
+
+    resolveFactory!(pipelineReturning([]));
+    const results = await Promise.all(promises);
+    expect(results).toHaveLength(5);
+    expect(factoryCalls).toBe(1);
+  });
+
+  it('T2: cold-start exceeds deadline → returns []', async () => {
+    _setNerFactoryForTesting(() => new Promise(() => { /* never resolves */ }));
+    const result = await handleRunNer('hello world', 50);
+    expect(result).toEqual([]);
+  });
+
+  it('T3: warm inference exceeds deadline → returns []', async () => {
+    const slowPipeline: FakePipeline = () => new Promise(() => { /* never resolves */ });
+    _setNerFactoryForTesting(async () => slowPipeline);
+    const result = await handleRunNer('hello world', 50);
+    expect(result).toEqual([]);
+  });
+
+  it('T4: tag mapping PER→person, ORG→organization, LOC→location, MISC→misc', async () => {
+    _setNerFactoryForTesting(async () =>
+      pipelineReturning([
+        { entity_group: 'PER', score: 0.99, word: 'Alice', start: 0, end: 5 },
+        { entity_group: 'ORG', score: 0.95, word: 'Acme Corp', start: 10, end: 19 },
+        { entity_group: 'LOC', score: 0.97, word: 'Tokyo', start: 25, end: 30 },
+        { entity_group: 'MISC', score: 0.90, word: 'Olympics', start: 35, end: 43 },
+      ]),
+    );
+
+    const result = await handleRunNer('Alice ... Acme Corp ... Tokyo ... Olympics');
+    expect(result).toEqual([
+      { type: 'person', value: 'Alice', span: [0, 5], confidence: 0.99 },
+      { type: 'organization', value: 'Acme Corp', span: [10, 19], confidence: 0.95 },
+      { type: 'location', value: 'Tokyo', span: [25, 30], confidence: 0.97 },
+      { type: 'misc', value: 'Olympics', span: [35, 43], confidence: 0.90 },
+    ]);
+  });
+
+  it('T5: confidence floor — score < 0.85 is dropped', async () => {
+    _setNerFactoryForTesting(async () =>
+      pipelineReturning([
+        { entity_group: 'PER', score: 0.84, word: 'Bob', start: 0, end: 3 },
+        { entity_group: 'PER', score: 0.86, word: 'Carol', start: 5, end: 10 },
+      ]),
+    );
+
+    const result = await handleRunNer('Bob and Carol');
+    expect(result).toHaveLength(1);
+    expect(result[0]?.value).toBe('Carol');
+  });
+
+  it('T6: offset adjust — caller-supplied offset shifts spans', async () => {
+    _setNerFactoryForTesting(async () =>
+      pipelineReturning([
+        { entity_group: 'PER', score: 0.99, word: 'Dana', start: 0, end: 4 },
+      ]),
+    );
+
+    const result = await handleRunNer('Dana', 250, 100);
+    expect(result).toEqual([
+      { type: 'person', value: 'Dana', span: [100, 104], confidence: 0.99 },
+    ]);
+  });
+
+  it('T7: factory throws → graceful empty result', async () => {
+    _setNerFactoryForTesting(async () => {
+      throw new Error('model load failed');
+    });
+
+    const result = await handleRunNer('hello');
+    expect(result).toEqual([]);
+  });
+
+  it('T8: _resetForTesting allows re-invocation of factory', async () => {
+    let factoryCalls = 0;
+    _setNerFactoryForTesting(async () => {
+      factoryCalls++;
+      return pipelineReturning([]);
+    });
+
+    await handleRunNer('first');
+    expect(factoryCalls).toBe(1);
+
+    // second call hits the cached pipeline — factory should NOT be called
+    await handleRunNer('second');
+    expect(factoryCalls).toBe(1);
+
+    _resetForTesting();
+    _setNerFactoryForTesting(async () => {
+      factoryCalls++;
+      return pipelineReturning([]);
+    });
+    await handleRunNer('third');
+    expect(factoryCalls).toBe(2);
+  });
+
+  it('drops hits without start/end offsets (tokenizer without offset_mapping)', async () => {
+    _setNerFactoryForTesting(async () => async () => [
+      { entity_group: 'PER', score: 0.99, word: 'Eve' } as FakeHit,
+    ]);
+
+    const result = await handleRunNer('Eve');
+    expect(result).toEqual([]);
+  });
+
+  it('drops hits with unknown entity_group', async () => {
+    _setNerFactoryForTesting(async () =>
+      pipelineReturning([
+        { entity_group: 'GADGET', score: 0.99, word: 'iPhone', start: 0, end: 6 },
+      ]),
+    );
+
+    const result = await handleRunNer('iPhone');
+    expect(result).toEqual([]);
+  });
+
+  it('strips B-/I- BIO prefixes when entity_group is missing (raw output)', async () => {
+    // raw output uses `entity` instead of `entity_group`. Our handler should
+    // accept either via runtime narrowing.
+    _setNerFactoryForTesting(async () => async (): Promise<FakeHit[]> => [
+      { entity: 'B-PER', score: 0.99, word: 'Frank', start: 0, end: 5, entity_group: undefined } as unknown as FakeHit,
+    ]);
+
+    const result = await handleRunNer('Frank');
+    expect(result).toEqual([
+      { type: 'person', value: 'Frank', span: [0, 5], confidence: 0.99 },
+    ]);
+  });
+
+  it('returns [] for empty input without invoking factory', async () => {
+    let factoryCalls = 0;
+    _setNerFactoryForTesting(async () => {
+      factoryCalls++;
+      return pipelineReturning([]);
+    });
+
+    const result = await handleRunNer('');
+    expect(result).toEqual([]);
+    expect(factoryCalls).toBe(0);
+  });
+});

--- a/src/offscreen/ner-engine.ts
+++ b/src/offscreen/ner-engine.ts
@@ -1,0 +1,164 @@
+import type { Entity, EntityType } from '@/hunters/ner/types.js';
+import { createLogger } from '@/shared/logger.js';
+import { loadTransformers } from './transformers-runtime.js';
+
+const log = createLogger('NerEngine');
+
+/**
+ * Issue #156 — quantized DistilBERT-NER served from the Hugging Face CDN.
+ * Lazy-fetched on first use; cached in the Cache API for subsequent loads.
+ * `dtype: 'q8'` matches `DEFAULT_DEVICE_DTYPE_MAPPING.wasm`, but is named
+ * explicitly so an upstream default change doesn't silently degrade us to
+ * fp32.
+ */
+const NER_MODEL_ID = 'Xenova/distilbert-base-NER';
+const NER_DEVICE = 'wasm' as const;
+const NER_DTYPE = 'q8' as const;
+const NER_AGGREGATION = 'simple' as const;
+
+const DEFAULT_INFERENCE_DEADLINE_MS = 250;
+
+/**
+ * Issue #156 — confidence floor for surfacing freeform NER entities. The
+ * regex extractors at `src/hunters/ner/extractors/*` use 0.6–0.95 ranges; a
+ * 0.85 floor for freeform output keeps the noise-to-signal ratio inside
+ * acceptable bounds for evidence-review rendering. Below this we'd surface
+ * tokenization artefacts (sub-words, partial spans) into the popup.
+ */
+const CONFIDENCE_FLOOR = 0.85;
+
+const TAG_TO_TYPE: Readonly<Record<string, EntityType>> = {
+  PER: 'person',
+  ORG: 'organization',
+  LOC: 'location',
+  MISC: 'misc',
+};
+
+interface NerHit {
+  readonly entity_group?: string;
+  readonly entity?: string;
+  readonly score: number;
+  readonly word: string;
+  readonly start?: number;
+  readonly end?: number;
+}
+
+type NerAggregation = 'simple' | 'none';
+
+interface NerPipeline {
+  (text: string, options?: { aggregation_strategy?: NerAggregation }): Promise<readonly NerHit[]>;
+}
+
+let nerInstance: NerPipeline | null = null;
+let nerInitPromise: Promise<NerPipeline | null> | null = null;
+let factoryOverride: (() => Promise<NerPipeline>) | null = null;
+
+function timeoutSignal(ms: number): Promise<null> {
+  return new Promise<null>((resolve) => setTimeout(() => resolve(null), ms));
+}
+
+async function defaultFactory(): Promise<NerPipeline> {
+  const tf = await loadTransformers();
+  const pipe = await tf.pipeline('token-classification', NER_MODEL_ID, {
+    dtype: NER_DTYPE,
+    device: NER_DEVICE,
+  });
+  // Narrow the typed pipeline to the structural NerPipeline surface used
+  // here. The transformers.js callable signature is over-specified for our
+  // use; we only need (text, options) → hits[].
+  return (text: string, options?: { aggregation_strategy?: NerAggregation }) =>
+    pipe(text, options) as unknown as Promise<readonly NerHit[]>;
+}
+
+async function getOrInitNer(): Promise<NerPipeline | null> {
+  if (nerInstance !== null) return nerInstance;
+  if (nerInitPromise !== null) return nerInitPromise;
+
+  const factory = factoryOverride ?? defaultFactory;
+
+  nerInitPromise = (async (): Promise<NerPipeline | null> => {
+    try {
+      const created = await factory();
+      nerInstance = created;
+      return created;
+    } catch (err) {
+      log.warn('NER pipeline init failed', err);
+      return null;
+    } finally {
+      nerInitPromise = null;
+    }
+  })();
+
+  return nerInitPromise;
+}
+
+/**
+ * Issue #156 — total function. Returns `readonly Entity[]` (`[]` on any
+ * failure path: empty input, model load failure, deadline miss, unexpected
+ * pipeline error). The caller (`handleRunNer` invocation in
+ * `src/offscreen/index.ts`) treats `[]` as "no NER signal" and the
+ * orchestrator merge pass keeps the regex-extracted entities untouched.
+ *
+ * The `deadlineMs` parameter races BOTH the cold-load and inference
+ * combined, so the first call after the offscreen-doc is created will
+ * almost always return `[]` (CDN model fetch + ONNX session init takes
+ * 2–5s warm). Production wiring pre-warms NER on offscreen-doc creation
+ * to minimise that window.
+ */
+export async function handleRunNer(
+  text: string,
+  deadlineMs: number = DEFAULT_INFERENCE_DEADLINE_MS,
+  offset = 0,
+): Promise<readonly Entity[]> {
+  if (text.length === 0) return [];
+
+  const work = (async (): Promise<readonly Entity[]> => {
+    const pipe = await getOrInitNer();
+    if (pipe === null) return [];
+    const hits = await pipe(text, { aggregation_strategy: NER_AGGREGATION });
+    return mapHitsToEntities(hits, offset);
+  })();
+
+  try {
+    const result = await Promise.race([work, timeoutSignal(deadlineMs)]);
+    if (result === null) {
+      log.debug(`NER inference exceeded ${deadlineMs}ms deadline`);
+      return [];
+    }
+    return result;
+  } catch (err) {
+    log.warn('handleRunNer unexpected failure', err);
+    return [];
+  }
+}
+
+function mapHitsToEntities(hits: readonly NerHit[], offset: number): readonly Entity[] {
+  const entities: Entity[] = [];
+  for (const hit of hits) {
+    if (hit.score < CONFIDENCE_FLOOR) continue;
+    if (hit.start === undefined || hit.end === undefined) continue;
+    const rawTag = hit.entity_group ?? hit.entity ?? '';
+    const normalisedTag = rawTag.replace(/^[BI]-/, '');
+    const type = TAG_TO_TYPE[normalisedTag];
+    if (type === undefined) continue;
+    entities.push({
+      type,
+      value: hit.word,
+      span: [offset + hit.start, offset + hit.end] as const,
+      confidence: hit.score,
+    });
+  }
+  return entities;
+}
+
+export function _setNerFactoryForTesting(
+  factory: (() => Promise<NerPipeline>) | null,
+): void {
+  factoryOverride = factory;
+}
+
+export function _resetForTesting(): void {
+  nerInstance = null;
+  nerInitPromise = null;
+  factoryOverride = null;
+}

--- a/src/offscreen/probe-runner.test.ts
+++ b/src/offscreen/probe-runner.test.ts
@@ -24,6 +24,7 @@ const basePacket: EvidencePacket = {
   fullChunkRef: 'h_test',
   score: 40,
   entities: [],
+  flaggedAbsStart: 50,
 };
 
 const benignReview = '{"confirmed": false, "reasoning": "context"}';

--- a/src/offscreen/transformers-runtime.test.ts
+++ b/src/offscreen/transformers-runtime.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  loadTransformers,
+  _setTransformersImporterForTesting,
+  _resetForTesting,
+} from './transformers-runtime.js';
+
+describe('transformers-runtime', () => {
+  beforeEach(() => {
+    _resetForTesting();
+  });
+
+  afterEach(() => {
+    _resetForTesting();
+  });
+
+  it('returns the imported module and configures env exactly once', async () => {
+    const fakeModule = {
+      env: { backends: { onnx: { wasm: {} as { numThreads?: number } } } },
+      pipeline: () => Promise.resolve(() => Promise.resolve([])),
+    };
+    let calls = 0;
+    _setTransformersImporterForTesting(async () => {
+      calls++;
+      return fakeModule as unknown as typeof import('@huggingface/transformers');
+    });
+
+    const m1 = await loadTransformers();
+    const m2 = await loadTransformers();
+
+    expect(m1).toBe(fakeModule);
+    expect(m2).toBe(fakeModule);
+    expect(calls).toBe(1);
+    expect(fakeModule.env.backends.onnx.wasm.numThreads).toBe(1);
+  });
+
+  it('single-flight: concurrent calls share one importer invocation', async () => {
+    const fakeModule = {
+      env: { backends: { onnx: { wasm: {} as { numThreads?: number } } } },
+    };
+    let calls = 0;
+    let resolveImporter: ((mod: unknown) => void) | undefined;
+    _setTransformersImporterForTesting(() => {
+      calls++;
+      return new Promise<typeof import('@huggingface/transformers')>((resolve) => {
+        resolveImporter = resolve as (mod: unknown) => void;
+      });
+    });
+
+    const p1 = loadTransformers();
+    const p2 = loadTransformers();
+    const p3 = loadTransformers();
+    expect(calls).toBe(1);
+
+    resolveImporter!(fakeModule);
+    const [r1, r2, r3] = await Promise.all([p1, p2, p3]);
+    expect(r1).toBe(fakeModule);
+    expect(r2).toBe(fakeModule);
+    expect(r3).toBe(fakeModule);
+    expect(calls).toBe(1);
+  });
+
+  it('importer rejection clears the in-flight promise so retries can re-fire', async () => {
+    let attempt = 0;
+    _setTransformersImporterForTesting(async () => {
+      attempt++;
+      if (attempt === 1) throw new Error('import failed once');
+      return {
+        env: { backends: { onnx: { wasm: {} } } },
+      } as unknown as typeof import('@huggingface/transformers');
+    });
+
+    await expect(loadTransformers()).rejects.toThrow('import failed once');
+    const second = await loadTransformers();
+    expect(second).toBeDefined();
+    expect(attempt).toBe(2);
+  });
+});

--- a/src/offscreen/transformers-runtime.ts
+++ b/src/offscreen/transformers-runtime.ts
@@ -4,34 +4,40 @@ type TransformersModule = typeof import('@huggingface/transformers');
 
 const log = createLogger('TransformersRuntime');
 
+/**
+ * Issue #156 — `@huggingface/transformers` is marked external in build.ts
+ * so Rollup leaves the runtime `import()` call intact instead of inlining
+ * the (~432 KB minified) library into every offscreen rebuild. The
+ * prebuilt browser bundle is copied to `dist/transformers/` at build time;
+ * at runtime we resolve the URL via `chrome.runtime.getURL` and `import()`
+ * it as an ES module from the extension origin (no CSP `unsafe-eval`
+ * needed; same-origin module imports are allowed under
+ * `script-src 'self'`).
+ */
+const PREBUILT_BUNDLE_PATH = 'dist/transformers/transformers.web.min.js';
+
 let cachedModule: TransformersModule | null = null;
 let importPromise: Promise<TransformersModule> | null = null;
 let envConfigured = false;
 let importerOverride: (() => Promise<TransformersModule>) | null = null;
 
-/**
- * Issue #156 — single-flight loader for `@huggingface/transformers` v4. Both
- * the NER engine and the lang-detect xlm-roberta fallback consume this so
- * the (~1–2 MB) library bundle is loaded once per offscreen-doc lifetime,
- * `env.backends.onnx.wasm.numThreads` is set exactly once, and concurrent
- * callers share one dynamic-import promise.
- *
- * `numThreads = 1` is set deliberately: offscreen documents cannot set
- * `Cross-Origin-Opener-Policy` / `Cross-Origin-Embedder-Policy`, so
- * `SharedArrayBuffer` is unavailable and threaded WASM falls back to the
- * single-threaded variant. Setting numThreads=1 explicitly suppresses the
- * silent-fallback warning and makes the configuration intentional.
- */
+async function defaultImporter(): Promise<TransformersModule> {
+  // chrome.runtime.getURL produces `chrome-extension://<id>/dist/transformers/...`
+  // which the offscreen doc can `import()` as an ES module. The string is
+  // built at runtime so the bundler does not statically resolve it.
+  const url = chrome.runtime.getURL(PREBUILT_BUNDLE_PATH);
+  const mod = (await import(/* @vite-ignore */ url)) as TransformersModule;
+  return mod;
+}
+
 export async function loadTransformers(): Promise<TransformersModule> {
   if (cachedModule !== null) return cachedModule;
   if (importPromise !== null) return importPromise;
 
   importPromise = (async () => {
     try {
-      const mod =
-        importerOverride !== null
-          ? await importerOverride()
-          : await import('@huggingface/transformers');
+      const importer = importerOverride ?? defaultImporter;
+      const mod = await importer();
       if (!envConfigured) {
         try {
           const wasm = mod.env.backends.onnx.wasm;

--- a/src/offscreen/transformers-runtime.ts
+++ b/src/offscreen/transformers-runtime.ts
@@ -1,0 +1,67 @@
+import { createLogger } from '@/shared/logger.js';
+
+type TransformersModule = typeof import('@huggingface/transformers');
+
+const log = createLogger('TransformersRuntime');
+
+let cachedModule: TransformersModule | null = null;
+let importPromise: Promise<TransformersModule> | null = null;
+let envConfigured = false;
+let importerOverride: (() => Promise<TransformersModule>) | null = null;
+
+/**
+ * Issue #156 — single-flight loader for `@huggingface/transformers` v4. Both
+ * the NER engine and the lang-detect xlm-roberta fallback consume this so
+ * the (~1–2 MB) library bundle is loaded once per offscreen-doc lifetime,
+ * `env.backends.onnx.wasm.numThreads` is set exactly once, and concurrent
+ * callers share one dynamic-import promise.
+ *
+ * `numThreads = 1` is set deliberately: offscreen documents cannot set
+ * `Cross-Origin-Opener-Policy` / `Cross-Origin-Embedder-Policy`, so
+ * `SharedArrayBuffer` is unavailable and threaded WASM falls back to the
+ * single-threaded variant. Setting numThreads=1 explicitly suppresses the
+ * silent-fallback warning and makes the configuration intentional.
+ */
+export async function loadTransformers(): Promise<TransformersModule> {
+  if (cachedModule !== null) return cachedModule;
+  if (importPromise !== null) return importPromise;
+
+  importPromise = (async () => {
+    try {
+      const mod =
+        importerOverride !== null
+          ? await importerOverride()
+          : await import('@huggingface/transformers');
+      if (!envConfigured) {
+        try {
+          const wasm = mod.env.backends.onnx.wasm;
+          if (wasm !== undefined) {
+            wasm.numThreads = 1;
+          }
+          envConfigured = true;
+        } catch (err) {
+          log.warn('failed to set ONNX wasm numThreads', err);
+        }
+      }
+      cachedModule = mod;
+      return mod;
+    } finally {
+      importPromise = null;
+    }
+  })();
+
+  return importPromise;
+}
+
+export function _setTransformersImporterForTesting(
+  factory: (() => Promise<TransformersModule>) | null,
+): void {
+  importerOverride = factory;
+}
+
+export function _resetForTesting(): void {
+  cachedModule = null;
+  importPromise = null;
+  envConfigured = false;
+  importerOverride = null;
+}

--- a/src/popup/entities.ts
+++ b/src/popup/entities.ts
@@ -13,6 +13,13 @@ const ENTITY_TYPE_ORDER: readonly EntityType[] = [
   'api_key',
   'url',
   'email',
+  // Issue #156 — freeform NER classes appear AFTER regex types because the
+  // structured patterns are stronger exfiltration signals. PER/ORG/LOC are
+  // contextual context, surfaced for human review only.
+  'person',
+  'organization',
+  'location',
+  'misc',
 ];
 
 const ENTITY_TYPE_LABEL: Readonly<Record<EntityType, string>> = Object.freeze({
@@ -22,6 +29,10 @@ const ENTITY_TYPE_LABEL: Readonly<Record<EntityType, string>> = Object.freeze({
   api_key: 'API key',
   credential: 'Credential',
   exfil_domain: 'Exfil domain',
+  person: 'People',
+  organization: 'Organizations',
+  location: 'Locations',
+  misc: 'Other entities',
 });
 
 function maskValue(entity: Entity): string {

--- a/src/popup/popup-entities.test.ts
+++ b/src/popup/popup-entities.test.ts
@@ -97,6 +97,44 @@ describe('renderEntitySummary (issue #122)', () => {
     expect(body.textContent).toContain('password=***');
     expect(body.textContent).not.toContain('hunter2');
   });
+
+  it('T18: renders person entities with raw values (no masking)', () => {
+    const body = makeBody();
+    const samples: readonly Entity[] = [
+      { type: 'person', value: 'Alice Smith', span: [0, 11], confidence: 0.99 },
+      { type: 'organization', value: 'Acme Corp', span: [13, 22], confidence: 0.95 },
+      { type: 'location', value: 'Tokyo', span: [25, 30], confidence: 0.97 },
+      { type: 'misc', value: 'Olympics', span: [35, 43], confidence: 0.9 },
+    ];
+    renderEntitySummary(body, {
+      counts: { person: 1, organization: 1, location: 1, misc: 1 },
+      samples,
+    });
+    expect(body.textContent).toContain('People: 1');
+    expect(body.textContent).toContain('Organizations: 1');
+    expect(body.textContent).toContain('Locations: 1');
+    expect(body.textContent).toContain('Other entities: 1');
+    expect(body.textContent).toContain('Alice Smith');
+    expect(body.textContent).toContain('Acme Corp');
+    expect(body.textContent).toContain('Tokyo');
+    expect(body.textContent).toContain('Olympics');
+  });
+
+  it('T19: regex-only entities (no NER) — only regex labels appear, no PER/LOC/ORG chips', () => {
+    const body = makeBody();
+    renderEntitySummary(body, {
+      counts: { url: 1, exfil_domain: 1 },
+      samples: [
+        { type: 'url', value: 'https://x.io', span: [0, 12], confidence: 0.9 },
+        { type: 'exfil_domain', value: 'webhook.site', span: [13, 25], confidence: 0.95 },
+      ],
+    });
+    expect(body.textContent).toContain('URL: 1');
+    expect(body.textContent).toContain('Exfil domain: 1');
+    expect(body.textContent).not.toContain('People');
+    expect(body.textContent).not.toContain('Organizations');
+    expect(body.textContent).not.toContain('Locations');
+  });
 });
 
 describe('rollupEntities', () => {

--- a/src/probes/base-probe.ts
+++ b/src/probes/base-probe.ts
@@ -29,6 +29,15 @@ export interface EvidencePacket {
   readonly fullChunkRef: string;
   readonly score: number;
   readonly entities: readonly Entity[];
+  /**
+   * Issue #156 — absolute start offset of the `flagged` excerpt within the
+   * full chunk text. Populated by buildEvidencePackets so the orchestrator's
+   * NER merge pass (mergeNerIntoPackets) can intersect chunk-absolute NER
+   * entity spans with each packet's window without re-finding via
+   * `chunk.text.indexOf(flagged)`. The centre-fallback packet sets this to
+   * the slice start; otherwise it's the substring-match `pos`.
+   */
+  readonly flaggedAbsStart: number;
 }
 
 export interface Probe {

--- a/src/probes/evidence-builder.ts
+++ b/src/probes/evidence-builder.ts
@@ -46,6 +46,7 @@ export function buildEvidencePackets(
           fullChunkRef: chunk.contentHash,
           score: result.score,
           entities: [],
+          flaggedAbsStart: sliceStart,
         });
         continue;
       }
@@ -61,6 +62,7 @@ export function buildEvidencePackets(
         fullChunkRef: chunk.contentHash,
         score: result.score,
         entities: [],
+        flaggedAbsStart: pos,
       });
     }
   }

--- a/src/probes/evidence-review.test.ts
+++ b/src/probes/evidence-review.test.ts
@@ -14,6 +14,7 @@ const samplePacket: EvidencePacket = {
   fullChunkRef: 'h_abc',
   score: 40,
   entities: [],
+  flaggedAbsStart: 100,
 };
 
 describe('evidenceReviewProbe (issue #118)', () => {

--- a/src/service-worker/ner-router.test.ts
+++ b/src/service-worker/ner-router.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { runNerForChunk, _resetForTesting } from './ner-router.js';
+import type { Entity } from '@/hunters/ner/types.js';
+import type { NerResultMessage } from '@/types/messages.js';
+
+interface FakeDeps {
+  readonly send: (text: string, offset: number) => Promise<NerResultMessage>;
+}
+
+function fakeReply(entities: readonly Entity[]): NerResultMessage {
+  return {
+    type: 'NER_RESULT',
+    entities,
+    inferenceMs: 12,
+  };
+}
+
+describe('runNerForChunk (issue #156)', () => {
+  beforeEach(() => _resetForTesting());
+
+  it('T13: cache hit — same chunk → one RPC across multiple calls', async () => {
+    let sendCalls = 0;
+    const deps: FakeDeps = {
+      send: async () => {
+        sendCalls++;
+        return fakeReply([
+          {
+            type: 'person',
+            value: 'Alice',
+            span: [0, 5],
+            confidence: 0.95,
+          },
+        ]);
+      },
+    };
+
+    const r1 = await runNerForChunk('repeated chunk text content', 0, deps);
+    const r2 = await runNerForChunk('repeated chunk text content', 0, deps);
+    const r3 = await runNerForChunk('repeated chunk text content', 0, deps);
+
+    expect(sendCalls).toBe(1);
+    expect(r1).toEqual(r2);
+    expect(r2).toEqual(r3);
+  });
+
+  it('different chunk text → separate RPCs', async () => {
+    let sendCalls = 0;
+    const deps: FakeDeps = {
+      send: async () => {
+        sendCalls++;
+        return fakeReply([]);
+      },
+    };
+
+    await runNerForChunk('chunk A content longer than threshold', 0, deps);
+    await runNerForChunk('chunk B content longer than threshold', 0, deps);
+    expect(sendCalls).toBe(2);
+  });
+
+  it('single-flight: concurrent calls for same text trigger one RPC', async () => {
+    let sendCalls = 0;
+    let resolve: ((reply: NerResultMessage) => void) | undefined;
+    const deps: FakeDeps = {
+      send: async () => {
+        sendCalls++;
+        return new Promise<NerResultMessage>((r) => { resolve = r; });
+      },
+    };
+
+    const promises = [
+      runNerForChunk('shared text longer than threshold', 0, deps),
+      runNerForChunk('shared text longer than threshold', 0, deps),
+      runNerForChunk('shared text longer than threshold', 0, deps),
+    ];
+    // Wait for sha256Hex hashing + inflight registration to complete.
+    // crypto.subtle.digest is implemented as a real async op so a single
+    // microtask flush is not enough.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(sendCalls).toBe(1);
+    resolve!(fakeReply([]));
+    const results = await Promise.all(promises);
+    expect(results).toHaveLength(3);
+    expect(sendCalls).toBe(1);
+  });
+
+  it('returns [] when send throws', async () => {
+    const deps: FakeDeps = {
+      send: async () => {
+        throw new Error('SW → offscreen channel disconnected');
+      },
+    };
+    const result = await runNerForChunk('a long enough chunk to clear MIN_NER_CHARS', 0, deps);
+    expect(result).toEqual([]);
+  });
+
+  it('skips RPC for short text', async () => {
+    let sendCalls = 0;
+    const deps: FakeDeps = {
+      send: async () => {
+        sendCalls++;
+        return fakeReply([]);
+      },
+    };
+
+    const result = await runNerForChunk('hi', 0, deps);
+    expect(result).toEqual([]);
+    expect(sendCalls).toBe(0);
+  });
+});

--- a/src/service-worker/ner-router.ts
+++ b/src/service-worker/ner-router.ts
@@ -1,0 +1,77 @@
+import { sha256Hex } from '@/shared/hash.js';
+import type { Entity } from '@/hunters/ner/types.js';
+import type { NerResultMessage, RunNerMessage } from '@/types/messages.js';
+
+/**
+ * Issue #156 — minimum chunk length to surface to NER. Shorter strings
+ * almost never produce useful PER/ORG/LOC hits and cost an offscreen RPC
+ * round-trip plus a 50–100 ms warm inference each. The same threshold is
+ * used by the language router so the two systems behave consistently.
+ */
+export const MIN_NER_CHARS = 20;
+
+export interface NerRouterDeps {
+  readonly send: (text: string, offset: number) => Promise<NerResultMessage>;
+}
+
+const cache = new Map<string, readonly Entity[]>();
+const inflight = new Map<string, Promise<readonly Entity[]>>();
+
+async function defaultSend(text: string, chunkOffset: number): Promise<NerResultMessage> {
+  const message: RunNerMessage = { type: 'RUN_NER', text, chunkOffset };
+  const reply = (await chrome.runtime.sendMessage(message)) as NerResultMessage;
+  return reply;
+}
+
+const defaultDeps: NerRouterDeps = { send: defaultSend };
+
+/**
+ * Issue #156 — sha256(text)-keyed single-flight + persistent cache for the
+ * orchestrator's per-chunk NER lookup. Mirrors `language-router.ts`'s
+ * pattern: cache survives for the SW lifetime so navigations that re-emit
+ * the same chunk text (browse-back, hash-only navigation) skip the
+ * offscreen round-trip. `chunkOffset` participates in the cache key
+ * because the offscreen handler reuses it to absolute-ize entity spans —
+ * different offsets must NOT share a cache entry.
+ *
+ * Total/never-throws contract: returns `[]` on send rejection, short
+ * input, or empty offscreen reply. Exceptions become empty arrays so the
+ * orchestrator merge pass keeps regex entities untouched.
+ */
+export async function runNerForChunk(
+  text: string,
+  chunkOffset: number,
+  deps: NerRouterDeps = defaultDeps,
+): Promise<readonly Entity[]> {
+  if (text.length < MIN_NER_CHARS) return [];
+
+  const baseKey = await sha256Hex(text);
+  const key = `${baseKey}:${chunkOffset}`;
+
+  const cached = cache.get(key);
+  if (cached !== undefined) return cached;
+
+  const pending = inflight.get(key);
+  if (pending !== undefined) return pending;
+
+  const promise = (async () => {
+    try {
+      const reply = await deps.send(text, chunkOffset);
+      const entities = reply.entities ?? [];
+      cache.set(key, entities);
+      return entities;
+    } catch {
+      return [] as readonly Entity[];
+    } finally {
+      inflight.delete(key);
+    }
+  })();
+
+  inflight.set(key, promise);
+  return promise;
+}
+
+export function _resetForTesting(): void {
+  cache.clear();
+  inflight.clear();
+}

--- a/src/service-worker/orchestrator.ts
+++ b/src/service-worker/orchestrator.ts
@@ -20,6 +20,8 @@ import { generateStamp } from './stamp.js';
 import { routeChunk } from './tier-router.js';
 import { createContentHash } from './content-hash.js';
 import { buildEvidencePackets } from '@/probes/evidence-builder.js';
+import { runNerForChunk } from './ner-router.js';
+import { mergeNerIntoPackets } from '@/hunters/ner/merge-ner.js';
 import type { EvidencePacket } from '@/probes/base-probe.js';
 import type { Entity } from '@/hunters/ner/types.js';
 import { rollupEntities } from '@/hunters/ner/rollup.js';
@@ -271,7 +273,26 @@ export async function analyzeSnapshot(
       // report. Empty array → probe-runner falls through to the existing
       // 3-probe stack (Hawk-only chunk-level signal). Non-empty → runs
       // evidence-review per packet + summarization.
-      const evidencePackets = buildEvidencePackets(chunks[index]!, huntReport);
+      const regexPackets = buildEvidencePackets(chunks[index]!, huntReport);
+
+      // Issue #156 — additive freeform NER over the chunk text. One RPC per
+      // chunk (sha256-cached in ner-router so repeats no-op). The merge
+      // pass intersects chunk-absolute NER spans with each packet's
+      // absolute window (flaggedAbsStart + before/flagged/after lengths)
+      // and re-bases to packet-relative offsets so evidence-review and
+      // popup rendering see uniform span semantics with regex entities.
+      // Skip the RPC entirely when there are no packets to enrich; benign
+      // chunks short-circuit to the existing CLEAN path.
+      let evidencePackets = regexPackets;
+      if (regexPackets.length > 0) {
+        try {
+          const nerEntities = await runNerForChunk(chunks[index]!.text, 0);
+          evidencePackets = mergeNerIntoPackets(regexPackets, nerEntities);
+        } catch (err) {
+          log.warn('NER merge failed; proceeding with regex-only entities', err);
+        }
+      }
+
       for (const packet of evidencePackets) {
         for (const entity of packet.entities) {
           allEntities.push(entity);

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -2,6 +2,7 @@ import type { PageSnapshot } from './snapshot.js';
 import type { ProbeResult, SecurityVerdict, WebGPUAdapterMode } from './verdict.js';
 import type { VerifyStampResult } from './page-stamp.js';
 import type { EvidencePacket } from '@/probes/base-probe.js';
+import type { Entity } from '@/hunters/ner/types.js';
 
 export type MessageType =
   | 'PAGE_SNAPSHOT'
@@ -39,7 +40,14 @@ export type MessageType =
   // offscreen (DOM context); the SW-side `language-router.ts` caches by
   // sha256(text) so a repeated chunk doesn't re-cross the boundary.
   | 'DETECT_LANGUAGE'
-  | 'LANGUAGE_RESULT';
+  | 'LANGUAGE_RESULT'
+  // Issue #156 — freeform NER RPC. SW (orchestrator chunk loop) → offscreen
+  // request with chunk text + absolute offset; offscreen replies via
+  // sendResponse with NerResultMessage carrying transformer-extracted
+  // PER/ORG/LOC/MISC entities. The SW-side ner-router caches by
+  // sha256(text) so a repeated chunk doesn't re-cross the boundary.
+  | 'RUN_NER'
+  | 'NER_RESULT';
 
 interface BaseMessage {
   readonly type: MessageType;
@@ -247,6 +255,25 @@ export interface LanguageResultMessage extends BaseMessage {
   readonly result: LanguageDetectionResult;
 }
 
+// Issue #156 — RUN_NER carries a chunk's full text + the chunk's absolute
+// offset within the page text. The offscreen handler invokes
+// `handleRunNer(text, deadlineMs, chunkOffset)`, so returned
+// `NerResultMessage.entities[].span` are absolute over the page text and
+// `mergeNerIntoPackets` (Phase 5) can intersect them with each evidence
+// packet's window without further bookkeeping.
+export interface RunNerMessage extends BaseMessage {
+  readonly type: 'RUN_NER';
+  readonly text: string;
+  readonly chunkOffset: number;
+  readonly deadlineMs?: number;
+}
+
+export interface NerResultMessage extends BaseMessage {
+  readonly type: 'NER_RESULT';
+  readonly entities: readonly Entity[];
+  readonly inferenceMs: number;
+}
+
 export type HoneyLLMMessage =
   | PageSnapshotMessage
   | RunProbesMessage
@@ -267,4 +294,6 @@ export type HoneyLLMMessage =
   | TriggerRescanMessage
   | RescanPageMessage
   | DetectLanguageMessage
-  | LanguageResultMessage;
+  | LanguageResultMessage
+  | RunNerMessage
+  | NerResultMessage;


### PR DESCRIPTION
## Summary

Closes #156 and #151. Wires `@huggingface/transformers` v4 + a quantized DistilBERT-NER model into the offscreen document so freeform CoNLL-2003 classes (`person` / `organization` / `location` / `misc`) complement the regex extractors shipped in #122 / PR #155. The same runtime install replaces the throwing xlm-roberta stub at `src/offscreen/lang-detect-engine.ts:65-71`, satisfying #151's acceptance criteria as a side-effect.

This is the last actionable Phase 5 follow-up; only telemetry-gated #157 remains. Phase 5 effectively complete after this lands.

**Closes #156**
**Closes #151**

## Strategy

Issue #156's body suggested copying `node_modules/@xenova/transformers/dist/*.wasm` into `dist/transformers/` at build time. After investigation:

- The package is now published as `@huggingface/transformers` v4 (Xenova fork is deprecated).
- onnxruntime-web v1.26-dev wasm files are 13–26 MB each; bundling any one of them blows the 2 MB delta budget by ~10×.
- The prebuilt minified browser bundle `dist/transformers.web.min.js` is **432 KB** — well within budget.

Pivoted to: copy the prebuilt browser bundle (+ ONNX JSEP loader companion, 46 KB) into `dist/transformers/`; mark `@huggingface/transformers` external in Vite's offscreen entry; load via `import(chrome.runtime.getURL('dist/transformers/transformers.web.min.js'))` at runtime. WASM kernels and the actual NER model continue to lazy-fetch from the HF/jsdelivr CDN at first use, cached via the Cache API. Mirrors the existing MLC WebLLM runtime-fetch pattern.

## Bundle delta

| | Baseline | After #156 | Delta |
|---|---|---|---|
| `dist/` total | 6.2 MB | 6.7 MB | **+500 KB** |
| `dist/offscreen/index.js` | 6.0 MB | 6.0 MB | 0 |
| `dist/transformers/` | — | 496 KB | +496 KB |

Well within the 2 MB budget. Static `@huggingface/transformers` references in source erase to type-only imports; the runtime URL is built dynamically (`chrome.runtime.getURL`) so the bundler doesn't statically resolve it.

## What ships

### Module layer
- **`src/offscreen/transformers-runtime.ts`** — single-flight `loadTransformers()` shared between the NER engine and lang-detect xlm fallback. Sets `env.backends.onnx.wasm.numThreads = 1` exactly once (offscreen docs lack COOP/COEP, so SharedArrayBuffer is unavailable; explicit `numThreads=1` suppresses the silent threaded-WASM fallback warning). DI seam (`_setTransformersImporterForTesting`) for unit tests.
- **`src/offscreen/ner-engine.ts`** — singleton + total `handleRunNer(text, deadlineMs?, offset?)`. Race-against-deadline: cold-load + inference compete with the 250 ms budget so a slow first call returns `[]` rather than blocking the orchestrator. CONFIDENCE_FLOOR=0.85, BIO-prefix strip, `entity_group` / `entity` narrowing, unknown-tag drop. Total/never-throws.
- **`src/offscreen/lang-detect-engine.ts`** (modified) — `getOrInitXlm()` stub at lines 65-71 replaced with a real `text-classification` pipeline using `Xenova/xlm-roberta-base-language-detection`. Same single-flight + 30-second cold-load timeout pattern as the NER engine. Closes #151.

### RPC + integration
- **`src/types/messages.ts`** (modified) — `'RUN_NER' | 'NER_RESULT'` added to `MessageType` + `HoneyLLMMessage` union; `RunNerMessage { text, chunkOffset, deadlineMs? }` and `NerResultMessage { entities, inferenceMs }`.
- **`src/offscreen/index.ts`** (modified) — RUN_NER handler block mirroring DETECT_LANGUAGE; pre-warm `handleRunNer('warmup', 30_000)` at offscreen-doc creation alongside the existing `initEngine()` top-level call.
- **`src/service-worker/ner-router.ts`** — sha256-keyed cache + single-flight, mirrors `language-router.ts`. Cache key includes `chunkOffset` so different absolute positions don't share entries (the offscreen handler reuses chunkOffset for span absolute-ization). Total contract.
- **`src/hunters/ner/merge-ner.ts`** — window-merge of chunk-absolute NER spans into per-packet entity arrays. Re-bases spans to packet-relative offsets so evidence-review and popup rendering see uniform semantics with regex extractors. Boundary-straddling drops, multi-packet routing, empty-NER pass-through.
- **`src/probes/base-probe.ts`** (modified) — `EvidencePacket.flaggedAbsStart: number` lets `mergeNerIntoPackets` compute packet windows without `String.indexOf` re-finds. `evidence-builder.ts` populates from `pos` (located path) or `sliceStart` (centre-fallback path).
- **`src/service-worker/orchestrator.ts`** (modified, ~lines 274-300) — chunk loop calls `runNerForChunk(chunk.text, 0)` after `buildEvidencePackets` returns non-empty, then merges via `mergeNerIntoPackets`. Try/catch — NER failure logs and proceeds with regex-only entities. Benign chunks skip NER entirely.

### Build + manifest
- **`build.ts`** — per-entry `external: readonly string[]` flag; offscreen marks `@huggingface/transformers` external so Rollup leaves the runtime `import()` intact. Asset-copy step appends the prebuilt bundle and ONNX JSEP loader (`cpSync`-ish via fs.copyFileSync, matching the existing pattern).
- **`manifest.json`** — `worker-src 'self' blob:` added to `extension_pages` CSP (ONNX runtime spawns a Worker via blob URL); `dist/transformers/*` added to `web_accessible_resources`. The pre-existing `wasm-unsafe-eval` directive is unchanged.

### Surface
- **`src/hunters/ner/types.ts`** — `EntityType` extended with `person | organization | location | misc`.
- **`src/popup/entities.ts`** — `ENTITY_TYPE_ORDER` + `ENTITY_TYPE_LABEL` extended. NER classes appear AFTER regex types (regex remain stronger exfiltration signals; NER is contextual signal for human review). `maskValue()` falls through to raw `entity.value` for the new types — these are descriptive context, not credentials.

## Hard constraints honored

- ✅ `git diff main -- docs/testing/inbrowser-results.json` is empty (Phase 2 byte-lock preserved)
- ✅ `TierDecision` union unchanged at `'BENIGN' | 'UNCERTAIN' | 'FLAGGED'`
- ✅ Bundle delta: **+500 KB** (≤2 MB budget)
- ✅ Model file NOT bundled — lazy-fetched from HF CDN at first use
- ✅ TypeScript strict — no `any` (uses `unknown` + narrowing in transformers-runtime; minimal structural `NerPipeline` interface in ner-engine)
- ✅ Files under 400 lines (largest new: ner-engine.ts ~165 lines)
- ✅ Total/never-throws contract: `handleRunNer`, `runNerForChunk`, `mergeNerIntoPackets`, `getOrInitXlm` all return safe defaults on every error path
- ✅ Offscreen lazy creation preserved; pre-warm fires once per offscreen-doc lifetime; idempotent

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — **806/806 pass** (was 771 baseline, **+35 new tests**)
- [x] `npm run build` — clean
- [x] `du -sh dist/` — 6.7 MB (+500 KB delta)
- [x] `git diff main -- docs/testing/inbrowser-results.json` — empty
- [x] `ls dist/transformers/` — `transformers.web.min.js` + `ort-wasm-simd-threaded.jsep.mjs` present, no extra weight
- [x] `dist/offscreen/index.js` does NOT contain `@huggingface/transformers` source (verified by grep)
- [ ] **Manual smoke**: load `dist/` as unpacked extension → verify offscreen console shows `[NerEngine]` / `[TransformersRuntime]` init logs without CSP violations on first scan
- [ ] **Manual smoke**: visit a Wikipedia article with named entities → popup `#accordion-entities` shows `People` / `Organizations` / `Locations` rows with raw values
- [ ] **Manual smoke**: benign Wikipedia stub → no PER/LOC/ORG chips
- [ ] **Manual smoke (lang-detect, closes #151)**: in offscreen test mode, force `LanguageDetector` API absent → SW console shows `xlm-roberta` source on `LanguageResultMessage`

## Test coverage breakdown

| Module | New tests |
|---|---|
| `transformers-runtime` | 3 |
| `ner-engine` | 12 (T1–T8 + 4 edge cases) |
| `lang-detect-engine` (xlm fallback) | 6 (T9–T12 + 2 edge cases) |
| `merge-ner` | 7 (T14–T16 + 4 edge cases) |
| `ner-router` | 5 (T13 + 4) |
| `popup-entities` | 2 (T18, T19) |
| **Total new** | **+35** |

## Phase 5 closure

This PR is the last actionable Phase 5 follow-up. After merge:

- ✅ #112 #113 #114 #115 #116 #117 #118 #119 #120 #121 #122 #123 #144 #145 (Stage 1 + Stage 2)
- ✅ **#156** (this PR)
- ✅ **#151** (closed as side-effect of #156's runtime install)
- ⏳ #157 (telemetry-gated until ≥1 week of fast-path hit-rate observation; reassess ~2026-05-07)

## Follow-ups (deferred)

- File issue if popup needs an explicit "Initializing AI models…" cold-start hint. The pre-warm at offscreen-doc creation greatly reduces the cold-window, but a slow connection on a fresh install could still cause the first scan to land mid-load and surface regex-only entities. Best-effort UX, not load-bearing.
- ~2026-05-07: query #157 fast-path telemetry to decide whether to ship the strict-LLM-bypass on high-confidence exfil entities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)