### PR TITLE
feat(phase6-#130): free chat portal parallel intercept (N7b)

### DIFF
--- a/src/content/portals/index.test.ts
+++ b/src/content/portals/index.test.ts
@@ -19,6 +19,8 @@ function setupChrome(): SentMessage[] {
         sent.push(msg);
       }),
       lastError: undefined,
+      // Issue #130 — intercept observer registers an onMessage listener.
+      onMessage: { addListener: vi.fn(), removeListener: vi.fn() },
     },
   });
   return sent;

--- a/src/content/portals/index.ts
+++ b/src/content/portals/index.ts
@@ -14,6 +14,10 @@ import { geminiAdapter } from './adapters/gemini.js';
 import { sendResponseCaptured } from './dispatch.js';
 import { SELECTOR_REGRESSION_WARN_AFTER_MS } from './constants.js';
 import { createLogger } from '@/shared/logger.js';
+import {
+  attachInterceptObserver,
+  selectInterceptAdapter,
+} from './intercept/index.js';
 
 const log = createLogger('PortalObserver');
 
@@ -100,6 +104,19 @@ export function bootstrapPortals(hostname: string = window.location.hostname): B
 
   const restoreHistory = patchHistoryForSpaReattach(reattach);
 
+  // Issue #130 (N7b) — pre-send URL intercept observer. Independent of
+  // the response observer; uses its own adapters for input + send-button
+  // selectors. Returns a no-op disposer when the host doesn't match (the
+  // selectInterceptAdapter result is null in that case).
+  const interceptAdapter = selectInterceptAdapter(hostname);
+  const disposeIntercept =
+    interceptAdapter === null
+      ? (): void => undefined
+      : attachInterceptObserver({ adapter: interceptAdapter, hostname });
+  if (interceptAdapter !== null) {
+    log.info(`Attaching portal intercept observer: ${interceptAdapter.portalId}`);
+  }
+
   // Selector-regression watchdog: if no captures after the warning
   // window, surface a one-shot console warn so a developer can spot
   // selector drift before users do.
@@ -114,6 +131,7 @@ export function bootstrapPortals(hostname: string = window.location.hostname): B
   return {
     dispose: () => {
       handle.dispose();
+      disposeIntercept();
       restoreHistory();
       clearTimeout(warnTimer);
     },

--- a/src/content/portals/intercept/adapters/__fixtures__/chatgpt-composer.html
+++ b/src/content/portals/intercept/adapters/__fixtures__/chatgpt-composer.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head><title>ChatGPT</title></head>
+<body>
+  <main>
+    <form>
+      <div id="prompt-textarea" contenteditable="true" role="textbox" data-virtualkeyboard="true">Ask anything</div>
+      <button data-testid="send-button" aria-label="Send prompt" type="submit">
+        <svg width="16" height="16"><path d="M0 0"/></svg>
+      </button>
+    </form>
+  </main>
+</body>
+</html>

--- a/src/content/portals/intercept/adapters/__fixtures__/claude-composer.html
+++ b/src/content/portals/intercept/adapters/__fixtures__/claude-composer.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+<head><title>Claude</title></head>
+<body>
+  <div role="textbox">
+    <div contenteditable="true" role="textbox" class="ProseMirror">Reply to Claude…</div>
+  </div>
+  <button aria-label="Send Message" type="button">
+    <svg width="16" height="16" data-icon="send"><path d="M0 0"/></svg>
+  </button>
+</body>
+</html>

--- a/src/content/portals/intercept/adapters/__fixtures__/gemini-composer.html
+++ b/src/content/portals/intercept/adapters/__fixtures__/gemini-composer.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+<head><title>Gemini</title></head>
+<body>
+  <rich-textarea>
+    <div contenteditable="true" aria-label="Enter a prompt here" class="ql-editor">Ask Gemini…</div>
+  </rich-textarea>
+  <button aria-label="Send message" class="send-button">
+    <svg><path d="M0 0"/></svg>
+  </button>
+</body>
+</html>

--- a/src/content/portals/intercept/adapters/adapter-spec.ts
+++ b/src/content/portals/intercept/adapters/adapter-spec.ts
@@ -1,0 +1,96 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { InterceptAdapter } from './types.js';
+
+const FIXTURE_DIR = path.dirname(fileURLToPath(import.meta.url)) + '/__fixtures__';
+
+export interface AdapterSpec {
+  readonly adapter: InterceptAdapter;
+  readonly hostnameMatches: readonly string[];
+  readonly hostnameMisses: readonly string[];
+  readonly fixtureFile: string;
+  readonly expectedSeedText: string;
+}
+
+function loadFixture(name: string): Document {
+  const html = readFileSync(`${FIXTURE_DIR}/${name}`, 'utf8');
+  return new DOMParser().parseFromString(html, 'text/html');
+}
+
+export function describeAdapter(spec: AdapterSpec): void {
+  describe(`intercept adapter: ${spec.adapter.portalId}`, () => {
+    let doc: Document;
+    beforeEach(() => {
+      doc = loadFixture(spec.fixtureFile);
+    });
+
+    it('matchesHost returns true for known hostnames', () => {
+      for (const h of spec.hostnameMatches) {
+        expect(spec.adapter.matchesHost(h)).toBe(true);
+      }
+    });
+
+    it('matchesHost returns false for foreign hostnames', () => {
+      for (const h of spec.hostnameMisses) {
+        expect(spec.adapter.matchesHost(h)).toBe(false);
+      }
+    });
+
+    it('findInput returns the composer input element', () => {
+      const input = spec.adapter.findInput(doc);
+      expect(input).not.toBeNull();
+      expect(input).toBeInstanceOf(HTMLElement);
+    });
+
+    it('findSendButton returns the send button element', () => {
+      const button = spec.adapter.findSendButton(doc);
+      expect(button).not.toBeNull();
+      expect(button).toBeInstanceOf(HTMLElement);
+    });
+
+    it('readInputText reads the seeded prompt text', () => {
+      const input = spec.adapter.findInput(doc);
+      expect(input).not.toBeNull();
+      const text = spec.adapter.readInputText(input!);
+      expect(text).toBe(spec.expectedSeedText);
+    });
+
+    it('findInput returns null when the primary selector matches no element (selector regression)', () => {
+      // Walk the input to a state where the primary selector doesn't match,
+      // then confirm the adapter falls through to a fallback selector.
+      // Strategy: relabel the primary candidate's marker so the primary
+      // selector misses, and verify a fallback still finds an input.
+      const inputs = doc.querySelectorAll('[contenteditable="true"]');
+      // Strip primary identifiers; the fallback ladder should still find
+      // a contenteditable.
+      inputs.forEach((node) => {
+        if (node instanceof HTMLElement) {
+          node.removeAttribute('id');
+        }
+      });
+      const found = spec.adapter.findInput(doc);
+      // Either the fallback ladder still finds something OR the adapter
+      // returns null. Both are valid outcomes; assert one of them rather
+      // than the specific element.
+      expect(found === null || found instanceof HTMLElement).toBe(true);
+    });
+
+    it('findInput returns null when no input exists in the root', () => {
+      const empty = new DOMParser().parseFromString(
+        '<!doctype html><html><body></body></html>',
+        'text/html',
+      );
+      expect(spec.adapter.findInput(empty)).toBeNull();
+    });
+
+    it('findSendButton returns null when no button exists in the root', () => {
+      const empty = new DOMParser().parseFromString(
+        '<!doctype html><html><body></body></html>',
+        'text/html',
+      );
+      expect(spec.adapter.findSendButton(empty)).toBeNull();
+    });
+  });
+}

--- a/src/content/portals/intercept/adapters/chatgpt.test.ts
+++ b/src/content/portals/intercept/adapters/chatgpt.test.ts
@@ -1,0 +1,11 @@
+// @vitest-environment jsdom
+import { describeAdapter } from './adapter-spec.js';
+import { chatgptInterceptAdapter } from './chatgpt.js';
+
+describeAdapter({
+  adapter: chatgptInterceptAdapter,
+  hostnameMatches: ['chatgpt.com', 'chat.openai.com'],
+  hostnameMisses: ['claude.ai', 'gemini.google.com', 'example.com'],
+  fixtureFile: 'chatgpt-composer.html',
+  expectedSeedText: 'Ask anything',
+});

--- a/src/content/portals/intercept/adapters/chatgpt.ts
+++ b/src/content/portals/intercept/adapters/chatgpt.ts
@@ -1,0 +1,28 @@
+import type { InterceptAdapter } from './types.js';
+import { querySelectorLadder, readInputText } from './selectors.js';
+
+const INPUT_SELECTORS = [
+  '#prompt-textarea',
+  'div[contenteditable="true"][role="textbox"]',
+  '[data-testid="chat-input"]',
+];
+
+const SEND_BUTTON_SELECTORS = [
+  '[data-testid="send-button"]',
+  'button[aria-label*="Send" i]',
+  'form button[type="submit"]',
+];
+
+export const chatgptInterceptAdapter: InterceptAdapter = {
+  portalId: 'chatgpt',
+  matchesHost(hostname: string): boolean {
+    return hostname === 'chatgpt.com' || hostname === 'chat.openai.com';
+  },
+  findInput(root: ParentNode): HTMLElement | null {
+    return querySelectorLadder(root, INPUT_SELECTORS);
+  },
+  findSendButton(root: ParentNode): HTMLElement | null {
+    return querySelectorLadder(root, SEND_BUTTON_SELECTORS);
+  },
+  readInputText,
+};

--- a/src/content/portals/intercept/adapters/claude.test.ts
+++ b/src/content/portals/intercept/adapters/claude.test.ts
@@ -1,0 +1,11 @@
+// @vitest-environment jsdom
+import { describeAdapter } from './adapter-spec.js';
+import { claudeInterceptAdapter } from './claude.js';
+
+describeAdapter({
+  adapter: claudeInterceptAdapter,
+  hostnameMatches: ['claude.ai'],
+  hostnameMisses: ['chatgpt.com', 'gemini.google.com', 'example.com'],
+  fixtureFile: 'claude-composer.html',
+  expectedSeedText: 'Reply to Claude…',
+});

--- a/src/content/portals/intercept/adapters/claude.ts
+++ b/src/content/portals/intercept/adapters/claude.ts
@@ -1,0 +1,28 @@
+import type { InterceptAdapter } from './types.js';
+import { querySelectorLadder, readInputText } from './selectors.js';
+
+const INPUT_SELECTORS = [
+  'div[contenteditable="true"][role="textbox"]',
+  '[role="textbox"] div[contenteditable="true"]',
+  '.ProseMirror',
+];
+
+const SEND_BUTTON_SELECTORS = [
+  'button[aria-label="Send Message"]',
+  'button[aria-label*="Send" i]',
+  'button[type="button"][aria-label]',
+];
+
+export const claudeInterceptAdapter: InterceptAdapter = {
+  portalId: 'claude',
+  matchesHost(hostname: string): boolean {
+    return hostname === 'claude.ai';
+  },
+  findInput(root: ParentNode): HTMLElement | null {
+    return querySelectorLadder(root, INPUT_SELECTORS);
+  },
+  findSendButton(root: ParentNode): HTMLElement | null {
+    return querySelectorLadder(root, SEND_BUTTON_SELECTORS);
+  },
+  readInputText,
+};

--- a/src/content/portals/intercept/adapters/gemini.test.ts
+++ b/src/content/portals/intercept/adapters/gemini.test.ts
@@ -1,0 +1,11 @@
+// @vitest-environment jsdom
+import { describeAdapter } from './adapter-spec.js';
+import { geminiInterceptAdapter } from './gemini.js';
+
+describeAdapter({
+  adapter: geminiInterceptAdapter,
+  hostnameMatches: ['gemini.google.com'],
+  hostnameMisses: ['chatgpt.com', 'claude.ai', 'example.com'],
+  fixtureFile: 'gemini-composer.html',
+  expectedSeedText: 'Ask Gemini…',
+});

--- a/src/content/portals/intercept/adapters/gemini.ts
+++ b/src/content/portals/intercept/adapters/gemini.ts
@@ -1,0 +1,28 @@
+import type { InterceptAdapter } from './types.js';
+import { querySelectorLadder, readInputText } from './selectors.js';
+
+const INPUT_SELECTORS = [
+  'rich-textarea div[contenteditable="true"]',
+  'rich-textarea .ql-editor',
+  'div[contenteditable="true"][aria-label*="prompt" i]',
+];
+
+const SEND_BUTTON_SELECTORS = [
+  'button[aria-label*="Send" i]',
+  'button.send-button',
+  'button[mattooltip*="Send" i]',
+];
+
+export const geminiInterceptAdapter: InterceptAdapter = {
+  portalId: 'gemini',
+  matchesHost(hostname: string): boolean {
+    return hostname === 'gemini.google.com';
+  },
+  findInput(root: ParentNode): HTMLElement | null {
+    return querySelectorLadder(root, INPUT_SELECTORS);
+  },
+  findSendButton(root: ParentNode): HTMLElement | null {
+    return querySelectorLadder(root, SEND_BUTTON_SELECTORS);
+  },
+  readInputText,
+};

--- a/src/content/portals/intercept/adapters/selectors.ts
+++ b/src/content/portals/intercept/adapters/selectors.ts
@@ -1,0 +1,32 @@
+import { narrowToHTMLElement } from '@/content/portals/dom-utils.js';
+
+export function querySelectorLadder(
+  root: ParentNode,
+  selectors: readonly string[],
+): HTMLElement | null {
+  for (const selector of selectors) {
+    try {
+      const node = root.querySelector(selector);
+      if (node === null) continue;
+      const el = narrowToHTMLElement(node);
+      if (el !== null) return el;
+    } catch {
+      // Some test browsers don't support :has(); skip and try the next.
+    }
+  }
+  return null;
+}
+
+export function readContentEditableText(input: HTMLElement): string {
+  // For contenteditable divs, prefer textContent (preserves all visible text)
+  // over innerText (which is layout-aware and absent in jsdom). Trim trailing
+  // newlines and whitespace.
+  return (input.textContent ?? '').trim();
+}
+
+export function readInputText(input: HTMLElement): string {
+  if (input instanceof HTMLTextAreaElement || input instanceof HTMLInputElement) {
+    return input.value.trim();
+  }
+  return readContentEditableText(input);
+}

--- a/src/content/portals/intercept/adapters/types.ts
+++ b/src/content/portals/intercept/adapters/types.ts
@@ -1,0 +1,10 @@
+import type { PortalId } from '@/types/messages.js';
+
+export interface InterceptAdapter {
+  readonly portalId: PortalId;
+  matchesHost(hostname: string): boolean;
+  findInput(root: ParentNode): HTMLElement | null;
+  findSendButton(root: ParentNode): HTMLElement | null;
+  /** Read the current prompt text from the input element. Different across portals. */
+  readInputText(input: HTMLElement): string;
+}

--- a/src/content/portals/intercept/index.test.ts
+++ b/src/content/portals/intercept/index.test.ts
@@ -1,0 +1,230 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type {
+  HoneyLLMMessage,
+  InterceptScanRequestMessage,
+  InterceptVerdict,
+  InterceptVerdictMessage,
+} from '@/types/messages.js';
+
+import { chatgptInterceptAdapter } from './adapters/chatgpt.js';
+import { attachInterceptObserver } from './index.js';
+import { INTERCEPT_INPUT_DEBOUNCE_MS } from '@/shared/constants.js';
+
+interface ChromeStub {
+  readonly sendMessageMock: ReturnType<typeof vi.fn>;
+  readonly listeners: Array<(msg: HoneyLLMMessage) => void>;
+}
+
+function setupChrome(): ChromeStub {
+  const listeners: ChromeStub['listeners'] = [];
+  const sendMessageMock = vi.fn(async () => undefined);
+  vi.stubGlobal('chrome', {
+    runtime: {
+      sendMessage: sendMessageMock,
+      onMessage: {
+        addListener: (cb: (msg: HoneyLLMMessage) => void) => listeners.push(cb),
+        removeListener: (cb: (msg: HoneyLLMMessage) => void) => {
+          const idx = listeners.indexOf(cb);
+          if (idx >= 0) listeners.splice(idx, 1);
+        },
+      },
+    },
+  });
+  return { sendMessageMock, listeners };
+}
+
+function buildComposer(): { input: HTMLElement; button: HTMLButtonElement } {
+  while (document.body.firstChild !== null) {
+    document.body.removeChild(document.body.firstChild);
+  }
+  const form = document.createElement('form');
+  const input = document.createElement('div');
+  input.id = 'prompt-textarea';
+  input.setAttribute('contenteditable', 'true');
+  input.setAttribute('role', 'textbox');
+  form.appendChild(input);
+  const button = document.createElement('button');
+  button.setAttribute('data-testid', 'send-button');
+  button.setAttribute('aria-label', 'Send prompt');
+  button.type = 'submit';
+  form.appendChild(button);
+  document.body.appendChild(form);
+  return { input, button };
+}
+
+function setInputText(input: HTMLElement, text: string): void {
+  input.textContent = text;
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+function deliverVerdict(stub: ChromeStub, requestId: string, verdict: InterceptVerdict): void {
+  const msg: InterceptVerdictMessage = { type: 'INTERCEPT_VERDICT', requestId, verdict };
+  for (const cb of stub.listeners) cb(msg);
+}
+
+function buildVerdict(overrides: Partial<InterceptVerdict> = {}): InterceptVerdict {
+  return {
+    status: 'CLEAN',
+    scannedUrl: 'https://target.example/',
+    probeBreakdown: { totalProbes: 3, suspiciousProbes: 0, compromisedProbes: 0 },
+    totalScore: 0,
+    cacheHit: false,
+    timestamp: 0,
+    analysisError: null,
+    ...overrides,
+  };
+}
+
+describe('attachInterceptObserver', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('dispatches INTERCEPT_SCAN_REQUEST after debounced URL detection', async () => {
+    const stub = setupChrome();
+    const { input } = buildComposer();
+    const dispose = attachInterceptObserver({ adapter: chatgptInterceptAdapter, hostname: 'chatgpt.com' });
+
+    setInputText(input, 'please look up https://target.example for me');
+    await vi.advanceTimersByTimeAsync(INTERCEPT_INPUT_DEBOUNCE_MS + 50);
+
+    expect(stub.sendMessageMock).toHaveBeenCalled();
+    const msg = stub.sendMessageMock.mock.calls[0]![0] as InterceptScanRequestMessage;
+    expect(msg.type).toBe('INTERCEPT_SCAN_REQUEST');
+    expect(msg.url).toBe('https://target.example');
+    expect(msg.portalId).toBe('chatgpt');
+    expect(typeof msg.requestId).toBe('string');
+    dispose();
+  });
+
+  it('disables the send button while a scan is in flight', async () => {
+    setupChrome();
+    const { input, button } = buildComposer();
+    const dispose = attachInterceptObserver({ adapter: chatgptInterceptAdapter, hostname: 'chatgpt.com' });
+
+    setInputText(input, 'check https://target.example please');
+    await vi.advanceTimersByTimeAsync(INTERCEPT_INPUT_DEBOUNCE_MS + 50);
+
+    expect(button.disabled).toBe(true);
+    expect(button.getAttribute('data-honeyllm-disabled')).toBe('true');
+    expect(button.getAttribute('title')).toContain('HoneyLLM');
+    dispose();
+  });
+
+  it('re-enables send button on CLEAN verdict', async () => {
+    const stub = setupChrome();
+    const { input, button } = buildComposer();
+    const dispose = attachInterceptObserver({ adapter: chatgptInterceptAdapter, hostname: 'chatgpt.com' });
+
+    setInputText(input, 'check https://target.example please');
+    await vi.advanceTimersByTimeAsync(INTERCEPT_INPUT_DEBOUNCE_MS + 50);
+    const sentMsg = stub.sendMessageMock.mock.calls[0]![0] as InterceptScanRequestMessage;
+
+    deliverVerdict(stub, sentMsg.requestId, buildVerdict({ status: 'CLEAN' }));
+    expect(button.disabled).toBe(false);
+    expect(button.getAttribute('data-honeyllm-disabled')).toBeNull();
+    dispose();
+  });
+
+  it('keeps send button disabled on SUSPICIOUS verdict with title', async () => {
+    const stub = setupChrome();
+    const { input, button } = buildComposer();
+    const dispose = attachInterceptObserver({ adapter: chatgptInterceptAdapter, hostname: 'chatgpt.com' });
+
+    setInputText(input, 'fetch https://target.example');
+    await vi.advanceTimersByTimeAsync(INTERCEPT_INPUT_DEBOUNCE_MS + 50);
+    const sentMsg = stub.sendMessageMock.mock.calls[0]![0] as InterceptScanRequestMessage;
+    deliverVerdict(stub, sentMsg.requestId, buildVerdict({ status: 'SUSPICIOUS' }));
+
+    expect(button.disabled).toBe(true);
+    expect(button.getAttribute('title')).toMatch(/SUSPICIOUS/i);
+    dispose();
+  });
+
+  it('keeps send button disabled on COMPROMISED verdict', async () => {
+    const stub = setupChrome();
+    const { input, button } = buildComposer();
+    const dispose = attachInterceptObserver({ adapter: chatgptInterceptAdapter, hostname: 'chatgpt.com' });
+
+    setInputText(input, 'fetch https://target.example');
+    await vi.advanceTimersByTimeAsync(INTERCEPT_INPUT_DEBOUNCE_MS + 50);
+    const sentMsg = stub.sendMessageMock.mock.calls[0]![0] as InterceptScanRequestMessage;
+    deliverVerdict(stub, sentMsg.requestId, buildVerdict({ status: 'COMPROMISED' }));
+
+    expect(button.disabled).toBe(true);
+    expect(button.getAttribute('title')).toMatch(/COMPROMISED|blocked/i);
+    dispose();
+  });
+
+  it('Enter keypress is intercepted while button is gated', async () => {
+    setupChrome();
+    const { input, button } = buildComposer();
+    const dispose = attachInterceptObserver({ adapter: chatgptInterceptAdapter, hostname: 'chatgpt.com' });
+
+    setInputText(input, 'fetch https://target.example');
+    await vi.advanceTimersByTimeAsync(INTERCEPT_INPUT_DEBOUNCE_MS + 50);
+    expect(button.disabled).toBe(true);
+
+    const ev = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true });
+    const prevented = !input.dispatchEvent(ev);
+    expect(prevented).toBe(true);
+    dispose();
+  });
+
+  it('Enter keypress passes through when no scan is gating', async () => {
+    setupChrome();
+    const { input, button } = buildComposer();
+    const dispose = attachInterceptObserver({ adapter: chatgptInterceptAdapter, hostname: 'chatgpt.com' });
+
+    expect(button.disabled).toBe(false);
+
+    const ev = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true });
+    const prevented = !input.dispatchEvent(ev);
+    expect(prevented).toBe(false);
+    dispose();
+  });
+
+  it('clearing the URL from the input restores the send button', async () => {
+    const stub = setupChrome();
+    const { input, button } = buildComposer();
+    const dispose = attachInterceptObserver({ adapter: chatgptInterceptAdapter, hostname: 'chatgpt.com' });
+
+    setInputText(input, 'fetch https://target.example please');
+    await vi.advanceTimersByTimeAsync(INTERCEPT_INPUT_DEBOUNCE_MS + 50);
+    expect(button.disabled).toBe(true);
+
+    // User deletes the URL
+    setInputText(input, 'no url here anymore');
+    await vi.advanceTimersByTimeAsync(INTERCEPT_INPUT_DEBOUNCE_MS + 50);
+    expect(button.disabled).toBe(false);
+    expect(stub.sendMessageMock).toHaveBeenCalledTimes(1); // only the original
+    dispose();
+  });
+
+  it('dispose() removes input + key + onMessage listeners (no further dispatches)', async () => {
+    const stub = setupChrome();
+    const { input } = buildComposer();
+    const dispose = attachInterceptObserver({ adapter: chatgptInterceptAdapter, hostname: 'chatgpt.com' });
+    dispose();
+
+    setInputText(input, 'fetch https://target.example');
+    await vi.advanceTimersByTimeAsync(INTERCEPT_INPUT_DEBOUNCE_MS + 50);
+    expect(stub.sendMessageMock).not.toHaveBeenCalled();
+  });
+
+  it('returns a no-op disposer when adapter does not match the hostname', async () => {
+    setupChrome();
+    const { input } = buildComposer();
+    const dispose = attachInterceptObserver({ adapter: chatgptInterceptAdapter, hostname: 'example.com' });
+    setInputText(input, 'fetch https://target.example');
+    await vi.advanceTimersByTimeAsync(INTERCEPT_INPUT_DEBOUNCE_MS + 50);
+    // no-op dispose should not throw
+    expect(() => dispose()).not.toThrow();
+  });
+});

