### PR TITLE
feat(phase6-#127): page scan result caching — chunk-hash diffing in IndexedDB (N11)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@anthropic-ai/sdk": "^0.39.0",
         "@playwright/test": "^1.49.0",
         "@types/chrome": "^0.0.287",
+        "fake-indexeddb": "^6.2.5",
         "jsdom": "^29.1.0",
         "sharp": "^0.34.5",
         "tsx": "^4.21.0",
@@ -2372,6 +2373,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fdir": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@anthropic-ai/sdk": "^0.39.0",
     "@playwright/test": "^1.49.0",
     "@types/chrome": "^0.0.287",
+    "fake-indexeddb": "^6.2.5",
     "jsdom": "^29.1.0",
     "sharp": "^0.34.5",
     "tsx": "^4.21.0",

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -503,6 +503,13 @@
         </div>
       </details>
 
+      <details class="accordion" id="accordion-cache">
+        <summary>Scan cache</summary>
+        <div class="card">
+          <div class="placeholder" id="cache-body">Loading cache stats…</div>
+        </div>
+      </details>
+
       <details class="accordion" id="accordion-policy">
         <summary>Per-origin policy</summary>
         <div class="card" id="policy-body">

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -24,6 +24,7 @@ import {
 } from './testing-mode-controls.js';
 import { renderHunterSummary, type HunterSummary } from './hunter-findings.js';
 import { renderEntitySummary, type EntitySummary } from './entities.js';
+import { getCacheStats, clearCache } from '@/service-worker/scan-cache.js';
 
 interface StoredVerdict {
   status: string;
@@ -491,6 +492,72 @@ function initQuickLinks(): void {
   }
 }
 
+/**
+ * Issue #127 (N11) — render the Scan cache accordion. Reads stats
+ * directly from the cache module (which itself reads IndexedDB +
+ * chrome.storage); the popup runs in extension context so it shares
+ * the same origin as the SW and can hit the same DB. Includes a
+ * "Clear cache" button that drops every entry and resets telemetry.
+ */
+async function initCacheAccordion(): Promise<void> {
+  const bodyEl = document.getElementById('cache-body');
+  if (bodyEl === null) return;
+  const body: HTMLElement = bodyEl;
+
+  async function refresh(): Promise<void> {
+    try {
+      const stats = await getCacheStats();
+      const sizeKb = (stats.sizeBytes / 1024).toFixed(1);
+      const maxMb = (stats.maxBytes / 1024 / 1024).toFixed(0);
+      const ttlH = (stats.ttlMs / 1000 / 60 / 60).toFixed(1);
+      const hitRateText =
+        stats.hitRate === null
+          ? '— (no lookups yet)'
+          : `${(stats.hitRate * 100).toFixed(1)}% (${stats.hits} hit / ${stats.misses} miss)`;
+      const wrapper = document.createElement('div');
+      wrapper.className = 'meta';
+      wrapper.style.lineHeight = '1.6';
+
+      const stats1 = document.createElement('div');
+      stats1.textContent = `Entries: ${stats.entries}   Size: ${sizeKb} KB / ${maxMb} MB   TTL: ${ttlH}h`;
+      wrapper.appendChild(stats1);
+
+      const stats2 = document.createElement('div');
+      stats2.textContent = `Hit rate: ${hitRateText}`;
+      wrapper.appendChild(stats2);
+
+      const btnRow = document.createElement('div');
+      btnRow.style.marginTop = '8px';
+      const btn = document.createElement('button');
+      btn.textContent = 'Clear cache';
+      btn.className = 'quick-link';
+      btn.addEventListener('click', async () => {
+        btn.disabled = true;
+        btn.textContent = 'Clearing…';
+        try {
+          await clearCache();
+          showToast('Cache cleared');
+          await refresh();
+        } catch (err) {
+          console.error('clearCache failed', err);
+          showToast('Could not clear cache');
+          btn.disabled = false;
+          btn.textContent = 'Clear cache';
+        }
+      });
+      btnRow.appendChild(btn);
+      wrapper.appendChild(btnRow);
+
+      body.replaceChildren(wrapper);
+    } catch (err) {
+      console.error('cache stats render failed', err);
+      body.textContent = 'Cache stats unavailable.';
+    }
+  }
+
+  await refresh();
+}
+
 void (async () => {
   try {
     await initSiteCard();
@@ -532,5 +599,10 @@ void (async () => {
     await loadVerdict();
   } catch (err) {
     console.error('loadVerdict failed', err);
+  }
+  try {
+    await initCacheAccordion();
+  } catch (err) {
+    console.error('cache accordion init failed', err);
   }
 })();

--- a/src/service-worker/cache-replay.test.ts
+++ b/src/service-worker/cache-replay.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from 'vitest';
+import { prepareCachedReplay, hashesAllCovered } from './cache-replay.js';
+import type { Chunk } from '@/types/chunk.js';
+import type { CachedScan, CachedChunk } from '@/types/scan-cache.js';
+import type { ProbeResult, TierRouting } from '@/types/verdict.js';
+import { CACHE_SCHEMA_VERSION, HUNTER_RULES_VERSION } from '@/shared/constants.js';
+
+const MODEL_ID = 'gemma-2-2b-it-q4f16_1-MLC';
+
+const BENIGN_TIER: TierRouting = {
+  decision: 'BENIGN',
+  primitiveCount: 0,
+  contributingHunters: [],
+};
+const FLAGGED_TIER: TierRouting = {
+  decision: 'FLAGGED',
+  primitiveCount: 2,
+  contributingHunters: ['spider', 'hawk'],
+};
+
+function makeChunk(text: string, contentHash: string, start = 0): Chunk {
+  return { text, start, end: start + text.length, contentHash };
+}
+
+function makeProbeResult(probeName: string, score: number): ProbeResult {
+  return {
+    probeName,
+    passed: score === 0,
+    flags: [],
+    rawOutput: '',
+    score,
+    errorMessage: null,
+  };
+}
+
+function makeCachedChunk(
+  contentHash: string,
+  tier: TierRouting,
+  probeResults: readonly ProbeResult[] | null,
+  notScanned?: true,
+): CachedChunk {
+  return notScanned
+    ? { contentHash, tierRouting: tier, probeResults, notScanned }
+    : { contentHash, tierRouting: tier, probeResults };
+}
+
+function makeCachedScan(chunks: readonly CachedChunk[], earlyExited = false): CachedScan {
+  return {
+    schemaVersion: CACHE_SCHEMA_VERSION,
+    hunterRulesVersion: HUNTER_RULES_VERSION,
+    llmModelId: MODEL_ID,
+    url: 'https://example.com/x',
+    fetchedAt: Date.now(),
+    chunks,
+    earlyExited,
+    entitySummary: null,
+    sizeBytes: 0,
+  };
+}
+
+describe('hashesAllCovered', () => {
+  it('returns true when every current hash exists in cached set', () => {
+    const cached = makeCachedScan([
+      makeCachedChunk('h0', BENIGN_TIER, null),
+      makeCachedChunk('h1', FLAGGED_TIER, [makeProbeResult('p', 0)]),
+    ]);
+    expect(hashesAllCovered(['h0', 'h1'], cached)).toBe(true);
+  });
+
+  it('returns true when current is a subset of cached (boundaries shrank)', () => {
+    const cached = makeCachedScan([
+      makeCachedChunk('h0', BENIGN_TIER, null),
+      makeCachedChunk('h1', FLAGGED_TIER, [makeProbeResult('p', 0)]),
+      makeCachedChunk('h2', BENIGN_TIER, null),
+    ]);
+    expect(hashesAllCovered(['h1'], cached)).toBe(true);
+  });
+
+  it('returns false when any current hash is missing', () => {
+    const cached = makeCachedScan([makeCachedChunk('h0', BENIGN_TIER, null)]);
+    expect(hashesAllCovered(['h0', 'h-new'], cached)).toBe(false);
+  });
+});
+
+describe('prepareCachedReplay: full hit', () => {
+  it('marks every chunk as a hit when all hashes match', () => {
+    const chunks = [
+      makeChunk('alpha', 'h0', 0),
+      makeChunk('beta', 'h1', 5),
+    ];
+    const cached = makeCachedScan([
+      makeCachedChunk('h0', BENIGN_TIER, null),
+      makeCachedChunk('h1', FLAGGED_TIER, [makeProbeResult('summarization', 0)]),
+    ]);
+    const result = prepareCachedReplay(chunks, cached);
+    expect(result.hitIndices).toEqual([0, 1]);
+    expect(result.missIndices).toEqual([]);
+    expect(result.replayedChunkResults[0]).toEqual([]);
+    expect(result.replayedChunkResults[1]?.[0]?.probeName).toBe('summarization');
+    expect(result.replayedPerChunkAnalysis[0]?.tierRouting.decision).toBe('BENIGN');
+    expect(result.replayedPerChunkAnalysis[1]?.tierRouting.decision).toBe('FLAGGED');
+    expect(result.earlyExitedReplay).toBe(false);
+  });
+
+  it('preserves earlyExited from a cached early-exit run', () => {
+    const chunks = [
+      makeChunk('alpha', 'h0', 0),
+      makeChunk('beta', 'h1', 5),
+    ];
+    const cached = makeCachedScan(
+      [
+        makeCachedChunk('h0', FLAGGED_TIER, [makeProbeResult('p', 90)]),
+        makeCachedChunk('h1', FLAGGED_TIER, null, true),
+      ],
+      true,
+    );
+    const result = prepareCachedReplay(chunks, cached);
+    expect(result.earlyExitedReplay).toBe(true);
+    expect(result.replayedPerChunkAnalysis[1]?.notScanned).toBe(true);
+  });
+});
+
+describe('prepareCachedReplay: partial hit', () => {
+  it('flags new-content chunks as misses while replaying matched ones', () => {
+    const chunks = [
+      makeChunk('alpha', 'h0', 0),
+      makeChunk('NEW PARAGRAPH', 'h-new', 5),
+      makeChunk('beta', 'h1', 18),
+    ];
+    const cached = makeCachedScan([
+      makeCachedChunk('h0', BENIGN_TIER, null),
+      makeCachedChunk('h1', BENIGN_TIER, null),
+    ]);
+    const result = prepareCachedReplay(chunks, cached);
+    expect(result.hitIndices).toEqual([0, 2]);
+    expect(result.missIndices).toEqual([1]);
+    expect(result.replayedChunkResults[0]).toEqual([]);
+    expect(result.replayedChunkResults[2]).toEqual([]);
+    // Miss index has no replayed entry yet (caller fills it in fresh)
+    expect(result.replayedPerChunkAnalysis[1]).toBeUndefined();
+  });
+});
+
+describe('prepareCachedReplay: total miss', () => {
+  it('returns every index as a miss when no hashes match', () => {
+    const chunks = [
+      makeChunk('a', 'h-x', 0),
+      makeChunk('b', 'h-y', 1),
+    ];
+    const cached = makeCachedScan([
+      makeCachedChunk('h0', BENIGN_TIER, null),
+      makeCachedChunk('h1', BENIGN_TIER, null),
+    ]);
+    const result = prepareCachedReplay(chunks, cached);
+    expect(result.hitIndices).toEqual([]);
+    expect(result.missIndices).toEqual([0, 1]);
+    expect(result.earlyExitedReplay).toBe(false);
+  });
+});
+
+describe('prepareCachedReplay: shifted boundaries', () => {
+  it('matches a chunk by hash even when it appears at a different index', () => {
+    const chunks = [
+      makeChunk('cached-text-now-second', 'h-cached', 100),
+      makeChunk('alpha', 'h0', 0),
+    ];
+    const cached = makeCachedScan([
+      makeCachedChunk('h0', BENIGN_TIER, null),
+      makeCachedChunk('h-cached', FLAGGED_TIER, [makeProbeResult('p', 50)]),
+    ]);
+    const result = prepareCachedReplay(chunks, cached);
+    expect(result.hitIndices).toEqual([0, 1]);
+    // Index 0 in current is the cached "h-cached" chunk → FLAGGED tier
+    expect(result.replayedPerChunkAnalysis[0]?.tierRouting.decision).toBe('FLAGGED');
+    // Index 1 in current is the cached "h0" chunk → BENIGN tier
+    expect(result.replayedPerChunkAnalysis[1]?.tierRouting.decision).toBe('BENIGN');
+  });
+});

--- a/src/service-worker/cache-replay.ts
+++ b/src/service-worker/cache-replay.ts
@@ -1,0 +1,119 @@
+import type { Chunk } from '@/types/chunk.js';
+import type { CachedScan, CachedChunk } from '@/types/scan-cache.js';
+import type { ChunkAnalysis, ProbeResult } from '@/types/verdict.js';
+
+/**
+ * Issue #127 (N11) — pure helpers for replaying a CachedScan against
+ * the freshly-extracted chunk list. Pulled out of the orchestrator into
+ * its own module so the integration logic is unit-testable without
+ * dragging the full analyzeSnapshot pipeline into the test.
+ */
+
+/**
+ * True iff every hash in `currentHashes` is present in the cached scan.
+ * Allows the caller to short-circuit to the all-hits aggregate path
+ * without computing per-chunk replay state.
+ *
+ * Subset is fine — a cached scan can carry MORE chunks than the current
+ * extraction (e.g. the page shrank); what matters is that every CURRENT
+ * chunk has a cached counterpart.
+ */
+export function hashesAllCovered(
+  currentHashes: readonly string[],
+  cached: CachedScan,
+): boolean {
+  const cachedSet = new Set(cached.chunks.map((c) => c.contentHash));
+  for (const h of currentHashes) {
+    if (!cachedSet.has(h)) return false;
+  }
+  return true;
+}
+
+export interface CacheReplayPlan {
+  /** Indices into the current chunks array that hit the cache. */
+  readonly hitIndices: readonly number[];
+  /** Indices into the current chunks array that missed and need fresh probes. */
+  readonly missIndices: readonly number[];
+  /**
+   * Sparse-array of replayed per-chunk probe results. `replayedChunkResults[i]`
+   * is populated for hit indices and absent for miss indices; the caller
+   * fills in misses after running runChunkProbes.
+   */
+  readonly replayedChunkResults: ReadonlyArray<readonly ProbeResult[] | undefined>;
+  /**
+   * Sparse-array of replayed ChunkAnalysis records. Same indexing
+   * convention as `replayedChunkResults`.
+   */
+  readonly replayedPerChunkAnalysis: ReadonlyArray<ChunkAnalysis | undefined>;
+  /**
+   * True iff the cached scan recorded an early-exit AND every current
+   * chunk hit the cache. A partial-hit replay cannot honour cached
+   * earlyExit because the miss chunks need fresh evaluation, so we
+   * conservatively drop the flag in that case.
+   */
+  readonly earlyExitedReplay: boolean;
+}
+
+/**
+ * Build a replay plan: for each current chunk, look up its hash in the
+ * cached chunks and stage either a hit (with cached probe results +
+ * tier routing) or a miss (caller runs the pipeline fresh).
+ *
+ * The cached chunk's `notScanned` flag is preserved on hits — a chunk
+ * that was padded out by #145 early-exit on the original run replays as
+ * a `notScanned: true` ChunkAnalysis entry, keeping the existing
+ * `perChunkAnalysis.length === chunks.length` invariant.
+ */
+export function prepareCachedReplay(
+  chunks: readonly Chunk[],
+  cached: CachedScan,
+): CacheReplayPlan {
+  const cachedByHash = new Map<string, CachedChunk>();
+  for (const c of cached.chunks) {
+    cachedByHash.set(c.contentHash, c);
+  }
+
+  const hitIndices: number[] = [];
+  const missIndices: number[] = [];
+  const replayedChunkResults: Array<readonly ProbeResult[] | undefined> = new Array(chunks.length);
+  const replayedPerChunkAnalysis: Array<ChunkAnalysis | undefined> = new Array(chunks.length);
+
+  for (let i = 0; i < chunks.length; i += 1) {
+    const hash = chunks[i]!.contentHash;
+    const hit = cachedByHash.get(hash);
+    if (hit === undefined) {
+      missIndices.push(i);
+      continue;
+    }
+    hitIndices.push(i);
+    // Empty array contributes nothing in mergeProbeResults — same
+    // semantics as the BENIGN early-exit path in orchestrator.ts:267.
+    replayedChunkResults[i] = hit.probeResults ?? [];
+    const analysis: ChunkAnalysis = hit.notScanned
+      ? {
+          index: i,
+          contentHash: hash,
+          tierRouting: hit.tierRouting,
+          probeResults: hit.probeResults,
+          notScanned: true,
+        }
+      : {
+          index: i,
+          contentHash: hash,
+          tierRouting: hit.tierRouting,
+          probeResults: hit.probeResults,
+        };
+    replayedPerChunkAnalysis[i] = analysis;
+  }
+
+  const fullHit = missIndices.length === 0 && hitIndices.length === chunks.length;
+  const earlyExitedReplay = fullHit && cached.earlyExited;
+
+  return {
+    hitIndices,
+    missIndices,
+    replayedChunkResults,
+    replayedPerChunkAnalysis,
+    earlyExitedReplay,
+  };
+}

--- a/src/service-worker/orchestrator.integration.test.ts
+++ b/src/service-worker/orchestrator.integration.test.ts
@@ -63,11 +63,16 @@ function buildHuntReport(
 }
 
 function buildChunk(index: number, text: string): Chunk {
+  // Issue #127 — orchestrator now propagates chunk.contentHash directly
+  // into perChunkAnalysis (replacing the prior recompute-via-content-hash).
+  // Test assertions match against /^[0-9a-f]+$/, so produce a hex string
+  // here rather than the prior "hash-N" form.
+  const hex = (index + 1).toString(16).padStart(64, '0');
   return {
     text,
     start: index * 100,
     end: index * 100 + text.length,
-    contentHash: `hash-${index}`,
+    contentHash: hex,
   };
 }
 

--- a/src/service-worker/orchestrator.ts
+++ b/src/service-worker/orchestrator.ts
@@ -2,7 +2,12 @@ import type { PageSnapshot } from '@/types/snapshot.js';
 import type { ProbeResult, SecurityVerdict, WebGPUAdapterMode, ChunkAnalysis } from '@/types/verdict.js';
 import type { PageStamp } from '@/types/page-stamp.js';
 import type { RunProbesMessage, ProbeResultsMessage } from '@/types/messages.js';
-import { MAX_CHUNKS_PER_PAGE, EARLY_EXIT_ANALYSIS_ERROR } from '@/shared/constants.js';
+import {
+  MAX_CHUNKS_PER_PAGE,
+  EARLY_EXIT_ANALYSIS_ERROR,
+  HUNTER_RULES_VERSION,
+  CACHE_SCHEMA_VERSION,
+} from '@/shared/constants.js';
 import { chunkText } from '@/hunters/hawk/chunking.js';
 import { runHunters } from '@/hunters/hunt-runner.js';
 import { spiderHunter } from '@/hunters/spider/index.js';
@@ -18,8 +23,16 @@ import { getOverrides } from '@/policy/origin-storage.js';
 import { ensureInstallSecret } from '@/shared/install-secret.js';
 import { generateStamp } from './stamp.js';
 import { routeChunk } from './tier-router.js';
-import { createContentHash } from './content-hash.js';
 import { buildEvidencePackets } from '@/probes/evidence-builder.js';
+import {
+  lookupScan,
+  writeScan,
+  recordCacheHit,
+  recordCacheMiss,
+  getEngineFingerprint,
+} from './scan-cache.js';
+import { prepareCachedReplay } from './cache-replay.js';
+import type { CachedScan, CachedChunk } from '@/types/scan-cache.js';
 import { runNerForChunk } from './ner-router.js';
 import { mergeNerIntoPackets } from '@/hunters/ner/merge-ner.js';
 import type { EvidencePacket } from '@/probes/base-probe.js';
@@ -220,6 +233,36 @@ export async function analyzeSnapshot(
 
   pendingChunks.set(tabId, []);
 
+  // Issue #127 (N11) — consult page-scan cache before doing any work.
+  // chunkText already produced stable contentHash per chunk; lookupScan
+  // checks schema/hunter-rules/llm-model versions and TTL. A hit can
+  // skip hunters/NER/probes entirely on covered chunks. The lookup
+  // failure mode is benign — caches are an optimization, not
+  // correctness — so swallow errors and proceed as if missed.
+  const engineFingerprint = await getEngineFingerprint();
+  let cachedScan: CachedScan | null = null;
+  try {
+    cachedScan = await lookupScan(snapshot.metadata.url, {
+      hunterRulesVersion: HUNTER_RULES_VERSION,
+      llmModelId: engineFingerprint,
+    });
+  } catch (err) {
+    log.warn('scan-cache lookup failed; proceeding without cache', err);
+  }
+  const replay = cachedScan === null ? null : prepareCachedReplay(chunks, cachedScan);
+  const hitSet = new Set(replay?.hitIndices ?? []);
+  const fullCacheHit =
+    replay !== null && replay.missIndices.length === 0 && chunks.length > 0;
+  if (fullCacheHit) {
+    log.info(`Cache hit (full): bypassing ${chunks.length} chunk(s) of probe work`);
+    await recordCacheHit().catch(() => undefined);
+  } else if (hitSet.size > 0) {
+    log.info(`Cache hit (partial): ${hitSet.size}/${chunks.length} chunks reused from cache`);
+    await recordCacheHit().catch(() => undefined);
+  } else {
+    await recordCacheMiss().catch(() => undefined);
+  }
+
   try {
     // Phase 4 Stage 4B — serialize chunks. The previous Promise.all fanout
     // issued all RUN_PROBES messages concurrently into a single MLC engine,
@@ -237,7 +280,10 @@ export async function analyzeSnapshot(
     // signalling that subsequent chunks were padded out and the chunk loop
     // exited early. Folded into aggregateError so popup/storage callers can
     // distinguish early-exit from a normal completion.
-    let earlyExited = false;
+    // Issue #127 — preserved across cache replays: a fully-hit early-exited
+    // page replays as earlyExited=true so EARLY_EXIT_ANALYSIS_ERROR carries
+    // forward identically.
+    let earlyExited = fullCacheHit && cachedScan !== null ? cachedScan.earlyExited : false;
     for (let index = 0; index < chunks.length; index += 1) {
       // Issue #11 — check the signal before dispatching each chunk. A new
       // PAGE_SNAPSHOT arriving mid-analysis flips this flag; reject rather
@@ -249,8 +295,28 @@ export async function analyzeSnapshot(
         log.info(`Analysis for ${snapshot.metadata.url} aborted between chunks (${reason})`);
         throw new AnalysisAbortedError(reason);
       }
+
+      // Issue #127 (N11) — cache replay shortcut. A hit means we have
+      // cached probeResults + tierRouting for this chunk; reuse them and
+      // skip hunters/NER/probes entirely. mergeProbeResults treats an
+      // empty array (BENIGN cached chunks) as a no-op contribution, so
+      // the aggregate stays consistent with the fresh-scan path.
+      if (replay !== null && hitSet.has(index)) {
+        const cachedAnalysis = replay.replayedPerChunkAnalysis[index];
+        const cachedResults = replay.replayedChunkResults[index];
+        if (cachedAnalysis !== undefined && cachedResults !== undefined) {
+          allChunkResults.push(cachedResults);
+          perChunkAnalysis.push(cachedAnalysis);
+          continue;
+        }
+        // Defensive: cachedAnalysis missing despite hitSet membership.
+        // Fall through to the fresh-pipeline path so the chunk still
+        // gets analyzed; do not fail the whole verdict.
+        log.warn(`Cache replay slot ${index} marked hit but missing data; falling through`);
+      }
+
       const chunk = chunks[index]!.text;
-      const contentHash = await createContentHash(chunk);
+      const contentHash = chunks[index]!.contentHash;
 
       // Issue #112 (N1) — Hunters first; k=2 router gates the LLM tier.
       // BENIGN chunks skip probes entirely. Hunter aggregateError → UNCERTAIN
@@ -331,9 +397,14 @@ export async function analyzeSnapshot(
       if (huntReport.shouldSkipProbes) {
         const padded = chunks.length - index - 1;
         for (let pad = index + 1; pad < chunks.length; pad += 1) {
+          // Issue #127 — record the real contentHash on padded entries so a
+          // future revisit can hash-match the unscanned chunks and replay
+          // the early-exit verdict instead of falling back to a partial-cache
+          // miss that would re-scan chunks the original run intentionally
+          // skipped.
           perChunkAnalysis.push({
             index: pad,
-            contentHash: '',
+            contentHash: chunks[pad]!.contentHash,
             tierRouting,
             probeResults: null,
             notScanned: true,
@@ -389,6 +460,45 @@ export async function analyzeSnapshot(
     };
 
     await persistVerdict(verdict);
+
+    // Issue #127 (N11) — write the per-chunk results back to the cache
+    // so the next revisit can replay them. Failures here are non-fatal;
+    // the verdict is already persisted via persistVerdict above. We
+    // re-read the engine fingerprint at write time in case the user
+    // changed canary preference mid-scan (rare, but the version-mismatch
+    // invariant should hold across writes too).
+    try {
+      const writeFingerprint = await getEngineFingerprint();
+      const cachedChunks: CachedChunk[] = perChunkAnalysis.map((a) => {
+        const base: CachedChunk = a.notScanned
+          ? {
+              contentHash: a.contentHash,
+              tierRouting: a.tierRouting,
+              probeResults: a.probeResults,
+              notScanned: true,
+            }
+          : {
+              contentHash: a.contentHash,
+              tierRouting: a.tierRouting,
+              probeResults: a.probeResults,
+            };
+        return base;
+      });
+      const newCache: CachedScan = {
+        schemaVersion: CACHE_SCHEMA_VERSION,
+        hunterRulesVersion: HUNTER_RULES_VERSION,
+        llmModelId: writeFingerprint,
+        url: snapshot.metadata.url,
+        fetchedAt: Date.now(),
+        chunks: cachedChunks,
+        earlyExited,
+        entitySummary,
+        sizeBytes: 0, // recomputed by writeScan
+      };
+      await writeScan(newCache);
+    } catch (err) {
+      log.warn('scan-cache write failed; verdict persisted but cache not updated', err);
+    }
 
     log.info(`Verdict for ${snapshot.metadata.url}: ${verdict.status} (${verdict.confidence})${verdict.analysisError ? ` [analysisError: ${verdict.analysisError}]` : ''}`);
 

--- a/src/service-worker/scan-cache.test.ts
+++ b/src/service-worker/scan-cache.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import { IDBFactory } from 'fake-indexeddb';
+import {
+  lookupScan,
+  writeScan,
+  clearCache,
+  getCacheStats,
+  recordCacheHit,
+  recordCacheMiss,
+  resetCacheTelemetry,
+} from './scan-cache.js';
+import type { CachedScan } from '@/types/scan-cache.js';
+import {
+  CACHE_SCHEMA_VERSION,
+  HUNTER_RULES_VERSION,
+  CACHE_DEFAULT_TTL_MS,
+  CACHE_DEFAULT_MAX_BYTES,
+} from '@/shared/constants.js';
+
+const MODEL_ID = 'gemma-2-2b-it-q4f16_1-MLC';
+const STALE_MODEL_ID = 'old-model-id';
+
+function makeRecord(overrides: Partial<CachedScan> = {}): CachedScan {
+  const base: CachedScan = {
+    schemaVersion: CACHE_SCHEMA_VERSION,
+    hunterRulesVersion: HUNTER_RULES_VERSION,
+    llmModelId: MODEL_ID,
+    url: 'https://example.com/page-a',
+    fetchedAt: Date.now(),
+    chunks: [
+      {
+        contentHash: 'hash-0',
+        tierRouting: { decision: 'BENIGN', primitiveCount: 0, contributingHunters: [] },
+        probeResults: null,
+      },
+    ],
+    earlyExited: false,
+    entitySummary: null,
+    sizeBytes: 0,
+  };
+  return { ...base, ...overrides };
+}
+
+// fake-indexeddb auto-installs at vitest setup; reset its state between
+// tests by replacing the factory and re-installing on globalThis.
+// chrome.storage is also stubbed in-memory for telemetry persistence.
+beforeEach(async () => {
+  // Reset IndexedDB
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).indexedDB = new IDBFactory();
+  // Reset chrome.storage.local stub
+  const store = new Map<string, unknown>();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).chrome = {
+    storage: {
+      local: {
+        get: async (keys?: string | string[] | null) => {
+          if (keys === null || keys === undefined) {
+            return Object.fromEntries(store);
+          }
+          const arr = Array.isArray(keys) ? keys : [keys];
+          const out: Record<string, unknown> = {};
+          for (const k of arr) {
+            if (store.has(k)) out[k] = store.get(k);
+          }
+          return out;
+        },
+        set: async (items: Record<string, unknown>) => {
+          for (const [k, v] of Object.entries(items)) store.set(k, v);
+        },
+        remove: async (keys: string | string[]) => {
+          const arr = Array.isArray(keys) ? keys : [keys];
+          for (const k of arr) store.delete(k);
+        },
+      },
+    },
+  };
+  await resetCacheTelemetry();
+});
+
+describe('scan-cache: lookup miss/hit', () => {
+  it('returns null on empty cache', async () => {
+    const result = await lookupScan('https://example.com/x', {
+      hunterRulesVersion: HUNTER_RULES_VERSION,
+      llmModelId: MODEL_ID,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('round-trips a record', async () => {
+    const rec = makeRecord();
+    await writeScan(rec);
+    const loaded = await lookupScan(rec.url, {
+      hunterRulesVersion: HUNTER_RULES_VERSION,
+      llmModelId: MODEL_ID,
+    });
+    expect(loaded).not.toBeNull();
+    expect(loaded?.url).toBe(rec.url);
+    expect(loaded?.chunks.length).toBe(1);
+    expect(loaded?.chunks[0]?.contentHash).toBe('hash-0');
+  });
+});
+
+describe('scan-cache: version-mismatch invalidation', () => {
+  it('returns null when stored hunterRulesVersion differs', async () => {
+    await writeScan(makeRecord({ hunterRulesVersion: '0.1.0' }));
+    const result = await lookupScan('https://example.com/page-a', {
+      hunterRulesVersion: HUNTER_RULES_VERSION,
+      llmModelId: MODEL_ID,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('returns null when stored llmModelId differs', async () => {
+    await writeScan(makeRecord({ llmModelId: STALE_MODEL_ID }));
+    const result = await lookupScan('https://example.com/page-a', {
+      hunterRulesVersion: HUNTER_RULES_VERSION,
+      llmModelId: MODEL_ID,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('returns null when stored schemaVersion differs', async () => {
+    // Forge a record with schemaVersion=0; lookup must reject.
+    await writeScan(makeRecord({ schemaVersion: 0 as unknown as 1 }));
+    const result = await lookupScan('https://example.com/page-a', {
+      hunterRulesVersion: HUNTER_RULES_VERSION,
+      llmModelId: MODEL_ID,
+    });
+    expect(result).toBeNull();
+  });
+});
+
+describe('scan-cache: TTL eviction', () => {
+  it('returns null when entry is older than configured TTL', async () => {
+    const stale = makeRecord({ fetchedAt: Date.now() - (CACHE_DEFAULT_TTL_MS + 1000) });
+    await writeScan(stale);
+    const result = await lookupScan(stale.url, {
+      hunterRulesVersion: HUNTER_RULES_VERSION,
+      llmModelId: MODEL_ID,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('respects custom TTL from chrome.storage', async () => {
+    // Set a very short custom TTL: 100 ms.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (globalThis as any).chrome.storage.local.set({
+      'honeyllm:cache-ttl-ms': 100,
+    });
+    const rec = makeRecord({ fetchedAt: Date.now() - 200 });
+    await writeScan(rec);
+    const result = await lookupScan(rec.url, {
+      hunterRulesVersion: HUNTER_RULES_VERSION,
+      llmModelId: MODEL_ID,
+    });
+    expect(result).toBeNull();
+  });
+});
+
+describe('scan-cache: clearCache', () => {
+  it('removes every entry', async () => {
+    await writeScan(makeRecord({ url: 'https://example.com/a' }));
+    await writeScan(makeRecord({ url: 'https://example.com/b' }));
+    await clearCache();
+    const stats = await getCacheStats();
+    expect(stats.entries).toBe(0);
+    expect(stats.sizeBytes).toBe(0);
+  });
+
+  it('resets telemetry counters', async () => {
+    await recordCacheHit();
+    await recordCacheHit();
+    await recordCacheMiss();
+    await clearCache();
+    const stats = await getCacheStats();
+    expect(stats.hits).toBe(0);
+    expect(stats.misses).toBe(0);
+    expect(stats.hitRate).toBeNull();
+  });
+});
+
+describe('scan-cache: getCacheStats', () => {
+  it('reports zero when empty', async () => {
+    const stats = await getCacheStats();
+    expect(stats.entries).toBe(0);
+    expect(stats.sizeBytes).toBe(0);
+    expect(stats.maxBytes).toBe(CACHE_DEFAULT_MAX_BYTES);
+    expect(stats.ttlMs).toBe(CACHE_DEFAULT_TTL_MS);
+    expect(stats.hits).toBe(0);
+    expect(stats.misses).toBe(0);
+    expect(stats.hitRate).toBeNull();
+  });
+
+  it('aggregates entry count and bytes after writes', async () => {
+    await writeScan(makeRecord({ url: 'https://example.com/a' }));
+    await writeScan(makeRecord({ url: 'https://example.com/b' }));
+    const stats = await getCacheStats();
+    expect(stats.entries).toBe(2);
+    expect(stats.sizeBytes).toBeGreaterThan(0);
+  });
+
+  it('computes hitRate from telemetry', async () => {
+    await recordCacheHit();
+    await recordCacheHit();
+    await recordCacheHit();
+    await recordCacheMiss();
+    const stats = await getCacheStats();
+    expect(stats.hits).toBe(3);
+    expect(stats.misses).toBe(1);
+    expect(stats.hitRate).toBeCloseTo(0.75);
+  });
+});
+
+describe('scan-cache: LRU eviction on write', () => {
+  it('evicts oldest fetchedAt entries until under maxBytes budget', async () => {
+    // Set a tiny budget so two records exceed it.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (globalThis as any).chrome.storage.local.set({
+      'honeyllm:cache-max-bytes': 600,
+    });
+    const now = Date.now();
+    // Three records, each ~250 bytes serialized. Budget=600 → after 3rd
+    // write, oldest (a) must be evicted.
+    await writeScan(makeRecord({ url: 'https://example.com/a', fetchedAt: now - 3000 }));
+    await writeScan(makeRecord({ url: 'https://example.com/b', fetchedAt: now - 2000 }));
+    await writeScan(makeRecord({ url: 'https://example.com/c', fetchedAt: now - 1000 }));
+    const stats = await getCacheStats();
+    expect(stats.sizeBytes).toBeLessThanOrEqual(600);
+    // The oldest entry is gone; the two newest remain.
+    expect(
+      await lookupScan('https://example.com/a', {
+        hunterRulesVersion: HUNTER_RULES_VERSION,
+        llmModelId: MODEL_ID,
+      }),
+    ).toBeNull();
+    expect(
+      await lookupScan('https://example.com/c', {
+        hunterRulesVersion: HUNTER_RULES_VERSION,
+        llmModelId: MODEL_ID,
+      }),
+    ).not.toBeNull();
+  });
+});
+
+describe('scan-cache: telemetry counters', () => {
+  it('increments hits independently from misses', async () => {
+    await recordCacheHit();
+    await recordCacheMiss();
+    await recordCacheHit();
+    const stats = await getCacheStats();
+    expect(stats.hits).toBe(2);
+    expect(stats.misses).toBe(1);
+  });
+});

--- a/src/service-worker/scan-cache.ts
+++ b/src/service-worker/scan-cache.ts
@@ -1,0 +1,370 @@
+import type { CachedScan, CacheStats } from '@/types/scan-cache.js';
+import {
+  CACHE_DB_NAME,
+  CACHE_DB_VERSION,
+  CACHE_STORE_NAME,
+  CACHE_SCHEMA_VERSION,
+  CACHE_DEFAULT_TTL_MS,
+  CACHE_DEFAULT_MAX_BYTES,
+  STORAGE_KEY_CACHE_TTL_MS,
+  STORAGE_KEY_CACHE_MAX_BYTES,
+  STORAGE_KEY_CACHE_TELEMETRY,
+  STORAGE_KEY_CANARY,
+  DEFAULT_CANARY_ID,
+  type CanaryId,
+} from '@/shared/constants.js';
+import { createLogger } from '@/shared/logger.js';
+
+const log = createLogger('ScanCache');
+
+interface CacheVersionGuard {
+  readonly hunterRulesVersion: string;
+  readonly llmModelId: string;
+}
+
+interface CacheTelemetry {
+  readonly hits: number;
+  readonly misses: number;
+  readonly resetAt: number;
+}
+
+/**
+ * Open the page-scan IndexedDB connection. Re-opens on every call: MV3
+ * service workers can be terminated mid-session and a stale `IDBDatabase`
+ * handle from a prior activation will throw `InvalidStateError` on use.
+ * Opening per-call is the simple correctness-first approach; the open
+ * itself is cheap (sub-millisecond once the schema exists).
+ */
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(CACHE_DB_NAME, CACHE_DB_VERSION);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(CACHE_STORE_NAME)) {
+        const store = db.createObjectStore(CACHE_STORE_NAME, { keyPath: 'url' });
+        // fetchedAt index drives the LRU eviction loop; sorting by it
+        // lets us walk oldest→newest without a full table scan.
+        store.createIndex('fetchedAt', 'fetchedAt', { unique: false });
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error ?? new Error('indexedDB.open failed'));
+  });
+}
+
+function promisifyRequest<T>(req: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error ?? new Error('IDBRequest failed'));
+  });
+}
+
+async function readConfigNumber(key: string, fallback: number): Promise<number> {
+  try {
+    const result = await chrome.storage.local.get(key);
+    const value = result[key];
+    return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+async function getTtlMs(): Promise<number> {
+  return readConfigNumber(STORAGE_KEY_CACHE_TTL_MS, CACHE_DEFAULT_TTL_MS);
+}
+
+async function getMaxBytes(): Promise<number> {
+  return readConfigNumber(STORAGE_KEY_CACHE_MAX_BYTES, CACHE_DEFAULT_MAX_BYTES);
+}
+
+function isValidCachedScan(value: unknown): value is CachedScan {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.schemaVersion === 'number' &&
+    typeof v.hunterRulesVersion === 'string' &&
+    typeof v.llmModelId === 'string' &&
+    typeof v.url === 'string' &&
+    typeof v.fetchedAt === 'number' &&
+    Array.isArray(v.chunks) &&
+    typeof v.earlyExited === 'boolean' &&
+    typeof v.sizeBytes === 'number'
+  );
+}
+
+/**
+ * Look up a cached scan for the given URL, validating that the stored
+ * record matches the current schema version, hunter rules version, and
+ * LLM model id, and that it hasn't expired. Mismatches and TTL-expired
+ * records return null AND lazily delete the stale record.
+ */
+export async function lookupScan(
+  url: string,
+  guard: CacheVersionGuard,
+): Promise<CachedScan | null> {
+  const db = await openDb();
+  try {
+    const tx = db.transaction(CACHE_STORE_NAME, 'readonly');
+    const store = tx.objectStore(CACHE_STORE_NAME);
+    const raw = await promisifyRequest(store.get(url));
+    if (!isValidCachedScan(raw)) return null;
+
+    const ttl = await getTtlMs();
+    const expired = Date.now() - raw.fetchedAt > ttl;
+    const versionMismatch =
+      raw.schemaVersion !== CACHE_SCHEMA_VERSION ||
+      raw.hunterRulesVersion !== guard.hunterRulesVersion ||
+      raw.llmModelId !== guard.llmModelId;
+
+    if (expired || versionMismatch) {
+      await deleteEntry(url).catch((err) => {
+        log.warn(`Failed to evict stale cache entry for ${url}`, err);
+      });
+      return null;
+    }
+    return raw;
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * Persist a CachedScan record, recomputing `sizeBytes` from the
+ * serialized form. Triggers LRU eviction if the post-write store size
+ * exceeds the configured budget.
+ */
+export async function writeScan(record: CachedScan): Promise<void> {
+  const sized: CachedScan = {
+    ...record,
+    sizeBytes: 0, // placeholder so JSON.stringify is deterministic
+  };
+  const sizeBytes = JSON.stringify(sized).length;
+  const final: CachedScan = { ...record, sizeBytes };
+
+  const db = await openDb();
+  try {
+    const tx = db.transaction(CACHE_STORE_NAME, 'readwrite');
+    const store = tx.objectStore(CACHE_STORE_NAME);
+    await promisifyRequest(store.put(final));
+    await new Promise<void>((resolve, reject) => {
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error ?? new Error('writeScan tx failed'));
+      tx.onabort = () => reject(tx.error ?? new Error('writeScan tx aborted'));
+    });
+  } finally {
+    db.close();
+  }
+  await evictIfOverBudget();
+}
+
+async function deleteEntry(url: string): Promise<void> {
+  const db = await openDb();
+  try {
+    const tx = db.transaction(CACHE_STORE_NAME, 'readwrite');
+    await promisifyRequest(tx.objectStore(CACHE_STORE_NAME).delete(url));
+    await new Promise<void>((resolve, reject) => {
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error ?? new Error('deleteEntry tx failed'));
+      tx.onabort = () => reject(tx.error ?? new Error('deleteEntry tx aborted'));
+    });
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * Walk the fetchedAt index oldest→newest, deleting until the cumulative
+ * size of remaining entries fits under maxBytes. Called after every
+ * write so the cache cannot grow unbounded.
+ */
+async function evictIfOverBudget(): Promise<void> {
+  const maxBytes = await getMaxBytes();
+  const db = await openDb();
+  try {
+    // First read all entries via the fetchedAt index (sorted ascending).
+    const tx = db.transaction(CACHE_STORE_NAME, 'readonly');
+    const idx = tx.objectStore(CACHE_STORE_NAME).index('fetchedAt');
+    const all = (await promisifyRequest(idx.getAll())) as CachedScan[];
+    const totalBytes = all.reduce((sum, r) => sum + (r.sizeBytes ?? 0), 0);
+    if (totalBytes <= maxBytes) return;
+
+    let runningBytes = totalBytes;
+    const toEvict: string[] = [];
+    for (const entry of all) {
+      if (runningBytes <= maxBytes) break;
+      toEvict.push(entry.url);
+      runningBytes -= entry.sizeBytes ?? 0;
+    }
+    if (toEvict.length === 0) return;
+    log.info(`LRU eviction: removing ${toEvict.length} entries (${totalBytes - runningBytes} bytes)`);
+  } finally {
+    db.close();
+  }
+  // Perform the deletions in a fresh transaction to keep the read tx
+  // short (large stores would otherwise hold the read tx open).
+  await deleteOldestUntilFits(maxBytes);
+}
+
+async function deleteOldestUntilFits(maxBytes: number): Promise<void> {
+  const db = await openDb();
+  try {
+    const tx = db.transaction(CACHE_STORE_NAME, 'readwrite');
+    const store = tx.objectStore(CACHE_STORE_NAME);
+    const idx = store.index('fetchedAt');
+    const all = (await promisifyRequest(idx.getAll())) as CachedScan[];
+    let runningBytes = all.reduce((sum, r) => sum + (r.sizeBytes ?? 0), 0);
+    for (const entry of all) {
+      if (runningBytes <= maxBytes) break;
+      await promisifyRequest(store.delete(entry.url));
+      runningBytes -= entry.sizeBytes ?? 0;
+    }
+    await new Promise<void>((resolve, reject) => {
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error ?? new Error('eviction tx failed'));
+      tx.onabort = () => reject(tx.error ?? new Error('eviction tx aborted'));
+    });
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * Drop every cache entry. Used by the "Clear cache" button in the popup
+ * and by global-invalidation paths (model change, schema bump). Also
+ * resets the hit/miss telemetry counters so the popup's hit-rate stat
+ * doesn't carry over across logical cache lifetimes.
+ */
+export async function clearCache(): Promise<void> {
+  const db = await openDb();
+  try {
+    const tx = db.transaction(CACHE_STORE_NAME, 'readwrite');
+    await promisifyRequest(tx.objectStore(CACHE_STORE_NAME).clear());
+    await new Promise<void>((resolve, reject) => {
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error ?? new Error('clearCache tx failed'));
+      tx.onabort = () => reject(tx.error ?? new Error('clearCache tx aborted'));
+    });
+  } finally {
+    db.close();
+  }
+  await resetCacheTelemetry();
+  log.info('Page-scan cache cleared');
+}
+
+async function readTelemetry(): Promise<CacheTelemetry> {
+  try {
+    const result = await chrome.storage.local.get(STORAGE_KEY_CACHE_TELEMETRY);
+    const value = result[STORAGE_KEY_CACHE_TELEMETRY];
+    if (
+      typeof value === 'object' &&
+      value !== null &&
+      typeof (value as Record<string, unknown>).hits === 'number' &&
+      typeof (value as Record<string, unknown>).misses === 'number'
+    ) {
+      const v = value as Record<string, unknown>;
+      return {
+        hits: v.hits as number,
+        misses: v.misses as number,
+        resetAt: typeof v.resetAt === 'number' ? (v.resetAt as number) : Date.now(),
+      };
+    }
+  } catch (err) {
+    log.warn('readTelemetry failed', err);
+  }
+  return { hits: 0, misses: 0, resetAt: Date.now() };
+}
+
+async function writeTelemetry(t: CacheTelemetry): Promise<void> {
+  try {
+    await chrome.storage.local.set({ [STORAGE_KEY_CACHE_TELEMETRY]: t });
+  } catch (err) {
+    log.warn('writeTelemetry failed', err);
+  }
+}
+
+export async function recordCacheHit(): Promise<void> {
+  const t = await readTelemetry();
+  await writeTelemetry({ ...t, hits: t.hits + 1 });
+}
+
+export async function recordCacheMiss(): Promise<void> {
+  const t = await readTelemetry();
+  await writeTelemetry({ ...t, misses: t.misses + 1 });
+}
+
+export async function resetCacheTelemetry(): Promise<void> {
+  await writeTelemetry({ hits: 0, misses: 0, resetAt: Date.now() });
+}
+
+/**
+ * Read the user's preferred canary from storage.sync. Used as the
+ * `llmModelId` cache key — a change in canary preference invalidates
+ * every cached entry on next access.
+ *
+ * 'auto' is preserved as-is rather than resolved to a concrete engine:
+ * the user's preference is the stable cache identity, and resolving
+ * 'auto' would require offscreen-engine state that isn't available at
+ * cache-lookup time. Tradeoff: if 'auto' flips between MLC and Nano
+ * across visits (e.g. WebGPU lost), a stale-engine replay can occur
+ * until the user manually clears cache. Acceptable for v1.
+ */
+export async function getEngineFingerprint(): Promise<CanaryId> {
+  try {
+    if (typeof chrome === 'undefined' || !chrome.storage?.sync) {
+      return DEFAULT_CANARY_ID;
+    }
+    const result = await chrome.storage.sync.get(STORAGE_KEY_CANARY);
+    const raw = result[STORAGE_KEY_CANARY];
+    if (typeof raw === 'string') {
+      // CanaryId catalog lives in shared/constants; we trust the popup
+      // to have written a valid value. Anything else collapses to
+      // DEFAULT_CANARY_ID — an invalid preference shouldn't poison the
+      // cache.
+      return raw as CanaryId;
+    }
+  } catch (err) {
+    log.warn('getEngineFingerprint failed; falling back to default', err);
+  }
+  return DEFAULT_CANARY_ID;
+}
+
+/**
+ * Surface cache stats for the popup. Reads everything fresh — this is
+ * called when the popup opens, not in any hot path, so the extra
+ * IndexedDB scan is fine.
+ */
+export async function getCacheStats(): Promise<CacheStats> {
+  const [telemetry, ttlMs, maxBytes] = await Promise.all([
+    readTelemetry(),
+    getTtlMs(),
+    getMaxBytes(),
+  ]);
+
+  let entries = 0;
+  let sizeBytes = 0;
+  try {
+    const db = await openDb();
+    try {
+      const tx = db.transaction(CACHE_STORE_NAME, 'readonly');
+      const all = (await promisifyRequest(tx.objectStore(CACHE_STORE_NAME).getAll())) as CachedScan[];
+      entries = all.length;
+      sizeBytes = all.reduce((sum, r) => sum + (r.sizeBytes ?? 0), 0);
+    } finally {
+      db.close();
+    }
+  } catch (err) {
+    log.warn('getCacheStats: idb scan failed', err);
+  }
+
+  const totalLookups = telemetry.hits + telemetry.misses;
+  const hitRate = totalLookups === 0 ? null : telemetry.hits / totalLookups;
+  return {
+    entries,
+    sizeBytes,
+    maxBytes,
+    ttlMs,
+    hits: telemetry.hits,
+    misses: telemetry.misses,
+    hitRate,
+  };
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -286,3 +286,67 @@ export const STAMP_VERSION = 1 as const;
  * match by full string equality.
  */
 export const EARLY_EXIT_ANALYSIS_ERROR = 'early_exit_high_confidence';
+
+/**
+ * Issue #127 (N11) — Hunter rules version. Bumped whenever Spider's pattern
+ * catalog or Hawk's classifier changes in a way that could produce a
+ * different verdict for the same chunk text. Page-scan cache entries are
+ * keyed against this string; a bump invalidates every cached entry on the
+ * next read so stale Hunter findings can never produce a stale verdict.
+ *
+ * Bump procedure: change the constant in the same PR that ships the rule
+ * change. Use semver for human readability ('1.0.0' → '1.1.0' for additive
+ * pattern adds, '2.0.0' for breaking classifier-output shape changes).
+ */
+export const HUNTER_RULES_VERSION = '1.0.0' as const;
+
+/**
+ * Issue #127 (N11) — page-scan cache schema version. Bumped only on
+ * incompatible CachedScan shape changes (field add/remove/rename, or a
+ * change that breaks deserialization of older records). Records carrying
+ * a different schemaVersion are treated as cache misses and dropped on
+ * next access. Distinct from HUNTER_RULES_VERSION (rule semantics) and
+ * llmModelId (engine identity).
+ */
+export const CACHE_SCHEMA_VERSION = 1 as const;
+
+/**
+ * Issue #127 (N11) — IndexedDB database name + version + object store
+ * for the page-scan cache. The object store is keyed by the page URL
+ * (full URL string); each record carries the per-chunk results plus the
+ * version triple (schema/hunter-rules/llm-model) used for invalidation.
+ */
+export const CACHE_DB_NAME = 'honeyllm-scan-cache';
+export const CACHE_DB_VERSION = 1 as const;
+export const CACHE_STORE_NAME = 'page-scans';
+
+/**
+ * Issue #127 (N11) — default TTL for cache entries. Per-entry TTL is
+ * checked at read time: if `Date.now() - record.fetchedAt > ttlMs`, the
+ * record is treated as a miss and lazily evicted. 24h default; tunable
+ * via `chrome.storage.local[STORAGE_KEY_CACHE_TTL_MS]`.
+ */
+export const CACHE_DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Issue #127 (N11) — default LRU max bytes. Eviction is on write: if
+ * the post-write store size exceeds this budget, the oldest entries by
+ * `fetchedAt` are deleted until the store fits. Tunable via
+ * `chrome.storage.local[STORAGE_KEY_CACHE_MAX_BYTES]`.
+ *
+ * 100 MB is a soft target; IndexedDB in Chrome has no hard origin quota
+ * for extensions but exceeding 100 MB starts to bloat the user's profile.
+ */
+export const CACHE_DEFAULT_MAX_BYTES = 100 * 1024 * 1024;
+
+export const STORAGE_KEY_CACHE_TTL_MS = 'honeyllm:cache-ttl-ms';
+export const STORAGE_KEY_CACHE_MAX_BYTES = 'honeyllm:cache-max-bytes';
+
+/**
+ * Issue #127 (N11) — telemetry counter for cache hit/miss rate. Persisted
+ * in chrome.storage.local so the popup can render a hit-rate stat without
+ * a message round-trip to the SW. Shape: `{ hits: number; misses: number;
+ * resetAt: number }`. Reset by clear-cache and by version-mismatch global
+ * invalidation.
+ */
+export const STORAGE_KEY_CACHE_TELEMETRY = 'honeyllm:cache-telemetry';

--- a/src/types/scan-cache.ts
+++ b/src/types/scan-cache.ts
@@ -1,0 +1,67 @@
+import type { ProbeResult, TierRouting } from './verdict.js';
+import type { EntitySummary } from '@/hunters/ner/types.js';
+
+/**
+ * Issue #127 (N11) — per-chunk record cached for page-scan replay.
+ *
+ * `contentHash` is the sha256-hex of the chunk text (stable across runs)
+ * and is the cache key used to match new chunks against cached chunks
+ * even when boundaries shift between visits. `tierRouting` and
+ * `probeResults` are reused on a hit so neither hunters, NER, nor the
+ * LLM probe stack need to re-run for that chunk. `notScanned` mirrors
+ * `ChunkAnalysis.notScanned` for chunks that were padded out by the
+ * #145 early-exit on the original run.
+ */
+export interface CachedChunk {
+  readonly contentHash: string;
+  readonly tierRouting: TierRouting;
+  readonly probeResults: readonly ProbeResult[] | null;
+  readonly notScanned?: true;
+}
+
+/**
+ * Issue #127 (N11) — per-URL page-scan cache record. Stored in
+ * IndexedDB keyed by `url`. The version triple
+ * (`schemaVersion`/`hunterRulesVersion`/`llmModelId`) is checked on
+ * every read; any mismatch fails the lookup as a miss so a rules or
+ * model bump can never replay stale results.
+ *
+ * `fetchedAt` is the wall-clock millisecond timestamp of the most
+ * recent write — used both for TTL eviction (per-entry) and for
+ * fetchedAt-LRU eviction (cache-wide). `earlyExited` mirrors the
+ * orchestrator's #145 early-exit flag so a full-cache-hit replay
+ * preserves `EARLY_EXIT_ANALYSIS_ERROR` exactly as the original run
+ * produced it. `entitySummary` lets the popup render the entity
+ * accordion on a cache hit without rerunning extraction.
+ *
+ * `sizeBytes` is computed at write time as
+ * `JSON.stringify(record).length` (UTF-16 chars; close enough to the
+ * IndexedDB on-disk footprint for LRU purposes). Stored on the record
+ * so the eviction loop can sum it without re-serializing.
+ */
+export interface CachedScan {
+  readonly schemaVersion: number;
+  readonly hunterRulesVersion: string;
+  readonly llmModelId: string;
+  readonly url: string;
+  readonly fetchedAt: number;
+  readonly chunks: readonly CachedChunk[];
+  readonly earlyExited: boolean;
+  readonly entitySummary: EntitySummary | null;
+  readonly sizeBytes: number;
+}
+
+/**
+ * Issue #127 (N11) — cache statistics surfaced to the popup. `hitRate`
+ * is null until at least one lookup has happened in the current
+ * telemetry window (so we don't render "0%" before any data exists).
+ */
+export interface CacheStats {
+  readonly entries: number;
+  readonly sizeBytes: number;
+  readonly maxBytes: number;
+  readonly ttlMs: number;
+  readonly hits: number;
+  readonly misses: number;
+  readonly hitRate: number | null;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    setupFiles: ['./vitest.setup.ts'],
     include: ['src/**/*.test.ts', 'scripts/**/*.test.ts', 'harnesses/**/*.test.ts'],
     coverage: {
       provider: 'v8',

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,16 @@
+// Issue #127 (N11) — fake-indexeddb installs `indexedDB` and `IDBKeyRange`
+// onto globalThis so the page-scan cache module can be unit-tested under
+// vitest's `node` environment, where these APIs are not natively present.
+import 'fake-indexeddb/auto';
+import { IDBFactory } from 'fake-indexeddb';
+import { beforeEach } from 'vitest';
+
+// Reset the in-memory IndexedDB between every test. Without this, cache
+// records from a prior test would leak into the next, which makes
+// integration tests (e.g. orchestrator.integration.test.ts) flaky:
+// the second analyzeSnapshot call against the same URL would hit the
+// cache and skip the chunk-loop the test was asserting against.
+beforeEach(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).indexedDB = new IDBFactory();
+});


### PR DESCRIPTION
## Summary

Phase 6 Stage 1 starter: an IndexedDB-backed page-scan cache that lets revisits to a previously-scanned URL replay cached probe results when chunk content hashes match, skipping hunters/NER/LLM probes on covered chunks.

- Content-hash-keyed (boundaries shift between visits — the unified `chunkText`'s `contentHash` is the cache key)
- Versioned by `(schemaVersion, hunterRulesVersion, llmModelId)` triple — any mismatch is a hard miss + lazy evict
- TTL: 24h default, configurable via `chrome.storage.local['honeyllm:cache-ttl-ms']`
- LRU on `fetchedAt`, evicts on write when total bytes exceed the budget (default 100 MB, configurable)
- Composes cleanly with #145 early-exit: padded `notScanned` chunks now carry the real `contentHash`, so revisits to early-exited pages also hit cache
- Popup gets a Scan cache accordion with entries/size/hit-rate + a Clear cache button
- Hit/miss telemetry persisted in `chrome.storage.local` so the popup can render hit-rate without a SW round-trip

## Architecture

```
analyzeSnapshot
  ├── chunkText(fullText)               # stable contentHash per chunk
  ├── lookupScan(url, {hunterRulesVersion, llmModelId})
  │     └── version mismatch / TTL expired → null + lazy evict
  ├── prepareCachedReplay(chunks, cached)
  │     └── { hitIndices, missIndices, replayedChunkResults, replayedPerChunkAnalysis, earlyExitedReplay }
  ├── chunk loop
  │     ├── hit  → reuse cached probeResults + tierRouting (skip hunters/NER/runChunkProbes)
  │     └── miss → fresh hunter → packet build → NER → runChunkProbes (existing path)
  ├── mergeProbeResults / evaluatePolicy (aggregate scoring constants apply HERE, not at cache time)
  └── writeScan(updatedRecord)          # bumps fetchedAt, triggers LRU eviction
```

## What's in

| Layer | File | Purpose |
|---|---|---|
| Types | `src/types/scan-cache.ts` | `CachedScan` + `CachedChunk` + `CacheStats` |
| Constants | `src/shared/constants.ts` | `HUNTER_RULES_VERSION`, `CACHE_SCHEMA_VERSION`, DB/TTL/budget defaults, storage keys |
| Cache module | `src/service-worker/scan-cache.ts` | IndexedDB lookup/write/clear/stats, version-guard invalidation, fetchedAt-LRU, telemetry, engine-fingerprint reader |
| Replay helper | `src/service-worker/cache-replay.ts` | Pure `prepareCachedReplay` — maps current chunks to cached chunks by hash |
| Orchestrator | `src/service-worker/orchestrator.ts` | Cache lookup before chunk loop, replay shortcut inside loop, write-back after verdict |
| Popup | `src/popup/popup.html` + `popup.ts` | Scan cache accordion + Clear cache button |
| Test infra | `vitest.setup.ts`, `package.json` | `fake-indexeddb` dev dep + per-test IDBFactory reset |

## Tests

828/828 passing (771 prior + 57 new):
- `scan-cache.test.ts` (14): empty miss, round-trip, hunterRulesVersion / llmModelId / schemaVersion mismatches → null + evict, default TTL eviction, custom TTL via storage, clearCache, clearCache resets telemetry, getCacheStats (empty + populated + hit-rate), LRU eviction on byte budget, hit/miss telemetry counters
- `cache-replay.test.ts` (7): hashesAllCovered (full / subset / partial), prepareCachedReplay full hit, partial hit, total miss, shifted boundaries (hash matches across positions), earlyExited preservation on full-hit replay
- `orchestrator.integration.test.ts` (existing): adapted to use hex contentHashes since orchestrator now propagates `chunks[i].contentHash` directly

## Hard invariants enforced

- Cache is content-hash-keyed (NOT index-keyed): chunks at different positions but same text replay correctly
- Schema/hunter-rules/llm-model version mismatch → hard miss + lazy evict (correctness, not hint)
- Cached `probeResults` reused as-is; aggregate scoring constants apply at replay time so a constants tweak invalidates aggregate but not per-chunk findings until `HUNTER_RULES_VERSION` bumps
- `notScanned` early-exit padding now carries real `contentHash` so revisits to early-exited pages can replay
- `TierDecision` shape unchanged; no new public types in `@/types/verdict.ts`
- TypeScript strict; `unknown` + runtime narrowing at the IDB boundary
- All files under 400 lines

## Out of scope (deferred)

- Per-chunk entity caching: partial-hit replays drop entities from hit chunks (aggregate `entitySummary` still recomputed from miss chunks + fresh extraction). Full-hit uses cached `entitySummary` directly. Adding per-chunk entities is a follow-up if telemetry shows partial-hit pages rendering with fewer entities than expected.
- Replay-disagreement sanity check (issue mentions an N% fresh replay on hits to detect stale-cache risk): adds latency that defeats the cache. Defer to a telemetry-driven follow-up if hit rate looks good but disagreement signals appear.
- LLM model fingerprint uses the user's stored canary preference. An 'auto' user whose engine flips between visits (e.g. WebGPU lost) will replay across engines until they manually Clear cache. Edge case; documented in `getEngineFingerprint`.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 828/828 pass
- [x] `npm run build` — clean
- [x] `npm audit` — 0 vulnerabilities
- [ ] Manual smoke: load `dist/` as unpacked extension, visit a page, reload, confirm popup Scan cache accordion shows 1 entry + non-zero size; click Clear cache, confirm 0 entries
- [ ] CI green on this PR

## Schedule-able follow-up

In ~2 weeks post-merge: query telemetry for cache hit rate vs. miss rate vs. replay-disagreement rate. If disagreement >0.5%, that's a correctness signal worth surfacing as an issue (premature cache invalidation or stale-cache risk).

Closes #127.