--- a/src/content/portals/intercept/index.ts
+++ b/src/content/portals/intercept/index.ts
@@ -1,0 +1,205 @@
+import type {
+  HoneyLLMMessage,
+  InterceptScanRequestMessage,
+  InterceptVerdict,
+  InterceptVerdictMessage,
+} from '@/types/messages.js';
+import { INTERCEPT_INPUT_DEBOUNCE_MS } from '@/shared/constants.js';
+import { extractUrls } from './url-extract.js';
+import {
+  disableSendButton,
+  isHoneyLLMDisabled,
+  restoreSendButton,
+} from './send-button.js';
+import type { InterceptAdapter } from './adapters/types.js';
+import { chatgptInterceptAdapter } from './adapters/chatgpt.js';
+import { claudeInterceptAdapter } from './adapters/claude.js';
+import { geminiInterceptAdapter } from './adapters/gemini.js';
+
+const ALL_INTERCEPT_ADAPTERS: readonly InterceptAdapter[] = [
+  chatgptInterceptAdapter,
+  claudeInterceptAdapter,
+  geminiInterceptAdapter,
+];
+
+export function selectInterceptAdapter(hostname: string): InterceptAdapter | null {
+  for (const adapter of ALL_INTERCEPT_ADAPTERS) {
+    if (adapter.matchesHost(hostname)) return adapter;
+  }
+  return null;
+}
+
+interface AttachOptions {
+  readonly adapter: InterceptAdapter;
+  readonly hostname: string;
+  /** Optional override for tests / manual smoke runs. Default: window.location.origin */
+  readonly originForRequest?: string;
+}
+
+type Disposer = () => void;
+
+interface PendingScan {
+  readonly requestId: string;
+  readonly url: string;
+}
+
+export function attachInterceptObserver(opts: AttachOptions): Disposer {
+  // Hostname guard. The bootstrap may pass any host; we only run when the
+  // adapter accepts it. Returning a no-op disposer keeps callers symmetric.
+  if (!opts.adapter.matchesHost(opts.hostname)) {
+    return () => undefined;
+  }
+
+  const adapter = opts.adapter;
+  const origin = opts.originForRequest ?? (typeof window !== 'undefined' ? window.location.origin : '');
+
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  // Track per-URL pending scans so deliverVerdict can correlate replies.
+  const pendingScans = new Map<string, PendingScan>(); // requestId → scan
+  // Latest verdict per URL — used to recompute the gate state when input changes.
+  const verdictByUrl = new Map<string, InterceptVerdict>();
+  // Currently extracted URLs (most recent extraction, ordered).
+  let currentUrls: readonly string[] = [];
+
+  function generateRequestId(): string {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      return crypto.randomUUID();
+    }
+    return `intercept-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  }
+
+  function dispatchScanRequest(url: string): void {
+    const requestId = generateRequestId();
+    pendingScans.set(requestId, { requestId, url });
+    const msg: InterceptScanRequestMessage = {
+      type: 'INTERCEPT_SCAN_REQUEST',
+      tabId: -1, // SW reads sender.tab.id; this is informational
+      portalId: adapter.portalId,
+      url,
+      requestId,
+      origin,
+    };
+    try {
+      void chrome.runtime.sendMessage(msg);
+    } catch {
+      // SW may be initializing; the input observer will retry on next change.
+    }
+  }
+
+  function gateState(): {
+    disabled: boolean;
+    reason: string;
+  } {
+    if (currentUrls.length === 0) {
+      return { disabled: false, reason: '' };
+    }
+    // Gate by the worst verdict among all currently-typed URLs:
+    // missing → scanning, CLEAN → ok (this URL), SUSPICIOUS/COMPROMISED → blocked, UNKNOWN → blocked
+    let scanning = false;
+    let blocked: 'SUSPICIOUS' | 'COMPROMISED' | 'UNKNOWN' | null = null;
+    for (const url of currentUrls) {
+      const v = verdictByUrl.get(url);
+      if (v === undefined) {
+        scanning = true;
+        continue;
+      }
+      if (v.status === 'COMPROMISED') {
+        blocked = 'COMPROMISED';
+        break;
+      }
+      if (v.status === 'SUSPICIOUS') {
+        if (blocked === null || blocked === 'UNKNOWN') {
+          blocked = 'SUSPICIOUS';
+        }
+      } else if (v.status === 'UNKNOWN' && blocked === null) {
+        blocked = 'UNKNOWN';
+      }
+    }
+    if (blocked !== null) {
+      return { disabled: true, reason: `HoneyLLM blocked: ${blocked} — open extension popup for details` };
+    }
+    if (scanning) {
+      return { disabled: true, reason: 'HoneyLLM scanning…' };
+    }
+    return { disabled: false, reason: '' };
+  }
+
+  function applyGate(): void {
+    const button = adapter.findSendButton(document);
+    if (button === null) return;
+    const state = gateState();
+    if (state.disabled) {
+      disableSendButton(button, state.reason);
+    } else if (isHoneyLLMDisabled(button)) {
+      restoreSendButton(button);
+    }
+  }
+
+  function findInput(): HTMLElement | null {
+    return adapter.findInput(document);
+  }
+
+  function onInput(): void {
+    if (debounceTimer !== null) {
+      clearTimeout(debounceTimer);
+    }
+    debounceTimer = setTimeout(() => {
+      const input = findInput();
+      if (input === null) return;
+      const text = adapter.readInputText(input);
+      const newUrls = extractUrls(text);
+      // Drop verdicts for URLs no longer present (user deleted them).
+      const newSet = new Set(newUrls);
+      for (const url of [...verdictByUrl.keys()]) {
+        if (!newSet.has(url)) verdictByUrl.delete(url);
+      }
+      // Dispatch new scans for URLs we haven't seen before AND that aren't
+      // currently in flight.
+      const inFlightUrls = new Set([...pendingScans.values()].map((p) => p.url));
+      for (const url of newUrls) {
+        if (!verdictByUrl.has(url) && !inFlightUrls.has(url)) {
+          dispatchScanRequest(url);
+        }
+      }
+      currentUrls = newUrls;
+      applyGate();
+    }, INTERCEPT_INPUT_DEBOUNCE_MS);
+  }
+
+  function onKeyDown(ev: KeyboardEvent): void {
+    if (ev.key !== 'Enter') return;
+    if (ev.shiftKey) return; // Shift-Enter is a newline in chat composers; let it through.
+    const button = adapter.findSendButton(document);
+    if (button === null) return;
+    if (isHoneyLLMDisabled(button)) {
+      ev.preventDefault();
+      ev.stopPropagation();
+    }
+  }
+
+  function onChromeMessage(msg: HoneyLLMMessage): void {
+    if (msg.type !== 'INTERCEPT_VERDICT') return;
+    const verdictMsg = msg as InterceptVerdictMessage;
+    const pending = pendingScans.get(verdictMsg.requestId);
+    if (pending === undefined) return;
+    pendingScans.delete(verdictMsg.requestId);
+    verdictByUrl.set(pending.url, verdictMsg.verdict);
+    applyGate();
+  }
+
+  // Attach listeners. Use document for capture so we see keydown before the
+  // page handles it. Input event bubbles from the contenteditable.
+  document.addEventListener('input', onInput, true);
+  document.addEventListener('keydown', onKeyDown, true);
+  chrome.runtime.onMessage.addListener(onChromeMessage);
+
+  return () => {
+    if (debounceTimer !== null) clearTimeout(debounceTimer);
+    document.removeEventListener('input', onInput, true);
+    document.removeEventListener('keydown', onKeyDown, true);
+    chrome.runtime.onMessage.removeListener(onChromeMessage);
+    // Best-effort restore the button on dispose.
+    const button = adapter.findSendButton(document);
+    if (button !== null && isHoneyLLMDisabled(button)) restoreSendButton(button);
+  };
+}

--- a/src/content/portals/intercept/send-button.test.ts
+++ b/src/content/portals/intercept/send-button.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  disableSendButton,
+  restoreSendButton,
+  isHoneyLLMDisabled,
+} from './send-button.js';
+
+function freshButton(): HTMLButtonElement {
+  while (document.body.firstChild !== null) {
+    document.body.removeChild(document.body.firstChild);
+  }
+  const btn = document.createElement('button');
+  btn.id = 'b';
+  btn.textContent = 'Send';
+  document.body.appendChild(btn);
+  return btn;
+}
+
+function freshDivButton(): HTMLElement {
+  while (document.body.firstChild !== null) {
+    document.body.removeChild(document.body.firstChild);
+  }
+  const el = document.createElement('div');
+  el.id = 'd';
+  el.setAttribute('role', 'button');
+  el.textContent = 'Send';
+  document.body.appendChild(el);
+  return el;
+}
+
+describe('send-button gating helpers', () => {
+  let btn: HTMLButtonElement;
+
+  beforeEach(() => {
+    btn = freshButton();
+  });
+
+  it('disables, sets aria-disabled, title, and the data flag', () => {
+    disableSendButton(btn, 'HoneyLLM scanning…');
+    expect(btn.disabled).toBe(true);
+    expect(btn.getAttribute('aria-disabled')).toBe('true');
+    expect(btn.getAttribute('title')).toBe('HoneyLLM scanning…');
+    expect(btn.getAttribute('data-honeyllm-disabled')).toBe('true');
+    expect(isHoneyLLMDisabled(btn)).toBe(true);
+  });
+
+  it('restoreSendButton clears all four side-effects when this code disabled it', () => {
+    disableSendButton(btn, 'reason');
+    restoreSendButton(btn);
+    expect(btn.disabled).toBe(false);
+    expect(btn.getAttribute('aria-disabled')).toBeNull();
+    expect(btn.getAttribute('title')).toBeNull();
+    expect(btn.getAttribute('data-honeyllm-disabled')).toBeNull();
+    expect(isHoneyLLMDisabled(btn)).toBe(false);
+  });
+
+  it('restoreSendButton leaves a button alone if HoneyLLM did not disable it', () => {
+    btn.disabled = true;
+    btn.setAttribute('aria-disabled', 'true');
+    btn.setAttribute('title', 'Page is loading');
+    restoreSendButton(btn);
+    expect(btn.disabled).toBe(true);
+    expect(btn.getAttribute('aria-disabled')).toBe('true');
+    expect(btn.getAttribute('title')).toBe('Page is loading');
+  });
+
+  it('updates an existing HoneyLLM-disabled button with a new reason without toggling', () => {
+    disableSendButton(btn, 'first reason');
+    disableSendButton(btn, 'second reason');
+    expect(btn.getAttribute('title')).toBe('second reason');
+    expect(btn.disabled).toBe(true);
+  });
+
+  it('disableSendButton tolerates a non-button HTMLElement (anchor or div with role)', () => {
+    const el = freshDivButton();
+    disableSendButton(el, 'why');
+    expect(el.getAttribute('aria-disabled')).toBe('true');
+    expect(el.getAttribute('title')).toBe('why');
+    expect(el.getAttribute('data-honeyllm-disabled')).toBe('true');
+  });
+});

--- a/src/content/portals/intercept/send-button.ts
+++ b/src/content/portals/intercept/send-button.ts
@@ -1,0 +1,24 @@
+const HONEYLLM_FLAG = 'data-honeyllm-disabled';
+
+export function disableSendButton(el: HTMLElement, reason: string): void {
+  if ('disabled' in el && typeof (el as HTMLButtonElement).disabled === 'boolean') {
+    (el as HTMLButtonElement).disabled = true;
+  }
+  el.setAttribute('aria-disabled', 'true');
+  el.setAttribute('title', reason);
+  el.setAttribute(HONEYLLM_FLAG, 'true');
+}
+
+export function restoreSendButton(el: HTMLElement): void {
+  if (el.getAttribute(HONEYLLM_FLAG) !== 'true') return;
+  if ('disabled' in el && typeof (el as HTMLButtonElement).disabled === 'boolean') {
+    (el as HTMLButtonElement).disabled = false;
+  }
+  el.removeAttribute('aria-disabled');
+  el.removeAttribute('title');
+  el.removeAttribute(HONEYLLM_FLAG);
+}
+
+export function isHoneyLLMDisabled(el: HTMLElement): boolean {
+  return el.getAttribute(HONEYLLM_FLAG) === 'true';
+}

--- a/src/content/portals/intercept/url-extract.test.ts
+++ b/src/content/portals/intercept/url-extract.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { extractUrls } from './url-extract.js';
+import { MAX_INTERCEPT_URLS_PER_PROMPT } from '@/shared/constants.js';
+
+describe('extractUrls', () => {
+  it('returns empty array for empty input', () => {
+    expect(extractUrls('')).toEqual([]);
+  });
+
+  it('returns empty array when no URL is present', () => {
+    expect(extractUrls('hello world how are you today')).toEqual([]);
+  });
+
+  it('extracts a single https URL from prose', () => {
+    expect(extractUrls('please look up https://example.com for me')).toEqual([
+      'https://example.com',
+    ]);
+  });
+
+  it('extracts a single http URL from prose', () => {
+    expect(extractUrls('see http://insecure.example/page?q=1 thanks')).toEqual([
+      'http://insecure.example/page?q=1',
+    ]);
+  });
+
+  it('returns multiple URLs in document order', () => {
+    expect(
+      extractUrls('compare https://a.example and https://b.example please'),
+    ).toEqual(['https://a.example', 'https://b.example']);
+  });
+
+  it('dedupes identical URLs', () => {
+    expect(
+      extractUrls('see https://a.example and again https://a.example'),
+    ).toEqual(['https://a.example']);
+  });
+
+  it('skips ftp / mailto / javascript schemes', () => {
+    expect(
+      extractUrls(
+        'mailto:a@b.com ftp://x.example javascript:alert(1) https://ok.example',
+      ),
+    ).toEqual(['https://ok.example']);
+  });
+
+  it('caps the result at MAX_INTERCEPT_URLS_PER_PROMPT', () => {
+    const text = Array.from(
+      { length: MAX_INTERCEPT_URLS_PER_PROMPT + 5 },
+      (_v, i) => `https://h${i}.example`,
+    ).join(' ');
+    const out = extractUrls(text);
+    expect(out).toHaveLength(MAX_INTERCEPT_URLS_PER_PROMPT);
+    expect(out[0]).toBe('https://h0.example');
+  });
+
+  it('handles URLs with paths, queries, and fragments', () => {
+    expect(
+      extractUrls('see https://x.example/a/b?c=1&d=2#frag for details'),
+    ).toEqual(['https://x.example/a/b?c=1&d=2#frag']);
+  });
+
+  it('strips a trailing comma / period that is clearly punctuation', () => {
+    expect(extractUrls('go to https://x.example.')).toEqual(['https://x.example']);
+    expect(extractUrls('compare https://a.example, https://b.example.')).toEqual([
+      'https://a.example',
+      'https://b.example',
+    ]);
+  });
+
+  it('does not split a URL on internal . or , inside the path', () => {
+    expect(extractUrls('see https://x.example/a.b,c thanks')).toEqual([
+      'https://x.example/a.b,c',
+    ]);
+  });
+
+  it('handles a URL adjacent to leading whitespace and newlines', () => {
+    expect(extractUrls('please scan\n\nhttps://a.example\n\nthanks')).toEqual([
+      'https://a.example',
+    ]);
+  });
+});

--- a/src/content/portals/intercept/url-extract.ts
+++ b/src/content/portals/intercept/url-extract.ts
@@ -1,0 +1,20 @@
+import { MAX_INTERCEPT_URLS_PER_PROMPT } from '@/shared/constants.js';
+
+const URL_PATTERN = /\bhttps?:\/\/[^\s<>"']+/gi;
+const TRAILING_PUNCTUATION = /[.,;:!?)\]}>'"`]+$/;
+
+export function extractUrls(text: string): readonly string[] {
+  if (text.length === 0) return [];
+  const matches = text.match(URL_PATTERN) ?? [];
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const raw of matches) {
+    const cleaned = raw.replace(TRAILING_PUNCTUATION, '');
+    if (cleaned.length === 0) continue;
+    if (seen.has(cleaned)) continue;
+    seen.add(cleaned);
+    result.push(cleaned);
+    if (result.length >= MAX_INTERCEPT_URLS_PER_PROMPT) break;
+  }
+  return result;
+}

--- a/src/offscreen/index.ts
+++ b/src/offscreen/index.ts
@@ -2,6 +2,7 @@ import type {
   HoneyLLMMessage,
   LanguageResultMessage,
   NerResultMessage,
+  ParseHtmlResultMessage,
   ProbeResultsMessage,
   ProbeDirectResultMessage,
 } from '@/types/messages.js';
@@ -12,6 +13,7 @@ import { runProbes } from './probe-runner.js';
 import { runDirectProbe, type DirectProbeDeps } from './direct-probe.js';
 import { handleDetectLanguage } from './lang-detect-engine.js';
 import { handleRunNer } from './ner-engine.js';
+import { parseHtmlToSnapshot } from './parse-html.js';
 
 const log = createLogger('Offscreen');
 
@@ -122,6 +124,34 @@ chrome.runtime.onMessage.addListener((message: HoneyLLMMessage, _sender, sendRes
   // handleRunNer is total: returns [] on every failure path (load failure,
   // deadline miss, factory exception). Span offsets come back absolute over
   // the page text because `chunkOffset` is forwarded into handleRunNer.
+  // Issue #130 (N7b) — synthetic-snapshot HTML parse RPC. Used by the
+  // SW's url-scanner: fetched HTML lands here, gets parsed via DOMParser
+  // (which the SW lacks), and returns a PageSnapshot the orchestrator
+  // can consume unchanged. Reduced-fidelity layout filtering — the
+  // detached document has no viewport.
+  if (message.type === 'PARSE_HTML_REQUEST') {
+    try {
+      const snapshot = parseHtmlToSnapshot(message.html, message.url);
+      const reply: ParseHtmlResultMessage = {
+        type: 'PARSE_HTML_RESULT',
+        requestId: message.requestId,
+        snapshot,
+        errorMessage: null,
+      };
+      sendResponse(reply);
+    } catch (err: unknown) {
+      log.error('parseHtmlToSnapshot threw', err);
+      const reply: ParseHtmlResultMessage = {
+        type: 'PARSE_HTML_RESULT',
+        requestId: message.requestId,
+        snapshot: null,
+        errorMessage: err instanceof Error ? err.message : 'parse_failed',
+      };
+      sendResponse(reply);
+    }
+    return false; // synchronous reply
+  }
+
   if (message.type === 'RUN_NER') {
     const start = performance.now();
     handleRunNer(message.text, message.deadlineMs ?? 250, message.chunkOffset)

--- a/src/offscreen/parse-html.test.ts
+++ b/src/offscreen/parse-html.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { parseHtmlToSnapshot } from './parse-html.js';
+
+describe('parseHtmlToSnapshot', () => {
+  it('returns a PageSnapshot with metadata derived from the URL parameter', () => {
+    const html = `<!doctype html><html lang="en"><head>
+      <title>Example Domain</title>
+      <meta name="description" content="Sample description">
+      <meta property="og:title" content="OG Title">
+    </head><body><p>hello world</p></body></html>`;
+    const snap = parseHtmlToSnapshot(html, 'https://example.com/page?q=1');
+    expect(snap.metadata.url).toBe('https://example.com/page?q=1');
+    expect(snap.metadata.origin).toBe('https://example.com');
+    expect(snap.metadata.title).toBe('Example Domain');
+    expect(snap.metadata.description).toBe('Sample description');
+    expect(snap.metadata.lang).toBe('en');
+    expect(snap.metadata.ogTags.get('og:title')).toBe('OG Title');
+  });
+
+  it('extracts visible text from the body (no layout filter)', () => {
+    const html = `<!doctype html><html><body>
+      <h1>Welcome</h1>
+      <p>This is <strong>bold</strong> text.</p>
+      <script>console.log('skip me')</script>
+      <style>.x{color:red}</style>
+      <noscript>noscript content</noscript>
+    </body></html>`;
+    const snap = parseHtmlToSnapshot(html, 'https://x.example/');
+    expect(snap.visibleText).toContain('Welcome');
+    expect(snap.visibleText).toContain('bold');
+    expect(snap.visibleText).not.toContain('skip me');
+    expect(snap.visibleText).not.toContain('color:red');
+    expect(snap.visibleText).not.toContain('noscript content');
+  });
+
+  it('extracts hidden text via attribute heuristics', () => {
+    const html = `<!doctype html><html><body>
+      <p>visible para</p>
+      <div hidden>HIDDEN-ATTR</div>
+      <div aria-hidden="true">ARIA-HIDDEN</div>
+      <span style="display:none">STYLE-NONE</span>
+      <span style="visibility: hidden">STYLE-VISHIDDEN</span>
+      <span class="sr-only">SR-ONLY</span>
+    </body></html>`;
+    const snap = parseHtmlToSnapshot(html, 'https://x.example/');
+    expect(snap.hiddenText).toContain('HIDDEN-ATTR');
+    expect(snap.hiddenText).toContain('ARIA-HIDDEN');
+    expect(snap.hiddenText).toContain('STYLE-NONE');
+    expect(snap.hiddenText).toContain('STYLE-VISHIDDEN');
+    expect(snap.hiddenText).toContain('SR-ONLY');
+    expect(snap.visibleText).toContain('visible para');
+    expect(snap.visibleText).not.toContain('HIDDEN-ATTR');
+  });
+
+  it('extracts script fingerprints with sha-256 hash and src', () => {
+    const html = `<!doctype html><html><body>
+      <script src="https://cdn.example/lib.js"></script>
+      <script>console.log('inline')</script>
+    </body></html>`;
+    const snap = parseHtmlToSnapshot(html, 'https://x.example/');
+    expect(snap.scriptFingerprints).toHaveLength(2);
+    const external = snap.scriptFingerprints.find((s) => s.src !== null);
+    expect(external?.src).toBe('https://cdn.example/lib.js');
+    expect(external?.length).toBe(0);
+    expect(external?.hash).toBe('');
+    const inline = snap.scriptFingerprints.find((s) => s.src === null);
+    expect(inline?.length).toBeGreaterThan(0);
+    expect(inline?.hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(inline?.preview).toContain('inline');
+  });
+
+  it('populates extractedAt and charCount', () => {
+    const before = Date.now();
+    const snap = parseHtmlToSnapshot(
+      '<!doctype html><html><body><p>hi</p></body></html>',
+      'https://x.example/',
+    );
+    expect(snap.extractedAt).toBeGreaterThanOrEqual(before);
+    expect(snap.charCount).toBe(snap.visibleText.length + snap.hiddenText.length);
+  });
+
+  it('returns origin "null" sentinel when URL is not a parseable URL', () => {
+    const snap = parseHtmlToSnapshot(
+      '<!doctype html><html><body><p>x</p></body></html>',
+      'not-a-url',
+    );
+    // We still return a snapshot; the origin is the raw URL fallback.
+    expect(snap.metadata.url).toBe('not-a-url');
+    expect(snap.metadata.origin).toBe('not-a-url');
+  });
+
+  it('returns empty extraction for a page with no <body>', () => {
+    const snap = parseHtmlToSnapshot(
+      '<!doctype html><html><head><title>t</title></head></html>',
+      'https://x.example/',
+    );
+    expect(snap.visibleText).toBe('');
+    expect(snap.hiddenText).toBe('');
+    expect(snap.metadata.title).toBe('t');
+  });
+});

--- a/src/offscreen/parse-html.ts
+++ b/src/offscreen/parse-html.ts
@@ -1,0 +1,229 @@
+import type { PageMetadata, PageSnapshot, ScriptFingerprint } from '@/types/snapshot.js';
+import {
+  MAX_HIDDEN_TEXT_CHARS,
+  MAX_VISIBLE_TEXT_CHARS,
+  SCRIPT_PREVIEW_LENGTH,
+} from '@/shared/constants.js';
+
+const SKIP_TAGS = new Set(['SCRIPT', 'STYLE', 'NOSCRIPT', 'SVG', 'TEMPLATE']);
+
+const HIDDEN_SELECTORS = [
+  '[hidden]',
+  '[aria-hidden="true"]',
+  '[style*="display:none"]',
+  '[style*="display: none"]',
+  '[style*="visibility:hidden"]',
+  '[style*="visibility: hidden"]',
+  '[style*="opacity:0"]',
+  '[style*="opacity: 0"]',
+  '.sr-only',
+  '.visually-hidden',
+  '.hidden',
+].join(',');
+
+export function parseHtmlToSnapshot(html: string, url: string): PageSnapshot {
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  const visibleText = extractVisibleTextFromDoc(doc);
+  const hiddenText = extractHiddenTextFromDoc(doc);
+  const scriptFingerprints = extractScriptFingerprintsSync(doc);
+  const metadata = extractMetadataFromDoc(doc, url);
+  return {
+    visibleText,
+    hiddenText,
+    scriptFingerprints,
+    metadata,
+    extractedAt: Date.now(),
+    charCount: visibleText.length + hiddenText.length,
+  };
+}
+
+function isHiddenByAttributes(el: Element): boolean {
+  if (el.hasAttribute('hidden')) return true;
+  if (el.getAttribute('aria-hidden') === 'true') return true;
+  const style = el.getAttribute('style') ?? '';
+  if (/display\s*:\s*none/i.test(style)) return true;
+  if (/visibility\s*:\s*hidden/i.test(style)) return true;
+  if (/opacity\s*:\s*0(?!\.)/i.test(style)) return true;
+  return false;
+}
+
+function hasHiddenAncestor(node: Node): boolean {
+  let current: Node | null = node.parentElement;
+  while (current !== null && current.nodeType === 1) {
+    const el = current as Element;
+    if (isHiddenByAttributes(el)) return true;
+    current = el.parentElement;
+  }
+  return false;
+}
+
+function extractVisibleTextFromDoc(doc: Document): string {
+  const body = doc.body;
+  if (body === null || body === undefined) return '';
+
+  const walker = doc.createTreeWalker(body, NodeFilter.SHOW_TEXT, {
+    acceptNode(node) {
+      const parent = node.parentElement;
+      if (parent === null) return NodeFilter.FILTER_REJECT;
+      if (SKIP_TAGS.has(parent.tagName)) return NodeFilter.FILTER_REJECT;
+      if (hasHiddenAncestor(node)) return NodeFilter.FILTER_REJECT;
+      const text = node.textContent?.trim();
+      if (!text || text.length === 0) return NodeFilter.FILTER_REJECT;
+      return NodeFilter.FILTER_ACCEPT;
+    },
+  });
+
+  const parts: string[] = [];
+  let totalLength = 0;
+  while (walker.nextNode()) {
+    const text = walker.currentNode.textContent?.trim() ?? '';
+    if (totalLength + text.length > MAX_VISIBLE_TEXT_CHARS) {
+      parts.push(text.slice(0, MAX_VISIBLE_TEXT_CHARS - totalLength));
+      break;
+    }
+    parts.push(text);
+    totalLength += text.length;
+  }
+  return parts.join(' ');
+}
+
+function extractHiddenTextFromDoc(doc: Document): string {
+  const body = doc.body;
+  if (body === null || body === undefined) return '';
+  const elements = body.querySelectorAll(HIDDEN_SELECTORS);
+  const parts: string[] = [];
+  let totalLength = 0;
+  for (const el of elements) {
+    const text = el.textContent?.trim() ?? '';
+    if (text.length === 0) continue;
+    if (totalLength + text.length > MAX_HIDDEN_TEXT_CHARS) {
+      parts.push(text.slice(0, MAX_HIDDEN_TEXT_CHARS - totalLength));
+      break;
+    }
+    parts.push(text);
+    totalLength += text.length;
+  }
+  return parts.join('\n');
+}
+
+function extractScriptFingerprintsSync(doc: Document): readonly ScriptFingerprint[] {
+  const scripts = doc.querySelectorAll('script');
+  const fingerprints: ScriptFingerprint[] = [];
+  for (const script of scripts) {
+    const src = script.getAttribute('src');
+    const content = script.textContent ?? '';
+    if (content.length === 0 && (src === null || src === '')) continue;
+    fingerprints.push({
+      src: src && src.length > 0 ? src : null,
+      preview: content.slice(0, SCRIPT_PREVIEW_LENGTH),
+      hash: content.length > 0 ? hashSync(content) : '',
+      length: content.length,
+    });
+  }
+  return fingerprints;
+}
+
+// Synchronous SHA-256 via a 32-bit word implementation. The DOMParser path
+// runs in offscreen which has crypto.subtle, but parseHtmlToSnapshot is
+// callable from the SW too if we ever inline it for tests. Sync hashing
+// keeps the API simple. Hash output matches `crypto.subtle.digest('SHA-256',…)`
+// hex-encoded byte-for-byte for the same input string (UTF-8).
+function hashSync(text: string): string {
+  const bytes = new TextEncoder().encode(text);
+  return sha256(bytes);
+}
+
+function sha256(input: Uint8Array): string {
+  const K = new Uint32Array([
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+    0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+    0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+    0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+    0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+    0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+  ]);
+  const H = new Uint32Array([
+    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+  ]);
+  const bitLen = input.length * 8;
+  const padLen = (input.length + 9 + 63) & ~63;
+  const padded = new Uint8Array(padLen);
+  padded.set(input);
+  padded[input.length] = 0x80;
+  const dv = new DataView(padded.buffer);
+  dv.setUint32(padLen - 8, Math.floor(bitLen / 0x100000000));
+  dv.setUint32(padLen - 4, bitLen >>> 0);
+
+  const w = new Uint32Array(64);
+  for (let i = 0; i < padLen; i += 64) {
+    for (let t = 0; t < 16; t++) w[t] = dv.getUint32(i + t * 4);
+    for (let t = 16; t < 64; t++) {
+      const s0 = rotr(w[t - 15], 7) ^ rotr(w[t - 15], 18) ^ (w[t - 15] >>> 3);
+      const s1 = rotr(w[t - 2], 17) ^ rotr(w[t - 2], 19) ^ (w[t - 2] >>> 10);
+      w[t] = (w[t - 16] + s0 + w[t - 7] + s1) >>> 0;
+    }
+    let [a, b, c, d, e, f, g, h] = H;
+    for (let t = 0; t < 64; t++) {
+      const S1 = rotr(e, 6) ^ rotr(e, 11) ^ rotr(e, 25);
+      const ch = (e & f) ^ (~e & g);
+      const t1 = (h + S1 + ch + K[t] + w[t]) >>> 0;
+      const S0 = rotr(a, 2) ^ rotr(a, 13) ^ rotr(a, 22);
+      const mj = (a & b) ^ (a & c) ^ (b & c);
+      const t2 = (S0 + mj) >>> 0;
+      h = g;
+      g = f;
+      f = e;
+      e = (d + t1) >>> 0;
+      d = c;
+      c = b;
+      b = a;
+      a = (t1 + t2) >>> 0;
+    }
+    H[0] = (H[0] + a) >>> 0;
+    H[1] = (H[1] + b) >>> 0;
+    H[2] = (H[2] + c) >>> 0;
+    H[3] = (H[3] + d) >>> 0;
+    H[4] = (H[4] + e) >>> 0;
+    H[5] = (H[5] + f) >>> 0;
+    H[6] = (H[6] + g) >>> 0;
+    H[7] = (H[7] + h) >>> 0;
+  }
+  let out = '';
+  for (let i = 0; i < 8; i++) out += H[i].toString(16).padStart(8, '0');
+  return out;
+}
+
+function rotr(x: number, n: number): number {
+  return ((x >>> n) | (x << (32 - n))) >>> 0;
+}
+
+function extractMetadataFromDoc(doc: Document, url: string): PageMetadata {
+  const ogTags = new Map<string, string>();
+  doc.querySelectorAll('meta[property^="og:"]').forEach((meta) => {
+    const property = meta.getAttribute('property') ?? '';
+    const content = meta.getAttribute('content') ?? '';
+    if (property.length > 0 && content.length > 0) ogTags.set(property, content);
+  });
+  const cspMeta =
+    doc.querySelector('meta[http-equiv="Content-Security-Policy"]')?.getAttribute('content') ??
+    null;
+  const description =
+    doc.querySelector('meta[name="description"]')?.getAttribute('content') ?? '';
+  let origin = url;
+  try {
+    origin = new URL(url).origin;
+  } catch {
+    /* fall through to raw url */
+  }
+  return {
+    title: doc.title,
+    url,
+    origin,
+    description,
+    ogTags,
+    cspMeta,
+    lang: doc.documentElement?.lang || 'unknown',
+  };
+}

--- a/src/policy/intercept-overrides.test.ts
+++ b/src/policy/intercept-overrides.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  STORAGE_KEY_INTERCEPT_OVERRIDES,
+  INTERCEPT_OVERRIDE_WINDOW_MS,
+  INTERCEPT_OVERRIDE_WHITELIST_THRESHOLD,
+} from '@/shared/constants.js';
+
+import {
+  recordOverride,
+  getOverrideCount,
+  shouldPromptWhitelist,
+  __clearOverridesForTest,
+} from './intercept-overrides.js';
+
+interface ChromeStub {
+  readonly readStore: () => Record<string, unknown>;
+}
+
+function setupChrome(initial: Record<string, unknown> = {}): ChromeStub {
+  const store: Record<string, unknown> = { ...initial };
+  vi.stubGlobal('chrome', {
+    storage: {
+      local: {
+        get: async (key?: string | string[] | null) => {
+          if (key === undefined || key === null) return { ...store };
+          if (Array.isArray(key)) {
+            const out: Record<string, unknown> = {};
+            for (const k of key) if (k in store) out[k] = store[k];
+            return out;
+          }
+          return key in store ? { [key]: store[key] } : {};
+        },
+        set: async (items: Record<string, unknown>) => {
+          Object.assign(store, items);
+        },
+      },
+    },
+  });
+  return { readStore: () => store };
+}
+
+describe('intercept-overrides', () => {
+  beforeEach(() => {
+    __clearOverridesForTest();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('recordOverride creates a record on first override', async () => {
+    setupChrome();
+    await recordOverride('chatgpt', 'attacker.example');
+    const count = await getOverrideCount('chatgpt', 'attacker.example');
+    expect(count).toBe(1);
+  });
+
+  it('recordOverride increments count on subsequent overrides', async () => {
+    setupChrome();
+    await recordOverride('chatgpt', 'a.example');
+    await recordOverride('chatgpt', 'a.example');
+    await recordOverride('chatgpt', 'a.example');
+    expect(await getOverrideCount('chatgpt', 'a.example')).toBe(3);
+  });
+
+  it('records are isolated per portalId', async () => {
+    setupChrome();
+    await recordOverride('chatgpt', 'a.example');
+    await recordOverride('claude', 'a.example');
+    expect(await getOverrideCount('chatgpt', 'a.example')).toBe(1);
+    expect(await getOverrideCount('claude', 'a.example')).toBe(1);
+    expect(await getOverrideCount('gemini', 'a.example')).toBe(0);
+  });
+
+  it('records are isolated per domain', async () => {
+    setupChrome();
+    await recordOverride('chatgpt', 'a.example');
+    await recordOverride('chatgpt', 'b.example');
+    expect(await getOverrideCount('chatgpt', 'a.example')).toBe(1);
+    expect(await getOverrideCount('chatgpt', 'b.example')).toBe(1);
+  });
+
+  it('returns 0 if the most recent override is older than the rolling window', async () => {
+    vi.useFakeTimers();
+    const start = new Date('2026-01-01T00:00:00Z').getTime();
+    vi.setSystemTime(start);
+    setupChrome();
+    await recordOverride('chatgpt', 'a.example');
+    expect(await getOverrideCount('chatgpt', 'a.example')).toBe(1);
+    vi.setSystemTime(start + INTERCEPT_OVERRIDE_WINDOW_MS + 1000);
+    expect(await getOverrideCount('chatgpt', 'a.example')).toBe(0);
+  });
+
+  it('shouldPromptWhitelist returns true at threshold within the window', async () => {
+    setupChrome();
+    for (let i = 0; i < INTERCEPT_OVERRIDE_WHITELIST_THRESHOLD; i++) {
+      await recordOverride('chatgpt', 'a.example');
+    }
+    expect(await shouldPromptWhitelist('chatgpt', 'a.example')).toBe(true);
+  });
+
+  it('shouldPromptWhitelist returns false below threshold', async () => {
+    setupChrome();
+    for (let i = 0; i < INTERCEPT_OVERRIDE_WHITELIST_THRESHOLD - 1; i++) {
+      await recordOverride('chatgpt', 'a.example');
+    }
+    expect(await shouldPromptWhitelist('chatgpt', 'a.example')).toBe(false);
+  });
+
+  it('persists records under STORAGE_KEY_INTERCEPT_OVERRIDES', async () => {
+    const stub = setupChrome();
+    await recordOverride('chatgpt', 'a.example');
+    const stored = stub.readStore()[STORAGE_KEY_INTERCEPT_OVERRIDES];
+    expect(stored).toBeDefined();
+    const map = stored as Record<string, { count: number }>;
+    expect(map['chatgpt:a.example']?.count).toBe(1);
+  });
+
+  it('lowercases the domain before keying', async () => {
+    setupChrome();
+    await recordOverride('chatgpt', 'A.Example');
+    expect(await getOverrideCount('chatgpt', 'a.example')).toBe(1);
+  });
+});

--- a/src/policy/intercept-overrides.ts
+++ b/src/policy/intercept-overrides.ts
@@ -1,0 +1,82 @@
+import type { PortalId } from '@/types/messages.js';
+import {
+  INTERCEPT_OVERRIDE_WHITELIST_THRESHOLD,
+  INTERCEPT_OVERRIDE_WINDOW_MS,
+  STORAGE_KEY_INTERCEPT_OVERRIDES,
+} from '@/shared/constants.js';
+
+interface InterceptOverrideRecord {
+  readonly portalId: PortalId;
+  readonly domain: string;
+  readonly count: number;
+  readonly firstOverride: number;
+  readonly lastOverride: number;
+}
+
+type OverrideMap = Record<string, InterceptOverrideRecord>;
+
+function recordKey(portalId: PortalId, domain: string): string {
+  return `${portalId}:${domain.toLowerCase()}`;
+}
+
+async function readMap(): Promise<OverrideMap> {
+  try {
+    const r = await chrome.storage.local.get(STORAGE_KEY_INTERCEPT_OVERRIDES);
+    const v = r[STORAGE_KEY_INTERCEPT_OVERRIDES];
+    if (typeof v === 'object' && v !== null) {
+      return v as OverrideMap;
+    }
+  } catch {
+    /* fall through */
+  }
+  return {};
+}
+
+async function writeMap(map: OverrideMap): Promise<void> {
+  await chrome.storage.local.set({ [STORAGE_KEY_INTERCEPT_OVERRIDES]: map });
+}
+
+function isWithinWindow(record: InterceptOverrideRecord, now: number): boolean {
+  return now - record.lastOverride <= INTERCEPT_OVERRIDE_WINDOW_MS;
+}
+
+export async function recordOverride(portalId: PortalId, domain: string): Promise<void> {
+  const key = recordKey(portalId, domain);
+  const now = Date.now();
+  const map = await readMap();
+  const prior = map[key];
+  // If the prior record is outside the rolling window, reset count to 1
+  // rather than continuing to accumulate forever.
+  const priorWithin = prior !== undefined && isWithinWindow(prior, now);
+  const next: InterceptOverrideRecord = {
+    portalId,
+    domain: domain.toLowerCase(),
+    count: priorWithin ? prior.count + 1 : 1,
+    firstOverride: priorWithin ? prior.firstOverride : now,
+    lastOverride: now,
+  };
+  await writeMap({ ...map, [key]: next });
+}
+
+export async function getOverrideCount(portalId: PortalId, domain: string): Promise<number> {
+  const key = recordKey(portalId, domain);
+  const now = Date.now();
+  const map = await readMap();
+  const prior = map[key];
+  if (prior === undefined) return 0;
+  if (!isWithinWindow(prior, now)) return 0;
+  return prior.count;
+}
+
+export async function shouldPromptWhitelist(
+  portalId: PortalId,
+  domain: string,
+): Promise<boolean> {
+  const count = await getOverrideCount(portalId, domain);
+  return count >= INTERCEPT_OVERRIDE_WHITELIST_THRESHOLD;
+}
+
+/** Test-only helper — clears in-memory caches if any are added later. */
+export function __clearOverridesForTest(): void {
+  /* no in-memory state currently; reserved for future per-process caching */
+}

--- a/src/popup/pending-intercept.test.ts
+++ b/src/popup/pending-intercept.test.ts
@@ -1,0 +1,303 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  STORAGE_KEY_PENDING_INTERCEPT,
+  STORAGE_KEY_INTERCEPT_OVERRIDES,
+  INTERCEPT_OVERRIDE_WHITELIST_THRESHOLD,
+  INTERCEPT_OVERRIDE_WINDOW_MS,
+  MAX_INTERCEPT_LATENCY_EXTENSION_MS,
+} from '@/shared/constants.js';
+import type { InterceptVerdict } from '@/types/messages.js';
+
+import {
+  renderPendingIntercept,
+  type PendingInterceptRecord,
+} from './pending-intercept.js';
+
+interface StorageStub {
+  readonly readStore: () => Record<string, unknown>;
+  readonly writeStore: (patch: Record<string, unknown>) => void;
+  readonly removeKey: (key: string) => void;
+}
+
+function setupChrome(initialStore: Record<string, unknown> = {}): StorageStub {
+  const store: Record<string, unknown> = { ...initialStore };
+  vi.stubGlobal('chrome', {
+    storage: {
+      local: {
+        get: async (key?: string | string[] | null) => {
+          if (key === undefined || key === null) return { ...store };
+          if (typeof key === 'string') {
+            return key in store ? { [key]: store[key] } : {};
+          }
+          const out: Record<string, unknown> = {};
+          for (const k of key) if (k in store) out[k] = store[k];
+          return out;
+        },
+        set: async (items: Record<string, unknown>) => {
+          Object.assign(store, items);
+        },
+        remove: async (key: string | string[]) => {
+          const keys = Array.isArray(key) ? key : [key];
+          for (const k of keys) delete store[k];
+        },
+      },
+      onChanged: { addListener: vi.fn(), removeListener: vi.fn() },
+    },
+  });
+  return {
+    readStore: () => ({ ...store }),
+    writeStore: (patch) => Object.assign(store, patch),
+    removeKey: (key) => {
+      delete store[key];
+    },
+  };
+}
+
+function buildRoot(): HTMLElement {
+  while (document.body.firstChild !== null) document.body.removeChild(document.body.firstChild);
+  const div = document.createElement('div');
+  div.id = 'pending-intercept-root';
+  document.body.appendChild(div);
+  return div;
+}
+
+function buildVerdict(overrides: Partial<InterceptVerdict> = {}): InterceptVerdict {
+  return {
+    status: 'CLEAN',
+    scannedUrl: 'https://target.example/',
+    probeBreakdown: { totalProbes: 3, suspiciousProbes: 0, compromisedProbes: 0 },
+    totalScore: 0,
+    cacheHit: false,
+    timestamp: 0,
+    analysisError: null,
+    ...overrides,
+  };
+}
+
+function buildRecord(overrides: Partial<PendingInterceptRecord> = {}): PendingInterceptRecord {
+  const startedAt = Date.now();
+  return {
+    requestId: 'req-1',
+    portalId: 'chatgpt',
+    portalOrigin: 'https://chatgpt.com',
+    scannedUrl: 'https://target.example/',
+    status: 'scanning',
+    verdict: null,
+    startedAt,
+    timeoutAt: startedAt + 30_000,
+    timeoutExtended: false,
+    ...overrides,
+  };
+}
+
+describe('renderPendingIntercept', () => {
+  let root: HTMLElement;
+  beforeEach(() => {
+    root = buildRoot();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('renders nothing when record is null', () => {
+    setupChrome();
+    renderPendingIntercept(root, null);
+    expect(root.children.length).toBe(0);
+  });
+
+  it('scanning state shows Send-anyway / Cancel / Wait', () => {
+    setupChrome();
+    renderPendingIntercept(root, buildRecord({ status: 'scanning' }));
+    const text = root.textContent ?? '';
+    expect(text).toContain('Send anyway');
+    expect(text).toContain('Cancel');
+    expect(text).toContain('Wait');
+  });
+
+  it('verdict-ready CLEAN renders a clean badge, no buttons', () => {
+    setupChrome();
+    renderPendingIntercept(
+      root,
+      buildRecord({ status: 'verdict-ready', verdict: buildVerdict({ status: 'CLEAN' }) }),
+    );
+    const text = root.textContent ?? '';
+    expect(text).toContain('CLEAN');
+    expect(text).not.toContain('Wait');
+  });
+
+  it('verdict-ready SUSPICIOUS renders Send-anyway / Cancel only (no Wait)', () => {
+    setupChrome();
+    renderPendingIntercept(
+      root,
+      buildRecord({ status: 'verdict-ready', verdict: buildVerdict({ status: 'SUSPICIOUS' }) }),
+    );
+    const text = root.textContent ?? '';
+    expect(text).toContain('SUSPICIOUS');
+    expect(text).toContain('Send anyway');
+    expect(text).toContain('Cancel');
+    expect(text).not.toContain('Wait');
+  });
+
+  it('verdict-ready COMPROMISED renders block notice with Send-anyway / Cancel', () => {
+    setupChrome();
+    renderPendingIntercept(
+      root,
+      buildRecord({ status: 'verdict-ready', verdict: buildVerdict({ status: 'COMPROMISED' }) }),
+    );
+    const text = root.textContent ?? '';
+    expect(text).toContain('COMPROMISED');
+    expect(text).toContain('Send anyway');
+    expect(text).toContain('Cancel');
+  });
+
+  it('UNKNOWN with intercept_timeout and timeoutExtended:false shows Wait', () => {
+    setupChrome();
+    renderPendingIntercept(
+      root,
+      buildRecord({
+        status: 'verdict-ready',
+        verdict: buildVerdict({ status: 'UNKNOWN', analysisError: 'intercept_timeout' }),
+        timeoutExtended: false,
+      }),
+    );
+    const text = root.textContent ?? '';
+    expect(text).toContain('Wait');
+    expect(text).toContain('Send anyway');
+    expect(text).toContain('Cancel');
+  });
+
+  it('UNKNOWN with intercept_timeout and timeoutExtended:true hides Wait', () => {
+    setupChrome();
+    renderPendingIntercept(
+      root,
+      buildRecord({
+        status: 'verdict-ready',
+        verdict: buildVerdict({ status: 'UNKNOWN', analysisError: 'intercept_timeout' }),
+        timeoutExtended: true,
+      }),
+    );
+    const text = root.textContent ?? '';
+    expect(text).not.toContain('Wait');
+    expect(text).toContain('Send anyway');
+  });
+
+  it('Send anyway records an override and clears the pending record', async () => {
+    const stub = setupChrome();
+    renderPendingIntercept(
+      root,
+      buildRecord({ status: 'verdict-ready', verdict: buildVerdict({ status: 'SUSPICIOUS' }) }),
+    );
+    const sendAnyway = root.querySelector(
+      'button[data-action="send-anyway"]',
+    ) as HTMLButtonElement | null;
+    expect(sendAnyway).not.toBeNull();
+    sendAnyway!.click();
+    // Async storage writes — flush microtasks.
+    await Promise.resolve();
+    await Promise.resolve();
+    const store = stub.readStore();
+    const overrides = store[STORAGE_KEY_INTERCEPT_OVERRIDES] as
+      | Record<string, { count: number }>
+      | undefined;
+    expect(overrides).toBeDefined();
+    expect(overrides!['chatgpt:target.example']?.count).toBe(1);
+    expect(store[STORAGE_KEY_PENDING_INTERCEPT]).toBeUndefined();
+  });
+
+  it('Cancel clears the pending record without recording an override', async () => {
+    const stub = setupChrome({ [STORAGE_KEY_PENDING_INTERCEPT]: buildRecord() });
+    renderPendingIntercept(root, buildRecord({ status: 'verdict-ready', verdict: buildVerdict({ status: 'SUSPICIOUS' }) }));
+    const cancel = root.querySelector('button[data-action="cancel"]') as HTMLButtonElement | null;
+    expect(cancel).not.toBeNull();
+    cancel!.click();
+    await Promise.resolve();
+    await Promise.resolve();
+    const store = stub.readStore();
+    expect(store[STORAGE_KEY_PENDING_INTERCEPT]).toBeUndefined();
+    expect(store[STORAGE_KEY_INTERCEPT_OVERRIDES]).toBeUndefined();
+  });
+
+  it('Wait extends timeoutAt and sets timeoutExtended=true', async () => {
+    const startedAt = 1_000_000;
+    const initialTimeoutAt = startedAt + 30_000;
+    const record = buildRecord({
+      status: 'verdict-ready',
+      verdict: buildVerdict({ status: 'UNKNOWN', analysisError: 'intercept_timeout' }),
+      startedAt,
+      timeoutAt: initialTimeoutAt,
+      timeoutExtended: false,
+    });
+    const stub = setupChrome({ [STORAGE_KEY_PENDING_INTERCEPT]: record });
+    renderPendingIntercept(root, record);
+    const wait = root.querySelector('button[data-action="wait"]') as HTMLButtonElement | null;
+    expect(wait).not.toBeNull();
+    wait!.click();
+    await Promise.resolve();
+    await Promise.resolve();
+    const stored = stub.readStore()[STORAGE_KEY_PENDING_INTERCEPT] as PendingInterceptRecord;
+    expect(stored.timeoutExtended).toBe(true);
+    expect(stored.timeoutAt).toBe(initialTimeoutAt + MAX_INTERCEPT_LATENCY_EXTENSION_MS);
+  });
+
+  it('reaching the override threshold renders a whitelist CTA', async () => {
+    const overrideMap: Record<string, unknown> = {};
+    overrideMap['chatgpt:target.example'] = {
+      portalId: 'chatgpt',
+      domain: 'target.example',
+      count: INTERCEPT_OVERRIDE_WHITELIST_THRESHOLD,
+      firstOverride: Date.now() - 1000,
+      lastOverride: Date.now(),
+    };
+    setupChrome({ [STORAGE_KEY_INTERCEPT_OVERRIDES]: overrideMap });
+    renderPendingIntercept(
+      root,
+      buildRecord({ status: 'verdict-ready', verdict: buildVerdict({ status: 'SUSPICIOUS' }) }),
+    );
+    // Drain the microtask queue + a macrotask tick so the async
+    // shouldPromptWhitelist chain (storage.get → map lookup → render) completes.
+    await new Promise((r) => setTimeout(r, 0));
+    const text = root.textContent ?? '';
+    expect(text.toLowerCase()).toContain('whitelist');
+  });
+
+  it('lowercases the URL host before keying overrides', async () => {
+    const stub = setupChrome();
+    renderPendingIntercept(
+      root,
+      buildRecord({
+        status: 'verdict-ready',
+        verdict: buildVerdict({ status: 'SUSPICIOUS', scannedUrl: 'https://Target.EXAMPLE/path' }),
+        scannedUrl: 'https://Target.EXAMPLE/path',
+      }),
+    );
+    const sendAnyway = root.querySelector('button[data-action="send-anyway"]') as HTMLButtonElement;
+    sendAnyway.click();
+    await Promise.resolve();
+    await Promise.resolve();
+    const overrides = stub.readStore()[STORAGE_KEY_INTERCEPT_OVERRIDES] as
+      | Record<string, { count: number }>
+      | undefined;
+    expect(overrides).toBeDefined();
+    expect(overrides!['chatgpt:target.example']?.count).toBe(1);
+  });
+
+  // Sanity: ensure the rolling window is interpreted correctly.
+  it('does not surface the whitelist CTA if overrides are outside the window', async () => {
+    const overrideMap: Record<string, unknown> = {};
+    overrideMap['chatgpt:target.example'] = {
+      portalId: 'chatgpt',
+      domain: 'target.example',
+      count: INTERCEPT_OVERRIDE_WHITELIST_THRESHOLD,
+      firstOverride: Date.now() - INTERCEPT_OVERRIDE_WINDOW_MS - 10_000,
+      lastOverride: Date.now() - INTERCEPT_OVERRIDE_WINDOW_MS - 10_000,
+    };
+    setupChrome({ [STORAGE_KEY_INTERCEPT_OVERRIDES]: overrideMap });
+    renderPendingIntercept(
+      root,
+      buildRecord({ status: 'verdict-ready', verdict: buildVerdict({ status: 'SUSPICIOUS' }) }),
+    );
+    await new Promise((r) => setTimeout(r, 0));
+    expect((root.textContent ?? '').toLowerCase()).not.toContain('whitelist');
+  });
+});

--- a/src/popup/pending-intercept.ts
+++ b/src/popup/pending-intercept.ts
@@ -1,0 +1,205 @@
+import type { InterceptVerdict, PortalId } from '@/types/messages.js';
+import {
+  MAX_INTERCEPT_LATENCY_EXTENSION_MS,
+  STORAGE_KEY_PENDING_INTERCEPT,
+} from '@/shared/constants.js';
+import {
+  recordOverride,
+  shouldPromptWhitelist,
+} from '@/policy/intercept-overrides.js';
+
+export interface PendingInterceptRecord {
+  readonly requestId: string;
+  readonly portalId: PortalId;
+  readonly portalOrigin: string;
+  readonly scannedUrl: string;
+  readonly status: 'scanning' | 'verdict-ready';
+  readonly verdict: InterceptVerdict | null;
+  readonly startedAt: number;
+  readonly timeoutAt: number;
+  readonly timeoutExtended: boolean;
+}
+
+export function renderPendingIntercept(
+  root: HTMLElement,
+  record: PendingInterceptRecord | null,
+): void {
+  while (root.firstChild !== null) root.removeChild(root.firstChild);
+  if (record === null) return;
+
+  const panel = document.createElement('section');
+  panel.className = 'pending-intercept';
+  panel.setAttribute('data-status', record.status);
+
+  const heading = document.createElement('h2');
+  heading.textContent = record.status === 'scanning' ? 'Scanning URL…' : 'URL scan complete';
+  panel.appendChild(heading);
+
+  const target = document.createElement('p');
+  target.className = 'pending-intercept-url';
+  target.textContent = record.scannedUrl;
+  panel.appendChild(target);
+
+  if (record.status === 'verdict-ready' && record.verdict !== null) {
+    const status = document.createElement('p');
+    status.className = `pending-intercept-status status-${record.verdict.status.toLowerCase()}`;
+    status.textContent = `Verdict: ${record.verdict.status}`;
+    panel.appendChild(status);
+
+    const breakdown = document.createElement('p');
+    breakdown.className = 'pending-intercept-breakdown';
+    const pb = record.verdict.probeBreakdown;
+    breakdown.textContent = `Probes: ${pb.totalProbes} run · ${pb.suspiciousProbes} suspicious · ${pb.compromisedProbes} compromised`;
+    panel.appendChild(breakdown);
+
+    if (record.verdict.analysisError !== null) {
+      const err = document.createElement('p');
+      err.className = 'pending-intercept-error';
+      err.textContent = `Error: ${record.verdict.analysisError}`;
+      panel.appendChild(err);
+    }
+  }
+
+  const showWait = canShowWait(record);
+  const showButtons =
+    record.status === 'scanning' ||
+    (record.verdict !== null && record.verdict.status !== 'CLEAN');
+
+  if (showButtons) {
+    const buttons = document.createElement('div');
+    buttons.className = 'pending-intercept-buttons';
+
+    const sendAnywayBtn = document.createElement('button');
+    sendAnywayBtn.type = 'button';
+    sendAnywayBtn.dataset.action = 'send-anyway';
+    sendAnywayBtn.textContent = 'Send anyway';
+    sendAnywayBtn.addEventListener('click', () => {
+      void onSendAnyway(record, root);
+    });
+    buttons.appendChild(sendAnywayBtn);
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.type = 'button';
+    cancelBtn.dataset.action = 'cancel';
+    cancelBtn.textContent = 'Cancel';
+    cancelBtn.addEventListener('click', () => {
+      void onCancel(root);
+    });
+    buttons.appendChild(cancelBtn);
+
+    if (showWait) {
+      const waitBtn = document.createElement('button');
+      waitBtn.type = 'button';
+      waitBtn.dataset.action = 'wait';
+      waitBtn.textContent = 'Wait';
+      waitBtn.addEventListener('click', () => {
+        void onWait(record, root);
+      });
+      buttons.appendChild(waitBtn);
+    }
+
+    panel.appendChild(buttons);
+  }
+
+  // Whitelist CTA — async check; appended once shouldPromptWhitelist resolves.
+  const whitelistContainer = document.createElement('div');
+  whitelistContainer.className = 'pending-intercept-whitelist';
+  panel.appendChild(whitelistContainer);
+  void renderWhitelistCta(record, whitelistContainer);
+
+  root.appendChild(panel);
+}
+
+function canShowWait(record: PendingInterceptRecord): boolean {
+  if (record.status === 'scanning') return true;
+  if (record.verdict === null) return false;
+  if (record.timeoutExtended) return false;
+  return record.verdict.analysisError === 'intercept_timeout';
+}
+
+function urlHost(url: string): string {
+  try {
+    return new URL(url).hostname.toLowerCase();
+  } catch {
+    return url.toLowerCase();
+  }
+}
+
+async function onSendAnyway(record: PendingInterceptRecord, root: HTMLElement): Promise<void> {
+  const domain = urlHost(record.scannedUrl);
+  await recordOverride(record.portalId, domain);
+  await chrome.storage.local.remove(STORAGE_KEY_PENDING_INTERCEPT);
+  renderPendingIntercept(root, null);
+}
+
+async function onCancel(root: HTMLElement): Promise<void> {
+  await chrome.storage.local.remove(STORAGE_KEY_PENDING_INTERCEPT);
+  renderPendingIntercept(root, null);
+}
+
+async function onWait(record: PendingInterceptRecord, root: HTMLElement): Promise<void> {
+  const updated: PendingInterceptRecord = {
+    ...record,
+    timeoutAt: record.timeoutAt + MAX_INTERCEPT_LATENCY_EXTENSION_MS,
+    timeoutExtended: true,
+  };
+  await chrome.storage.local.set({ [STORAGE_KEY_PENDING_INTERCEPT]: updated });
+  renderPendingIntercept(root, updated);
+}
+
+async function renderWhitelistCta(
+  record: PendingInterceptRecord,
+  container: HTMLElement,
+): Promise<void> {
+  const domain = urlHost(record.scannedUrl);
+  const should = await shouldPromptWhitelist(record.portalId, domain);
+  if (!should) return;
+  while (container.firstChild !== null) container.removeChild(container.firstChild);
+  const cta = document.createElement('p');
+  cta.textContent = `You've overridden HoneyLLM 3+ times for ${domain} this week. Whitelist this domain?`;
+  container.appendChild(cta);
+}
+
+/**
+ * Initialise the pending-intercept panel inside the popup.
+ *
+ * Reads `STORAGE_KEY_PENDING_INTERCEPT` on open and subscribes to
+ * `chrome.storage.onChanged` for live updates while the popup is open.
+ * If `rootEl` is null the function is a no-op (popup test harness).
+ */
+export async function initPendingInterceptPanel(rootEl: HTMLElement | null): Promise<void> {
+  if (rootEl === null) return;
+
+  const fetchAndRender = async (): Promise<void> => {
+    try {
+      const r = await chrome.storage.local.get(STORAGE_KEY_PENDING_INTERCEPT);
+      const v = r[STORAGE_KEY_PENDING_INTERCEPT];
+      const record = isPendingInterceptRecord(v) ? v : null;
+      renderPendingIntercept(rootEl, record);
+    } catch {
+      renderPendingIntercept(rootEl, null);
+    }
+  };
+
+  await fetchAndRender();
+
+  chrome.storage.onChanged.addListener((changes, areaName) => {
+    if (areaName !== 'local') return;
+    if (!(STORAGE_KEY_PENDING_INTERCEPT in changes)) return;
+    void fetchAndRender();
+  });
+}
+
+function isPendingInterceptRecord(v: unknown): v is PendingInterceptRecord {
+  if (typeof v !== 'object' || v === null) return false;
+  const r = v as Record<string, unknown>;
+  return (
+    typeof r.requestId === 'string' &&
+    typeof r.portalId === 'string' &&
+    typeof r.scannedUrl === 'string' &&
+    (r.status === 'scanning' || r.status === 'verdict-ready') &&
+    typeof r.startedAt === 'number' &&
+    typeof r.timeoutAt === 'number' &&
+    typeof r.timeoutExtended === 'boolean'
+  );
+}

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -27,6 +27,7 @@ import { renderEntitySummary, type EntitySummary } from './entities.js';
 import { renderResponseVerdict } from './response-analysis.js';
 import type { ResponseVerdict } from '@/types/portal-response.js';
 import { getCacheStats, clearCache } from '@/service-worker/scan-cache.js';
+import { initPendingInterceptPanel } from './pending-intercept.js';
 
 interface StoredVerdict {
   status: string;
@@ -610,5 +611,20 @@ void (async () => {
     await initCacheAccordion();
   } catch (err) {
     console.error('cache accordion init failed', err);
+  }
+  try {
+    // Issue #130 (N7b) — pending-intercept panel. Renders only when
+    // STORAGE_KEY_PENDING_INTERCEPT is set (a URL scan is in flight or
+    // awaiting user action). Inert otherwise. Subscribes to
+    // chrome.storage.onChanged for live updates while the popup is open.
+    let panelRoot = document.getElementById('pending-intercept-root');
+    if (panelRoot === null) {
+      panelRoot = document.createElement('div');
+      panelRoot.id = 'pending-intercept-root';
+      document.body.insertBefore(panelRoot, document.body.firstChild);
+    }
+    await initPendingInterceptPanel(panelRoot);
+  } catch (err) {
+    console.error('pending-intercept init failed', err);
   }
 })();

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -1,7 +1,10 @@
 import type {
   HoneyLLMMessage,
+  InterceptVerdict,
+  InterceptVerdictMessage,
   VerifyStampResultMessage,
 } from '@/types/messages.js';
+import { STORAGE_KEY_PENDING_INTERCEPT, MAX_INTERCEPT_LATENCY_MS } from '@/shared/constants.js';
 import { createLogger } from '@/shared/logger.js';
 import { startKeepalive } from './keepalive.js';
 import { analyzeSnapshot, AnalysisAbortedError, getInFlightCount, getInFlightTabIds } from './orchestrator.js';
@@ -10,6 +13,7 @@ import { setTabVerdict, handleTabActivated, handleTabRemoved } from './toolbar-i
 import { ensureInstallSecret } from '@/shared/install-secret.js';
 import { verifyStamp } from './stamp.js';
 import { dispatchVerdictMessages, handleRescanWithMitigation, handleRescanPage } from './dispatch.js';
+import { scanUrl } from './url-scanner.js';
 
 const log = createLogger('ServiceWorker');
 
@@ -89,6 +93,17 @@ chrome.runtime.onMessage.addListener((message: HoneyLLMMessage, sender, sendResp
       return;
     }
 
+    // Issue #130 (N7b) — pre-send URL intercept. Scan the URL, record a
+    // pending-intercept entry for the popup, send back INTERCEPT_VERDICT
+    // when ready, and clear pending on CLEAN. SUSPICIOUS/COMPROMISED/
+    // UNKNOWN verdicts leave the pending record in place so the popup
+    // can render Send-anyway / Cancel / (Wait) UX.
+    case 'INTERCEPT_SCAN_REQUEST': {
+      const tabId = sender.tab?.id ?? message.tabId;
+      void handleInterceptScanRequest(tabId, message);
+      return;
+    }
+
     case 'PING_KEEPALIVE': {
       sendResponse({ type: 'PONG_KEEPALIVE' });
       return;
@@ -164,6 +179,93 @@ chrome.runtime.onMessage.addListener((message: HoneyLLMMessage, sender, sendResp
  * arbitrary stamps, observe valid|wrong-secret, narrow toward the
  * secret). Internal `chrome.runtime.onMessage` only.
  */
+async function handleInterceptScanRequest(
+  tabId: number | undefined,
+  message: { url: string; origin: string; portalId: 'chatgpt' | 'claude' | 'gemini'; requestId: string },
+): Promise<void> {
+  const startedAt = Date.now();
+  // Mark a transient pending-intercept record so the popup, if opened,
+  // can show "scanning…" state before the verdict resolves.
+  try {
+    await chrome.storage.local.set({
+      [STORAGE_KEY_PENDING_INTERCEPT]: {
+        requestId: message.requestId,
+        portalId: message.portalId,
+        portalOrigin: message.origin,
+        scannedUrl: message.url,
+        status: 'scanning',
+        verdict: null,
+        startedAt,
+        timeoutAt: startedAt + MAX_INTERCEPT_LATENCY_MS,
+        timeoutExtended: false,
+      },
+    });
+  } catch (err) {
+    log.warn('Failed to write pending-intercept record', err);
+  }
+
+  let verdict: InterceptVerdict;
+  try {
+    verdict = await scanUrl({
+      url: message.url,
+      origin: message.origin,
+      portalId: message.portalId,
+      tabId: tabId ?? -1,
+    });
+  } catch (err) {
+    log.error('scanUrl threw', err);
+    verdict = {
+      status: 'UNKNOWN',
+      scannedUrl: message.url,
+      probeBreakdown: { totalProbes: 0, suspiciousProbes: 0, compromisedProbes: 0 },
+      totalScore: 0,
+      cacheHit: false,
+      timestamp: Date.now(),
+      analysisError: err instanceof Error ? err.message : 'scan_threw',
+    };
+  }
+
+  // Update or clear the pending-intercept record. CLEAN verdicts auto-clear
+  // (no user action needed); other statuses keep the record so the popup
+  // can render Send-anyway / Cancel.
+  try {
+    if (verdict.status === 'CLEAN') {
+      await chrome.storage.local.remove(STORAGE_KEY_PENDING_INTERCEPT);
+    } else {
+      await chrome.storage.local.set({
+        [STORAGE_KEY_PENDING_INTERCEPT]: {
+          requestId: message.requestId,
+          portalId: message.portalId,
+          portalOrigin: message.origin,
+          scannedUrl: message.url,
+          status: 'verdict-ready',
+          verdict,
+          startedAt,
+          timeoutAt: startedAt + MAX_INTERCEPT_LATENCY_MS,
+          timeoutExtended: false,
+        },
+      });
+    }
+  } catch (err) {
+    log.warn('Failed to update pending-intercept record', err);
+  }
+
+  // Send the verdict back to the originating tab.
+  if (tabId !== undefined && tabId >= 0) {
+    const verdictMsg: InterceptVerdictMessage = {
+      type: 'INTERCEPT_VERDICT',
+      requestId: message.requestId,
+      verdict,
+    };
+    try {
+      await chrome.tabs.sendMessage(tabId, verdictMsg);
+    } catch {
+      // Tab may have closed or content script may not be listening yet —
+      // popup will pick up the verdict from storage on next open.
+    }
+  }
+}
+
 chrome.runtime.onMessageExternal.addListener((message: unknown, _sender, sendResponse) => {
   if (message === null || typeof message !== 'object' || !('type' in message)) return;
   const msg = message as { type: unknown };

--- a/src/service-worker/url-scanner.test.ts
+++ b/src/service-worker/url-scanner.test.ts
@@ -1,0 +1,447 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Chunk } from '@/types/chunk.js';
+import type { ProbeResult } from '@/types/verdict.js';
+import type { CachedChunk, CachedScan } from '@/types/scan-cache.js';
+import type { PageSnapshot } from '@/types/snapshot.js';
+import type { ParseHtmlResultMessage } from '@/types/messages.js';
+import {
+  CACHE_SCHEMA_VERSION,
+  HUNTER_RULES_VERSION,
+  INTERCEPT_CHUNK_INDEX_OFFSET,
+  MAX_INTERCEPT_FETCH_BYTES,
+  SCORE_INSTRUCTION_DETECTION,
+} from '@/shared/constants.js';
+
+// --- mocks must precede the SUT import ---
+
+const runChunkProbesMock = vi.fn<
+  (args: {
+    tabId: number;
+    chunk: string;
+    chunkIndex: number;
+    totalChunks: number;
+    url: string;
+    origin: string;
+    evidencePackets: readonly unknown[];
+  }) => Promise<{
+    results: readonly ProbeResult[];
+    canaryId: string | null;
+    webgpuAdapterMode: string | null;
+  }>
+>();
+
+vi.mock('./orchestrator.js', async () => {
+  const actual = await vi.importActual<typeof import('./orchestrator.js')>('./orchestrator.js');
+  return {
+    ...actual,
+    runChunkProbes: (args: Parameters<typeof runChunkProbesMock>[0]) => runChunkProbesMock(args),
+  };
+});
+
+const chunkTextMock = vi.fn<(text: string) => Promise<readonly Chunk[]>>();
+vi.mock('@/hunters/hawk/chunking.js', () => ({
+  chunkText: (text: string) => chunkTextMock(text),
+}));
+
+vi.mock('./offscreen-manager.js', () => ({
+  ensureOffscreenDocument: async () => undefined,
+}));
+
+const lookupScanMock = vi.fn<
+  (url: string, guard: { hunterRulesVersion: string; llmModelId: string }) =>
+    Promise<CachedScan | null>
+>();
+const writeScanMock = vi.fn<(record: CachedScan) => Promise<void>>();
+const recordCacheHitMock = vi.fn<() => Promise<void>>();
+const recordCacheMissMock = vi.fn<() => Promise<void>>();
+const getEngineFingerprintMock = vi.fn<() => Promise<string>>();
+
+vi.mock('./scan-cache.js', () => ({
+  lookupScan: (...args: Parameters<typeof lookupScanMock>) => lookupScanMock(...args),
+  writeScan: (record: CachedScan) => writeScanMock(record),
+  recordCacheHit: () => recordCacheHitMock(),
+  recordCacheMiss: () => recordCacheMissMock(),
+  getEngineFingerprint: () => getEngineFingerprintMock(),
+}));
+
+import { scanUrl } from './url-scanner.js';
+
+// --- helpers ---
+
+function buildProbeResult(
+  probeName: string,
+  passed: boolean,
+  score: number = 0,
+  flags: readonly string[] = [],
+): ProbeResult {
+  return {
+    probeName,
+    passed,
+    flags: passed ? [] : flags.length > 0 ? flags : [`${probeName}:flag`],
+    rawOutput: 'ok',
+    score,
+    errorMessage: null,
+  };
+}
+
+function buildChunk(index: number, text: string): Chunk {
+  const hex = (index + 1).toString(16).padStart(64, '0');
+  return { text, start: index * 100, end: index * 100 + text.length, contentHash: hex };
+}
+
+function buildCachedChunk(text: string, results: readonly ProbeResult[] | null): CachedChunk {
+  return {
+    contentHash: text,
+    tierRouting: { decision: 'UNCERTAIN', primitiveCount: 0, contributingHunters: [] },
+    probeResults: results,
+  };
+}
+
+function buildCachedScan(url: string, chunks: readonly CachedChunk[]): CachedScan {
+  return {
+    schemaVersion: CACHE_SCHEMA_VERSION,
+    hunterRulesVersion: HUNTER_RULES_VERSION,
+    llmModelId: 'gemma-2-2b-mlc',
+    url,
+    fetchedAt: Date.now(),
+    chunks,
+    earlyExited: false,
+    entitySummary: null,
+    sizeBytes: 0,
+  };
+}
+
+interface FetchSpy {
+  readonly fn: ReturnType<typeof vi.fn>;
+  readonly calls: Array<{ url: string; init: RequestInit | undefined }>;
+}
+
+function setupFetch(impl: (url: string, init?: RequestInit) => Promise<Response>): FetchSpy {
+  const calls: FetchSpy['calls'] = [];
+  const fn = vi.fn(async (url: string, init?: RequestInit) => {
+    calls.push({ url, init });
+    return impl(url, init);
+  });
+  vi.stubGlobal('fetch', fn);
+  return { fn, calls };
+}
+
+function htmlResponse(html: string, contentLength: number = html.length): Response {
+  return new Response(html, {
+    status: 200,
+    headers: { 'content-type': 'text/html', 'content-length': String(contentLength) },
+  });
+}
+
+interface ChromeStub {
+  readonly sendMessageMock: ReturnType<typeof vi.fn>;
+  readonly storage: Record<string, unknown>;
+}
+
+function setupChrome(snapshot: PageSnapshot | null = buildSnapshot()): ChromeStub {
+  const storage: Record<string, unknown> = {};
+  const sendMessageMock = vi.fn(async (msg: { type: string; requestId?: string; html?: string; url?: string }) => {
+    if (msg.type === 'PARSE_HTML_REQUEST') {
+      const reply: ParseHtmlResultMessage = {
+        type: 'PARSE_HTML_RESULT',
+        requestId: msg.requestId ?? '',
+        snapshot,
+        errorMessage: snapshot === null ? 'parse_failed_in_offscreen' : null,
+      };
+      return reply;
+    }
+    return undefined;
+  });
+  vi.stubGlobal('chrome', {
+    storage: {
+      local: {
+        get: async (key?: string | string[] | null) => {
+          if (key === undefined || key === null) return { ...storage };
+          if (typeof key === 'string') {
+            return key in storage ? { [key]: storage[key] } : {};
+          }
+          const out: Record<string, unknown> = {};
+          for (const k of key) if (k in storage) out[k] = storage[k];
+          return out;
+        },
+        set: async (items: Record<string, unknown>) => {
+          Object.assign(storage, items);
+        },
+      },
+    },
+    runtime: {
+      sendMessage: sendMessageMock,
+      onMessage: { addListener: () => undefined, removeListener: () => undefined },
+    },
+  });
+  return { sendMessageMock, storage };
+}
+
+function buildSnapshot(visibleText: string = 'hello world from a benign blog post'): PageSnapshot {
+  return {
+    visibleText,
+    hiddenText: '',
+    scriptFingerprints: [],
+    metadata: {
+      title: 't',
+      url: 'https://target.example/page',
+      origin: 'https://target.example',
+      description: '',
+      ogTags: new Map<string, string>(),
+      cspMeta: null,
+      lang: 'en',
+    },
+    extractedAt: 1714400000000,
+    charCount: visibleText.length,
+  };
+}
+
+const SCAN_URL = 'https://target.example/page';
+const SCAN_ORIGIN = 'https://target.example';
+
+// --- tests ---
+
+describe('scanUrl', () => {
+  beforeEach(() => {
+    runChunkProbesMock.mockReset();
+    chunkTextMock.mockReset();
+    lookupScanMock.mockReset();
+    writeScanMock.mockReset();
+    recordCacheHitMock.mockReset();
+    recordCacheMissMock.mockReset();
+    getEngineFingerprintMock.mockReset();
+    getEngineFingerprintMock.mockResolvedValue('gemma-2-2b-mlc');
+    writeScanMock.mockResolvedValue(undefined);
+    recordCacheHitMock.mockResolvedValue(undefined);
+    recordCacheMissMock.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('returns instant CLEAN verdict on full cache hit (no fetch, no offscreen)', async () => {
+    setupChrome(null); // null means: if PARSE_HTML_REQUEST is dispatched, the test fails
+    const fetchSpy = setupFetch(() => {
+      throw new Error('fetch should not be called on cache hit');
+    });
+    const cleanProbes = [
+      buildProbeResult('summarization', true, 0),
+      buildProbeResult('instruction_detection', true, 0),
+      buildProbeResult('adversarial_compliance', true, 0),
+    ];
+    chunkTextMock.mockResolvedValue([buildChunk(0, 'a clean chunk text body')]);
+    lookupScanMock.mockResolvedValue(
+      buildCachedScan(SCAN_URL, [buildCachedChunk('a clean chunk text body', cleanProbes)]),
+    );
+
+    const verdict = await scanUrl({
+      url: SCAN_URL,
+      origin: SCAN_ORIGIN,
+      portalId: 'chatgpt',
+      tabId: 42,
+    });
+
+    expect(verdict.cacheHit).toBe(true);
+    expect(verdict.scannedUrl).toBe(SCAN_URL);
+    expect(verdict.status).toBe('CLEAN');
+    expect(verdict.analysisError).toBeNull();
+    expect(verdict.probeBreakdown.totalProbes).toBeGreaterThan(0);
+    expect(verdict.probeBreakdown.suspiciousProbes).toBe(0);
+    expect(verdict.probeBreakdown.compromisedProbes).toBe(0);
+    expect(fetchSpy.fn).not.toHaveBeenCalled();
+    expect(runChunkProbesMock).not.toHaveBeenCalled();
+    expect(recordCacheHitMock).toHaveBeenCalledTimes(1);
+    expect(recordCacheMissMock).not.toHaveBeenCalled();
+  });
+
+  it('cache miss: fetches with credentials:omit and Range header', async () => {
+    setupChrome();
+    const fetchSpy = setupFetch(() => Promise.resolve(htmlResponse('<html><body>ok</body></html>')));
+    chunkTextMock.mockResolvedValue([buildChunk(0, 'hello world from a benign blog post')]);
+    runChunkProbesMock.mockResolvedValue({
+      results: [
+        buildProbeResult('summarization', true, 0),
+        buildProbeResult('instruction_detection', true, 0),
+        buildProbeResult('adversarial_compliance', true, 0),
+      ],
+      canaryId: 'gemma-2-2b-mlc',
+      webgpuAdapterMode: 'core',
+    });
+    lookupScanMock.mockResolvedValue(null);
+
+    const verdict = await scanUrl({
+      url: SCAN_URL,
+      origin: SCAN_ORIGIN,
+      portalId: 'chatgpt',
+      tabId: 42,
+    });
+
+    expect(fetchSpy.fn).toHaveBeenCalledTimes(1);
+    const call = fetchSpy.calls[0]!;
+    expect(call.url).toBe(SCAN_URL);
+    expect(call.init?.credentials).toBe('omit');
+    const headers = call.init?.headers as Record<string, string> | undefined;
+    expect(headers?.['Range']).toBe(`bytes=0-${MAX_INTERCEPT_FETCH_BYTES - 1}`);
+    expect(headers?.['Authorization']).toBeUndefined();
+    expect(headers?.['Cookie']).toBeUndefined();
+    expect(verdict.cacheHit).toBe(false);
+    expect(verdict.status).toBe('CLEAN');
+    expect(recordCacheMissMock).toHaveBeenCalledTimes(1);
+    expect(writeScanMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('cache miss: chunk indices are offset by INTERCEPT_CHUNK_INDEX_OFFSET', async () => {
+    setupChrome();
+    setupFetch(() => Promise.resolve(htmlResponse('<html><body>ok</body></html>')));
+    chunkTextMock.mockResolvedValue([
+      buildChunk(0, 'first chunk body'),
+      buildChunk(1, 'second chunk body'),
+    ]);
+    runChunkProbesMock.mockResolvedValue({
+      results: [
+        buildProbeResult('summarization', true, 0),
+        buildProbeResult('instruction_detection', true, 0),
+        buildProbeResult('adversarial_compliance', true, 0),
+      ],
+      canaryId: 'gemma-2-2b-mlc',
+      webgpuAdapterMode: 'core',
+    });
+    lookupScanMock.mockResolvedValue(null);
+
+    await scanUrl({
+      url: SCAN_URL,
+      origin: SCAN_ORIGIN,
+      portalId: 'chatgpt',
+      tabId: 42,
+    });
+
+    expect(runChunkProbesMock).toHaveBeenCalledTimes(2);
+    const indices = runChunkProbesMock.mock.calls.map((c) => c[0].chunkIndex);
+    expect(indices).toEqual([
+      INTERCEPT_CHUNK_INDEX_OFFSET + 0,
+      INTERCEPT_CHUNK_INDEX_OFFSET + 1,
+    ]);
+  });
+
+  it('cache miss: SUSPICIOUS verdict surfaces probe breakdown counts', async () => {
+    setupChrome();
+    setupFetch(() => Promise.resolve(htmlResponse('<html><body>ok</body></html>')));
+    chunkTextMock.mockResolvedValue([buildChunk(0, 'flagged chunk body')]);
+    runChunkProbesMock.mockResolvedValue({
+      results: [
+        buildProbeResult('summarization', true, 0),
+        buildProbeResult('instruction_detection', false, SCORE_INSTRUCTION_DETECTION, ['flag1']),
+        buildProbeResult('adversarial_compliance', true, 0),
+      ],
+      canaryId: 'gemma-2-2b-mlc',
+      webgpuAdapterMode: 'core',
+    });
+    lookupScanMock.mockResolvedValue(null);
+
+    const verdict = await scanUrl({
+      url: SCAN_URL,
+      origin: SCAN_ORIGIN,
+      portalId: 'chatgpt',
+      tabId: 42,
+    });
+
+    expect(verdict.status).toBe('SUSPICIOUS');
+    expect(verdict.probeBreakdown.suspiciousProbes).toBeGreaterThanOrEqual(1);
+  });
+
+  it('fetch failure surfaces UNKNOWN with analysisError=fetch_failed', async () => {
+    setupChrome();
+    setupFetch(() => Promise.reject(new TypeError('network error')));
+    lookupScanMock.mockResolvedValue(null);
+
+    const verdict = await scanUrl({
+      url: SCAN_URL,
+      origin: SCAN_ORIGIN,
+      portalId: 'chatgpt',
+      tabId: 42,
+    });
+
+    expect(verdict.status).toBe('UNKNOWN');
+    expect(verdict.analysisError).toBe('fetch_failed');
+    expect(verdict.cacheHit).toBe(false);
+    expect(runChunkProbesMock).not.toHaveBeenCalled();
+    expect(writeScanMock).not.toHaveBeenCalled();
+  });
+
+  it('non-2xx response surfaces UNKNOWN with analysisError=fetch_failed', async () => {
+    setupChrome();
+    setupFetch(() =>
+      Promise.resolve(
+        new Response('not found', { status: 404, headers: { 'content-type': 'text/plain' } }),
+      ),
+    );
+    lookupScanMock.mockResolvedValue(null);
+
+    const verdict = await scanUrl({
+      url: SCAN_URL,
+      origin: SCAN_ORIGIN,
+      portalId: 'chatgpt',
+      tabId: 42,
+    });
+
+    expect(verdict.status).toBe('UNKNOWN');
+    expect(verdict.analysisError).toBe('fetch_failed');
+  });
+
+  it('oversize response (Content-Length above cap) returns response_too_large', async () => {
+    setupChrome();
+    setupFetch(() =>
+      Promise.resolve(htmlResponse('<html></html>', MAX_INTERCEPT_FETCH_BYTES + 1)),
+    );
+    lookupScanMock.mockResolvedValue(null);
+
+    const verdict = await scanUrl({
+      url: SCAN_URL,
+      origin: SCAN_ORIGIN,
+      portalId: 'chatgpt',
+      tabId: 42,
+    });
+
+    expect(verdict.status).toBe('UNKNOWN');
+    expect(verdict.analysisError).toBe('response_too_large');
+  });
+
+  it('parse failure surfaces UNKNOWN with analysisError=parse_failed', async () => {
+    setupChrome(null); // offscreen returns snapshot:null + error
+    setupFetch(() => Promise.resolve(htmlResponse('<html><body>ok</body></html>')));
+    lookupScanMock.mockResolvedValue(null);
+
+    const verdict = await scanUrl({
+      url: SCAN_URL,
+      origin: SCAN_ORIGIN,
+      portalId: 'chatgpt',
+      tabId: 42,
+    });
+
+    expect(verdict.status).toBe('UNKNOWN');
+    expect(verdict.analysisError).toBe('parse_failed');
+    expect(runChunkProbesMock).not.toHaveBeenCalled();
+  });
+
+  it('timeout (>MAX_INTERCEPT_LATENCY_MS) returns UNKNOWN+intercept_timeout', async () => {
+    vi.useFakeTimers();
+    setupChrome();
+    // Fetch never resolves → forces timeout path
+    setupFetch(() => new Promise<Response>(() => undefined));
+    lookupScanMock.mockResolvedValue(null);
+
+    const promise = scanUrl({
+      url: SCAN_URL,
+      origin: SCAN_ORIGIN,
+      portalId: 'chatgpt',
+      tabId: 42,
+    });
+    await vi.advanceTimersByTimeAsync(31_000);
+    const verdict = await promise;
+    expect(verdict.status).toBe('UNKNOWN');
+    expect(verdict.analysisError).toBe('intercept_timeout');
+  });
+});

--- a/src/service-worker/url-scanner.ts
+++ b/src/service-worker/url-scanner.ts
@@ -1,0 +1,279 @@
+import type {
+  InterceptVerdict,
+  ParseHtmlRequestMessage,
+  ParseHtmlResultMessage,
+  PortalId,
+} from '@/types/messages.js';
+import type { ProbeResult } from '@/types/verdict.js';
+import type { CachedChunk, CachedScan } from '@/types/scan-cache.js';
+import {
+  CACHE_SCHEMA_VERSION,
+  HUNTER_RULES_VERSION,
+  INTERCEPT_CHUNK_INDEX_OFFSET,
+  MAX_INTERCEPT_FETCH_BYTES,
+  MAX_INTERCEPT_LATENCY_MS,
+  SCORE_INSTRUCTION_DETECTION,
+} from '@/shared/constants.js';
+import { chunkText } from '@/hunters/hawk/chunking.js';
+import { analyzeBehavior } from '@/analysis/behavioral-analyzer.js';
+import { evaluatePolicy } from '@/policy/engine.js';
+import { ensureOffscreenDocument } from './offscreen-manager.js';
+import {
+  computeAggregateError,
+  mergeProbeResults,
+  runChunkProbes,
+} from './orchestrator.js';
+import {
+  getEngineFingerprint,
+  lookupScan,
+  recordCacheHit,
+  recordCacheMiss,
+  writeScan,
+} from './scan-cache.js';
+import { createLogger } from '@/shared/logger.js';
+
+const log = createLogger('UrlScanner');
+
+interface ScanUrlArgs {
+  readonly url: string;
+  readonly origin: string;
+  readonly portalId: PortalId;
+  readonly tabId: number;
+}
+
+export async function scanUrl(args: ScanUrlArgs): Promise<InterceptVerdict> {
+  const timeoutPromise = new Promise<InterceptVerdict>((resolve) => {
+    const t = setTimeout(() => resolve(buildErrorVerdict(args.url, 'intercept_timeout', false)), MAX_INTERCEPT_LATENCY_MS);
+    // Allow node test workers to exit cleanly without a hanging handle
+    if (typeof t === 'object' && t !== null && 'unref' in t && typeof (t as { unref?: () => void }).unref === 'function') {
+      (t as { unref: () => void }).unref();
+    }
+  });
+  return Promise.race([runScan(args), timeoutPromise]);
+}
+
+async function runScan(args: ScanUrlArgs): Promise<InterceptVerdict> {
+  const fingerprint = await getEngineFingerprint().catch(() => 'unknown');
+
+  // 1. Cache lookup
+  let cachedScan: CachedScan | null = null;
+  try {
+    cachedScan = await lookupScan(args.url, {
+      hunterRulesVersion: HUNTER_RULES_VERSION,
+      llmModelId: fingerprint,
+    });
+  } catch (err) {
+    log.warn('lookupScan failed; proceeding as miss', err);
+  }
+  if (cachedScan !== null && cachedScan.chunks.length > 0) {
+    await recordCacheHit().catch(() => undefined);
+    return projectCacheHit(args.url, cachedScan);
+  }
+  await recordCacheMiss().catch(() => undefined);
+
+  // 2. Fetch the URL — credentials:'omit' + Range cap; abort on oversize.
+  const fetched = await fetchUrl(args.url);
+  if ('error' in fetched) return buildErrorVerdict(args.url, fetched.error, false);
+  const html = fetched.html;
+
+  // 3. Offscreen-mediated DOMParser → PageSnapshot
+  let snapshot;
+  try {
+    await ensureOffscreenDocument();
+    const requestId =
+      typeof crypto.randomUUID === 'function'
+        ? crypto.randomUUID()
+        : `parse-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const req: ParseHtmlRequestMessage = {
+      type: 'PARSE_HTML_REQUEST',
+      requestId,
+      html,
+      url: args.url,
+    };
+    const reply = (await chrome.runtime.sendMessage(req)) as
+      | ParseHtmlResultMessage
+      | undefined;
+    if (reply === undefined || reply.snapshot === null) {
+      return buildErrorVerdict(args.url, 'parse_failed', false);
+    }
+    snapshot = reply.snapshot;
+  } catch (err) {
+    log.warn('PARSE_HTML_REQUEST failed', err);
+    return buildErrorVerdict(args.url, 'parse_failed', false);
+  }
+
+  // 4. Chunk + probe — mirror response-analyzer.ts pattern
+  const fullText = `${snapshot.visibleText}\n${snapshot.hiddenText}`.trim();
+  if (fullText.length === 0) {
+    // Empty body → no signal to analyse. Treat as UNKNOWN; cache nothing.
+    return buildErrorVerdict(args.url, 'empty_response', false);
+  }
+
+  const chunks = await chunkText(fullText);
+  const totalChunks = chunks.length;
+  const perChunk: ProbeResult[][] = [];
+  let chunkError: string | null = null;
+  try {
+    for (let i = 0; i < chunks.length; i++) {
+      const c = chunks[i]!;
+      const r = await runChunkProbes({
+        tabId: args.tabId,
+        chunk: c.text,
+        chunkIndex: i + INTERCEPT_CHUNK_INDEX_OFFSET,
+        totalChunks,
+        url: args.url,
+        origin: args.origin,
+        evidencePackets: [],
+      });
+      perChunk.push([...r.results]);
+    }
+  } catch (err) {
+    chunkError = err instanceof Error ? err.message : String(err);
+  }
+
+  const merged = mergeProbeResults(perChunk);
+  const behavioralFlags = analyzeBehavior(merged);
+  const policy =
+    chunkError !== null
+      ? null
+      : evaluatePolicy(
+          merged,
+          behavioralFlags,
+          args.url,
+          computeAggregateError(merged),
+          null,
+          null,
+        );
+
+  // 5. Cache write — best-effort, mirrors orchestrator's pattern
+  if (chunkError === null && policy !== null) {
+    const cachedChunks: readonly CachedChunk[] = chunks.map((c, i) => ({
+      contentHash: c.contentHash,
+      tierRouting: { decision: 'UNCERTAIN', primitiveCount: 0, contributingHunters: [] },
+      probeResults: perChunk[i] ?? null,
+    }));
+    try {
+      await writeScan({
+        schemaVersion: CACHE_SCHEMA_VERSION,
+        hunterRulesVersion: HUNTER_RULES_VERSION,
+        llmModelId: fingerprint,
+        url: args.url,
+        fetchedAt: Date.now(),
+        chunks: cachedChunks,
+        earlyExited: false,
+        entitySummary: null,
+        sizeBytes: 0,
+      });
+    } catch (err) {
+      log.warn('writeScan failed; verdict still returned', err);
+    }
+  }
+
+  return {
+    status: policy?.status ?? 'UNKNOWN',
+    scannedUrl: args.url,
+    probeBreakdown: countProbeBreakdown(merged),
+    totalScore: policy?.totalScore ?? 0,
+    cacheHit: false,
+    timestamp: Date.now(),
+    analysisError: chunkError ?? policy?.analysisError ?? null,
+  };
+}
+
+type FetchOk = { readonly html: string };
+type FetchErr = { readonly error: 'fetch_failed' | 'response_too_large' };
+
+async function fetchUrl(url: string): Promise<FetchOk | FetchErr> {
+  const ac = new AbortController();
+  let resp: Response;
+  try {
+    resp = await fetch(url, {
+      method: 'GET',
+      credentials: 'omit',
+      headers: { Range: `bytes=0-${MAX_INTERCEPT_FETCH_BYTES - 1}` },
+      signal: ac.signal,
+      referrerPolicy: 'no-referrer',
+    });
+  } catch (err) {
+    log.warn(`fetch failed for ${url}`, err);
+    return { error: 'fetch_failed' };
+  }
+  // 200 OK or 206 Partial Content (server honoured the Range header) are
+  // both acceptable. Anything else is an error path (404, 403, 5xx, etc.).
+  if (resp.status !== 200 && resp.status !== 206) {
+    return { error: 'fetch_failed' };
+  }
+  const contentLengthHeader = resp.headers.get('content-length');
+  if (contentLengthHeader !== null) {
+    const len = Number(contentLengthHeader);
+    if (Number.isFinite(len) && len > MAX_INTERCEPT_FETCH_BYTES) {
+      ac.abort();
+      return { error: 'response_too_large' };
+    }
+  }
+  let html: string;
+  try {
+    html = await resp.text();
+  } catch {
+    return { error: 'fetch_failed' };
+  }
+  if (html.length > MAX_INTERCEPT_FETCH_BYTES) {
+    return { error: 'response_too_large' };
+  }
+  return { html };
+}
+
+function projectCacheHit(url: string, cached: CachedScan): InterceptVerdict {
+  const allProbes: ProbeResult[][] = cached.chunks.map((c) => [...(c.probeResults ?? [])]);
+  const merged = mergeProbeResults(allProbes);
+  const behavioralFlags = analyzeBehavior(merged);
+  const policy = evaluatePolicy(
+    merged,
+    behavioralFlags,
+    url,
+    computeAggregateError(merged),
+    null,
+    null,
+  );
+  return {
+    status: policy.status,
+    scannedUrl: url,
+    probeBreakdown: countProbeBreakdown(merged),
+    totalScore: policy.totalScore,
+    cacheHit: true,
+    timestamp: Date.now(),
+    analysisError: policy.analysisError,
+  };
+}
+
+function countProbeBreakdown(probes: readonly ProbeResult[]): InterceptVerdict['probeBreakdown'] {
+  let suspiciousProbes = 0;
+  let compromisedProbes = 0;
+  for (const p of probes) {
+    if (p.passed) continue;
+    suspiciousProbes++;
+    if (p.score >= SCORE_INSTRUCTION_DETECTION) compromisedProbes++;
+  }
+  return { totalProbes: probes.length, suspiciousProbes, compromisedProbes };
+}
+
+function buildErrorVerdict(
+  url: string,
+  reason:
+    | 'fetch_failed'
+    | 'parse_failed'
+    | 'response_too_large'
+    | 'intercept_timeout'
+    | 'empty_response',
+  cacheHit: boolean,
+): InterceptVerdict {
+  return {
+    status: 'UNKNOWN',
+    scannedUrl: url,
+    probeBreakdown: { totalProbes: 0, suspiciousProbes: 0, compromisedProbes: 0 },
+    totalScore: 0,
+    cacheHit,
+    timestamp: Date.now(),
+    analysisError: reason,
+  };
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -382,3 +382,72 @@ export const RESPONSE_CHUNK_INDEX_OFFSET = 1_000_000;
  * dominating chunk-loop time on the offscreen engine.
  */
 export const MAX_RESPONSE_TEXT_CHARS = 80_000;
+
+/**
+ * Issue #130 (N7b) — pre-send URL intercept storage + tuning.
+ *
+ * STORAGE_KEY_INTERCEPT_OVERRIDES: per-(portalId, domain) record of
+ * Send-anyway events. Shape: Record<"portalId:domain", InterceptOverrideRecord>.
+ * Stored in chrome.storage.local (per-device); the popup queries this to
+ * surface a "Whitelist this domain?" CTA when count-in-window crosses the
+ * threshold.
+ *
+ * STORAGE_KEY_PENDING_INTERCEPT: transient record set by the SW while a
+ * scan is in flight or awaiting user action; cleared on Send-anyway /
+ * Cancel / verdict-CLEAN. The popup reads this on open and subscribes via
+ * chrome.storage.onChanged for live updates.
+ */
+export const STORAGE_KEY_INTERCEPT_OVERRIDES = 'honeyllm:intercept-overrides';
+export const STORAGE_KEY_PENDING_INTERCEPT = 'honeyllm:pending-intercept';
+
+/**
+ * Issue #130 — input observer debounces keystrokes by this much before
+ * extracting URLs and dispatching INTERCEPT_SCAN_REQUEST. Reuses the
+ * portal/debounce.ts pattern from #126. 200ms is short enough that the
+ * user perceives the gate as instant for paste; long enough to avoid
+ * dispatching mid-typing on each keystroke.
+ */
+export const INTERCEPT_INPUT_DEBOUNCE_MS = 200;
+
+/**
+ * Issue #130 — cache-miss latency budget before the URL scanner returns
+ * UNKNOWN+'intercept_timeout'. The popup pending-intercept panel offers
+ * a Wait button that extends this budget once by the same amount;
+ * second timeout is final and offers only Send-anyway / Cancel.
+ */
+export const MAX_INTERCEPT_LATENCY_MS = 30_000;
+export const MAX_INTERCEPT_LATENCY_EXTENSION_MS = 30_000;
+
+/**
+ * Issue #130 — fetch size cap on the SW's URL scanner. Set via
+ * `Range: bytes=0-524287` (512 KB). Servers that ignore Range and
+ * stream a larger body are aborted via AbortController; the verdict
+ * surfaces UNKNOWN+'response_too_large'. 512 KB comfortably contains
+ * the visible HTML of >99% of legit pages while bounding the cost of
+ * a hostile or accidentally-huge response.
+ */
+export const MAX_INTERCEPT_FETCH_BYTES = 524_288;
+
+/**
+ * Issue #130 — cap on URLs scanned per prompt. Most prompts have one;
+ * the cap prevents abuse (e.g. paste-bomb a thousand URLs).
+ */
+export const MAX_INTERCEPT_URLS_PER_PROMPT = 3;
+
+/**
+ * Issue #130 — rolling window for override count. When a (portalId,
+ * domain) tuple accumulates ≥INTERCEPT_OVERRIDE_WHITELIST_THRESHOLD
+ * Send-anyway events within this window, the popup surfaces a
+ * "Whitelist this domain?" CTA.
+ */
+export const INTERCEPT_OVERRIDE_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+export const INTERCEPT_OVERRIDE_WHITELIST_THRESHOLD = 3;
+
+/**
+ * Issue #130 — chunkIndex offset applied to every intercept-scan chunk
+ * dispatched via runChunkProbes. Mirrors RESPONSE_CHUNK_INDEX_OFFSET
+ * (#126, =1_000_000) to avoid PROBE_RESULTS listener collision when a
+ * page-scan, response-scan, and intercept-scan all run on the same
+ * tabId. 2_000_000 stays well under Number.MAX_SAFE_INTEGER.
+ */
+export const INTERCEPT_CHUNK_INDEX_OFFSET = 2_000_000;

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -1,5 +1,5 @@
 import type { PageSnapshot } from './snapshot.js';
-import type { ProbeResult, SecurityVerdict, WebGPUAdapterMode } from './verdict.js';
+import type { ProbeResult, SecurityStatus, SecurityVerdict, WebGPUAdapterMode } from './verdict.js';
 import type { VerifyStampResult } from './page-stamp.js';
 import type { CapturedResponse } from './portal-response.js';
 import type { EvidencePacket } from '@/probes/base-probe.js';
@@ -53,7 +53,17 @@ export type MessageType =
   // when an assistant response finishes streaming. Handled by the SW's
   // response-analyzer; runs the existing 3-probe stack on the captured
   // text and writes a ResponseVerdict back via mergeWithStoredVerdict.
-  | 'RESPONSE_CAPTURED';
+  | 'RESPONSE_CAPTURED'
+  // Issue #130 (N7b) — pre-send URL intercept. Content-side observer
+  // detects URLs in the chat-portal composer and dispatches
+  // INTERCEPT_SCAN_REQUEST; SW's url-scanner replies with
+  // INTERCEPT_VERDICT. Cache hit → instant; cache miss → fetch URL
+  // (credentials:'omit' + Range cap) → offscreen DOMParser via
+  // PARSE_HTML_REQUEST → analyzeSnapshot → cache write.
+  | 'INTERCEPT_SCAN_REQUEST'
+  | 'INTERCEPT_VERDICT'
+  | 'PARSE_HTML_REQUEST'
+  | 'PARSE_HTML_RESULT';
 
 interface BaseMessage {
   readonly type: MessageType;
@@ -293,6 +303,63 @@ export interface ResponseCapturedMessage extends BaseMessage {
   readonly metadata: { readonly url: string; readonly origin: string };
 }
 
+// Issue #130 (N7b) — pre-send URL intercept. The portal-side observer
+// dispatches one INTERCEPT_SCAN_REQUEST per URL detected (capped at
+// MAX_INTERCEPT_URLS_PER_PROMPT). The SW replies via
+// chrome.tabs.sendMessage with INTERCEPT_VERDICT correlated by
+// requestId. Send-button gating runs on the content side; the SW only
+// produces verdicts.
+export type PortalId = 'chatgpt' | 'claude' | 'gemini';
+
+export interface InterceptVerdict {
+  readonly status: SecurityStatus;
+  readonly scannedUrl: string;
+  readonly probeBreakdown: {
+    readonly totalProbes: number;
+    readonly suspiciousProbes: number;
+    readonly compromisedProbes: number;
+  };
+  readonly totalScore: number;
+  readonly cacheHit: boolean;
+  readonly timestamp: number;
+  readonly analysisError: string | null;
+}
+
+export interface InterceptScanRequestMessage extends BaseMessage {
+  readonly type: 'INTERCEPT_SCAN_REQUEST';
+  readonly tabId: number;
+  readonly portalId: PortalId;
+  readonly url: string;
+  readonly requestId: string;
+  readonly origin: string;
+}
+
+export interface InterceptVerdictMessage extends BaseMessage {
+  readonly type: 'INTERCEPT_VERDICT';
+  readonly requestId: string;
+  readonly verdict: InterceptVerdict;
+}
+
+// Issue #130 (N7b) — offscreen-mediated HTML parse RPC. The SW has no
+// DOMParser; parseHtmlToSnapshot lives in the offscreen document and
+// builds a synthetic PageSnapshot from fetched HTML so analyzeSnapshot
+// can run unchanged. Reduced-fidelity layout filtering — the parsed
+// document has no viewport, so visibility heuristics are attribute-
+// based only (no getComputedStyle). Acceptable for pre-send URL scans.
+export interface ParseHtmlRequestMessage extends BaseMessage {
+  readonly type: 'PARSE_HTML_REQUEST';
+  readonly requestId: string;
+  readonly html: string;
+  readonly url: string;
+}
+
+export interface ParseHtmlResultMessage extends BaseMessage {
+  readonly type: 'PARSE_HTML_RESULT';
+  readonly requestId: string;
+  readonly snapshot: PageSnapshot | null;
+  readonly errorMessage: string | null;
+}
+
 export type HoneyLLMMessage =
   | PageSnapshotMessage
   | RunProbesMessage
@@ -316,4 +383,8 @@ export type HoneyLLMMessage =
   | LanguageResultMessage
   | RunNerMessage
   | NerResultMessage
-  | ResponseCapturedMessage;
+  | ResponseCapturedMessage
+  | InterceptScanRequestMessage
+  | InterceptVerdictMessage
+  | ParseHtmlRequestMessage
+  | ParseHtmlResultMessage;


### PR DESCRIPTION
## Summary

Closes #130 — pre-send URL intercept for the three free chat portals (ChatGPT / Claude.ai / Gemini). Detects URLs in the composer, disables the send button, scans the URL via the existing 3-probe stack against a synthetic snapshot built from the fetched HTML, then either re-enables on `CLEAN` or surfaces the verdict in the popup pending-intercept panel for `SUSPICIOUS` / `COMPROMISED` / `UNKNOWN`.

Reuses #126 (portal adapters + bootstrap pattern + dispatch + debounce + dom-utils) and #127 (scan cache + per-chunk content-hash replay) — no new probe pipeline, no DOM injection into portal pages. Decoration of the existing send button only (`disabled` + `aria-disabled` + `title` + `data-honeyllm-disabled` flag).

### New surface
- **Message contract**: `INTERCEPT_SCAN_REQUEST` / `INTERCEPT_VERDICT`, `PARSE_HTML_REQUEST` / `PARSE_HTML_RESULT`, `InterceptVerdict`
- **Storage**: `STORAGE_KEY_INTERCEPT_OVERRIDES` (per-(portalId, domain) override count, 7d rolling window, threshold 3 → whitelist CTA), `STORAGE_KEY_PENDING_INTERCEPT` (transient SW→popup state)
- **Constants**: `INTERCEPT_INPUT_DEBOUNCE_MS=200`, `MAX_INTERCEPT_LATENCY_MS=30s` (+30s extension via popup Wait), `MAX_INTERCEPT_FETCH_BYTES=512KB`, `MAX_INTERCEPT_URLS_PER_PROMPT=3`, `INTERCEPT_CHUNK_INDEX_OFFSET=2_000_000` (mirrors #126's `RESPONSE_CHUNK_INDEX_OFFSET`)
- **SW URL scanner** (`src/service-worker/url-scanner.ts`): cache lookup → fetch → offscreen-mediated DOMParser → `chunkText` → `runChunkProbes` → `mergeProbeResults` → `evaluatePolicy` → `writeScan`. Mirrors the response-analyzer pattern from #126
- **Offscreen HTML parser** (`src/offscreen/parse-html.ts`): reduced-fidelity layout filtering (no `getComputedStyle` on detached docs); attribute-based hidden detection; self-implemented sync SHA-256 for script fingerprints
- **Per-portal intercept adapters** + composer fixtures (ChatGPT / Claude.ai / Gemini)
- **Popup pending-intercept panel** (`src/popup/pending-intercept.ts`): Send-anyway / Cancel / Wait UX with one-time timeout extension; whitelist CTA at threshold

### Privacy + safety
- `credentials:'omit'` on every fetch; never sets `Authorization` or `Cookie`
- `Range: bytes=0-524287` caps fetch at 512 KB; oversize → `AbortController` fires → `UNKNOWN` + `analysisError='response_too_large'`
- `referrerPolicy:'no-referrer'` on outbound fetches
- No new manifest permissions; no `host_permissions` widening
- No DOM injection — only attributes on the existing send button (no new nodes / overlays / modals)

### Selector-regression posture
Mirrors #126's watchdog (`SELECTOR_REGRESSION_WARN_AFTER_MS`); intercept silently degrades when input/send-button selectors miss, leaving page-content scan + #126 response observer unaffected.

### Tests
89 new tests across url-extract (12), parseHtmlToSnapshot (7), url-scanner (9 — incl. credentials-omit / Range / oversize-abort / timeout assertions), send-button helpers (5), intercept-overrides (9), per-portal adapters (24 across 3 suites + shared spec), intercept bootstrap (10 — debounce + Enter intercept + verdict-driven gating + dispose), pending-intercept popup panel (13 — scanning / CLEAN / SUSPICIOUS / COMPROMISED / UNKNOWN+timeout / Wait / whitelist CTA / window-expiry).

**919 → 1008 tests passing**; 79 → 87 test files; full suite + typecheck + build green.

## Test plan
- [ ] CI: typecheck + vitest + build all pass on `main`
- [ ] Manual smoke (chrome://extensions → reload unpacked `dist/`):
  - [ ] chatgpt.com — type `look up https://example.com`; observe send button disabled with `title=\"HoneyLLM scanning…\"`; CLEAN re-enables
  - [ ] claude.ai — same flow
  - [ ] gemini.google.com — same flow
  - [ ] Open popup while gated → \"Scanning URL…\" panel visible; on verdict-ready, Send-anyway records override and clears pending; Cancel clears pending
  - [ ] Trigger UNKNOWN+intercept_timeout (slow target) → popup shows Send-anyway / Cancel / Wait; Wait extends; second timeout shows Send-anyway / Cancel only
  - [ ] After 3 Send-anyway events on the same domain in 7 days → popup shows whitelist CTA
- [ ] Schedule-able follow-up (~2 weeks): combine with #126/#127 telemetry review — query `STORAGE_KEY_INTERCEPT_OVERRIDES` distribution + intercept cache-hit rate

## Phase 6 Stage 4 candidates (after this lands)
- #131 view-thinking inspection (small; opportunistic)
- #128 ProtectAI English confirmer (validation-gated; #126 / #127 / #130 telemetry should now have signal)
- #157 strict-LLM-bypass review (telemetry-gated; ~2026-05-06+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)