### PR TITLE
feat(phase6-#131): free chat portal thinking-block inspection (N7c)

### DIFF
--- a/src/content/portals/index.ts
+++ b/src/content/portals/index.ts
@@ -18,6 +18,10 @@ import {
   attachInterceptObserver,
   selectInterceptAdapter,
 } from './intercept/index.js';
+import {
+  attachThinkingObserver,
+  selectThinkingAdapter,
+} from './thinking/index.js';
 
 const log = createLogger('PortalObserver');
 
@@ -117,6 +121,21 @@ export function bootstrapPortals(hostname: string = window.location.hostname): B
     log.info(`Attaching portal intercept observer: ${interceptAdapter.portalId}`);
   }
 
+  // Issue #131 (N7c) — thinking-block (reasoning) observer. Watches the
+  // thinking subtree on each portal (model-thoughts/<thinking-block> on
+  // Gemini, extended-thinking ladder on Claude, reasoning ladder on
+  // ChatGPT) and dispatches THINKING_CAPTURED to the SW thinking-analyzer.
+  // No-op when the host doesn't match. Most portal sessions never enter
+  // thinking mode → empty subtree → no captures, by design.
+  const thinkingAdapter = selectThinkingAdapter(hostname);
+  const disposeThinking =
+    thinkingAdapter === null
+      ? (): void => undefined
+      : attachThinkingObserver({ adapter: thinkingAdapter });
+  if (thinkingAdapter !== null) {
+    log.info(`Attaching portal thinking observer: ${thinkingAdapter.portalId}`);
+  }
+
   // Selector-regression watchdog: if no captures after the warning
   // window, surface a one-shot console warn so a developer can spot
   // selector drift before users do.
@@ -132,6 +151,7 @@ export function bootstrapPortals(hostname: string = window.location.hostname): B
     dispose: () => {
       handle.dispose();
       disposeIntercept();
+      disposeThinking();
       restoreHistory();
       clearTimeout(warnTimer);
     },

--- a/src/content/portals/thinking/adapters/__fixtures__/chatgpt-thinking.html
+++ b/src/content/portals/thinking/adapters/__fixtures__/chatgpt-thinking.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head><title>ChatGPT</title></head>
+<body>
+  <main>
+    <article data-message-author-role="assistant" data-message-id="thinking-msg-1">
+      <details data-testid="reasoning">
+        <summary>Thought for 5 seconds</summary>
+        <div>
+          <p>The user is asking how recursion works. I should explain base cases and the call stack.</p>
+          <p>I'll use factorial as an illustrative example.</p>
+        </div>
+      </details>
+      <div class="markdown">
+        <p>Recursion is when a function calls itself with a smaller subproblem until it reaches a base case.</p>
+      </div>
+      <button data-testid="copy-turn-action-button" aria-label="Copy">Copy</button>
+    </article>
+  </main>
+</body>
+</html>

--- a/src/content/portals/thinking/adapters/__fixtures__/claude-thinking.html
+++ b/src/content/portals/thinking/adapters/__fixtures__/claude-thinking.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<head><title>Claude</title></head>
+<body>
+  <main>
+    <div data-test-render-count="1" data-is-streaming="false">
+      <details data-testid="claude-thinking" aria-label="Thinking process">
+        <summary>Claude's thinking</summary>
+        <div>
+          <p>The user wants to know about prime factorisation. Let me work through it step by step.</p>
+          <p>For 60 = 2 × 30 = 2 × 2 × 15 = 2 × 2 × 3 × 5.</p>
+        </div>
+      </details>
+      <div role="article" aria-label="Claude's response">
+        <p>The prime factorisation of 60 is 2² × 3 × 5.</p>
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/src/content/portals/thinking/adapters/__fixtures__/gemini-thinking.html
+++ b/src/content/portals/thinking/adapters/__fixtures__/gemini-thinking.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head><title>Gemini</title></head>
+<body>
+  <main>
+    <model-response>
+      <model-thoughts>
+        <p>Let me think through this carefully. The user is asking about prime numbers.</p>
+        <p>I should start with the definition: a number greater than 1 with only two divisors.</p>
+      </model-thoughts>
+      <message-content>
+        <p>A prime number is a natural number greater than 1 that has no positive divisors other than 1 and itself.</p>
+      </message-content>
+      <button aria-label="Copy">Copy</button>
+    </model-response>
+  </main>
+</body>
+</html>

--- a/src/content/portals/thinking/adapters/adapter-spec.ts
+++ b/src/content/portals/thinking/adapters/adapter-spec.ts
@@ -1,0 +1,88 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { ThinkingAdapter } from './types.js';
+
+const FIXTURE_DIR = path.dirname(fileURLToPath(import.meta.url)) + '/__fixtures__';
+
+export interface ThinkingAdapterSpec {
+  readonly adapter: ThinkingAdapter;
+  readonly hostnameMatches: readonly string[];
+  readonly hostnameMisses: readonly string[];
+  readonly fixtureFile: string;
+  /** A short substring expected to appear in the captured thinking text. */
+  readonly expectedThinkingFragment: string;
+}
+
+function loadFixture(name: string): Document {
+  const html = readFileSync(`${FIXTURE_DIR}/${name}`, 'utf8');
+  return new DOMParser().parseFromString(html, 'text/html');
+}
+
+export function describeThinkingAdapter(spec: ThinkingAdapterSpec): void {
+  describe(`thinking adapter: ${spec.adapter.portalId}`, () => {
+    let doc: Document;
+    beforeEach(() => {
+      doc = loadFixture(spec.fixtureFile);
+    });
+
+    it('matchesHost returns true for known hostnames', () => {
+      for (const h of spec.hostnameMatches) {
+        expect(spec.adapter.matchesHost(h)).toBe(true);
+      }
+    });
+
+    it('matchesHost returns false for foreign hostnames', () => {
+      for (const h of spec.hostnameMisses) {
+        expect(spec.adapter.matchesHost(h)).toBe(false);
+      }
+    });
+
+    it('findThinkingBlocks locates at least one thinking block in the fixture', () => {
+      const blocks = spec.adapter.findThinkingBlocks(doc);
+      expect(blocks.length).toBeGreaterThan(0);
+      for (const b of blocks) expect(b).toBeInstanceOf(HTMLElement);
+    });
+
+    it('captured thinking text contains the expected fragment', () => {
+      const blocks = spec.adapter.findThinkingBlocks(doc);
+      expect(blocks.length).toBeGreaterThan(0);
+      const text = blocks
+        .map((b) => b.textContent ?? '')
+        .join(' ');
+      expect(text).toContain(spec.expectedThinkingFragment);
+    });
+
+    it('findThinkingBlocks returns [] when no thinking elements exist', () => {
+      const empty = new DOMParser().parseFromString(
+        '<!doctype html><html><body><main><div>Just a regular page</div></main></body></html>',
+        'text/html',
+      );
+      expect(spec.adapter.findThinkingBlocks(empty)).toEqual([]);
+    });
+
+    it('attachThinkingObserver emits a CapturedThinking on the seeded fixture (debounce + flush)', async () => {
+      const captures: Array<{ portalId: string; text: string; messageId: string }> = [];
+      const dispose = spec.adapter.attachThinkingObserver(doc, (cap) => {
+        captures.push({ portalId: cap.portalId, text: cap.text, messageId: cap.messageId });
+      });
+
+      // Allow the debounce timer to fire. STREAM_END_DEBOUNCE_MS is 600ms;
+      // we wait a touch longer to absorb any queued microtasks.
+      await new Promise((resolve) => setTimeout(resolve, 750));
+      dispose();
+
+      expect(captures.length).toBeGreaterThan(0);
+      const first = captures[0]!;
+      expect(first.portalId).toBe(spec.adapter.portalId);
+      expect(first.text).toContain(spec.expectedThinkingFragment);
+      expect(first.messageId.startsWith(`${spec.adapter.portalId}-thinking:`)).toBe(true);
+    });
+
+    it('attachThinkingObserver returns a disposer that detaches cleanly', () => {
+      const dispose = spec.adapter.attachThinkingObserver(doc, () => undefined);
+      expect(() => dispose()).not.toThrow();
+    });
+  });
+}

--- a/src/content/portals/thinking/adapters/chatgpt.test.ts
+++ b/src/content/portals/thinking/adapters/chatgpt.test.ts
@@ -1,0 +1,11 @@
+// @vitest-environment jsdom
+import { describeThinkingAdapter } from './adapter-spec.js';
+import { chatgptThinkingAdapter } from './chatgpt.js';
+
+describeThinkingAdapter({
+  adapter: chatgptThinkingAdapter,
+  hostnameMatches: ['chatgpt.com', 'chat.openai.com'],
+  hostnameMisses: ['claude.ai', 'gemini.google.com', 'example.com'],
+  fixtureFile: 'chatgpt-thinking.html',
+  expectedThinkingFragment: 'recursion',
+});

--- a/src/content/portals/thinking/adapters/chatgpt.ts
+++ b/src/content/portals/thinking/adapters/chatgpt.ts
@@ -1,0 +1,190 @@
+import type {
+  CapturedThinking,
+  PortalId,
+} from '@/types/portal-response.js';
+import type { ThinkingAdapter } from './types.js';
+import { createStreamEndDebouncer } from '../../debounce.js';
+import { STREAM_END_DEBOUNCE_MS, MAX_DEBOUNCE_LATENCY_MS } from '../../constants.js';
+import { extractMarkdownText, firstAttribute, narrowToHTMLElement } from '../../dom-utils.js';
+
+// Issue #131 (N7c) — ChatGPT thinking adapter.
+//
+// ChatGPT's o1/o3 reasoning summary is rendered inside the same assistant
+// turn (`[data-message-author-role="assistant"]`) but in a sibling node
+// to the `.markdown` answer subtree. Selectors are LOW-CONFIDENCE: this
+// is the most uncertain portal of the three for thinking selectors,
+// because the reasoning panel design has shifted multiple times and we
+// have not pinned a stable DOM signature in this session.
+//
+// Selector ladder, broadest-to-most-specific so a redesign that adds new
+// data-testid values still gets caught by the looser later candidates:
+//   1. [data-message-author-role="reasoning"]   (hypothetical, mirrors response)
+//   2. [data-testid*="reasoning" i]
+//   3. [data-testid*="thinking" i]
+//   4. details[data-testid]                     (collapsible chrome)
+//   5. .reasoning-summary
+//
+// Stream-end heuristic: same copy/regenerate buttons used by the response
+// adapter. They appear once the entire turn finishes, after thinking has
+// already settled. Fall back to debounce.
+
+const PORTAL_ID: PortalId = 'chatgpt';
+
+const ASSISTANT_SELECTOR = '[data-message-author-role="assistant"]';
+const THINKING_SELECTORS: readonly string[] = [
+  '[data-message-author-role="reasoning"]',
+  '[data-testid*="reasoning" i]',
+  '[data-testid*="thinking" i]',
+  'details[data-testid]',
+  '.reasoning-summary',
+];
+const COMPLETION_MARKER_SELECTORS = [
+  '[data-testid="copy-turn-action-button"]',
+  '[data-testid="regenerate-response-button"]',
+  'button[aria-label="Copy"]',
+];
+
+function matchesHost(host: string): boolean {
+  return host === 'chatgpt.com' || host === 'chat.openai.com';
+}
+
+function findThinkingBlocks(root: ParentNode): readonly HTMLElement[] {
+  const found = new Set<HTMLElement>();
+  for (const sel of THINKING_SELECTORS) {
+    const list = root.querySelectorAll<HTMLElement>(sel);
+    for (const el of Array.from(list)) {
+      // Limit to candidates that sit inside an assistant turn.
+      if (el.closest(ASSISTANT_SELECTOR) !== null) found.add(el);
+    }
+  }
+  return Array.from(found);
+}
+
+function getThinkingText(el: HTMLElement): string {
+  return extractMarkdownText(el);
+}
+
+function getMessageId(el: HTMLElement): string {
+  const turn = el.closest(ASSISTANT_SELECTOR) as HTMLElement | null;
+  if (turn !== null) {
+    const id = firstAttribute(turn, ['data-message-id']);
+    if (id !== null) return `chatgpt-thinking:${id}`;
+  }
+  const prefix = (el.textContent ?? '').slice(0, 32).replace(/\s+/g, '_');
+  return `chatgpt-thinking:fallback:${prefix}`;
+}
+
+function isThinkingComplete(el: HTMLElement): boolean {
+  const turn = el.closest(ASSISTANT_SELECTOR);
+  if (turn === null) return false;
+  for (const sel of COMPLETION_MARKER_SELECTORS) {
+    if (turn.querySelector(sel) !== null) return true;
+  }
+  return false;
+}
+
+function conversationIdFromLocation(): string | null {
+  try {
+    const m = window.location.pathname.match(/\/c\/([^/?#]+)/);
+    return m?.[1] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function buildCapture(el: HTMLElement, key: string): CapturedThinking {
+  const messageId = key.split('|', 1)[0] ?? getMessageId(el);
+  return {
+    portalId: PORTAL_ID,
+    text: getThinkingText(el),
+    capturedAt: Date.now(),
+    conversationId: conversationIdFromLocation(),
+    messageId,
+    streamComplete: isThinkingComplete(el),
+  };
+}
+
+function attachThinkingObserver(
+  root: ParentNode,
+  callback: (cap: CapturedThinking) => void,
+): () => void {
+  const trackedByKey = new Map<string, HTMLElement>();
+  const firedKeys = new Set<string>();
+
+  const debouncer = createStreamEndDebouncer({
+    debounceMs: STREAM_END_DEBOUNCE_MS,
+    maxLatencyMs: MAX_DEBOUNCE_LATENCY_MS,
+    onFire: (key) => {
+      const el = trackedByKey.get(key);
+      trackedByKey.delete(key);
+      firedKeys.add(key);
+      if (el === undefined || !el.isConnected) return;
+      const cap = buildCapture(el, key);
+      if (cap.text.trim().length === 0) return;
+      callback(cap);
+    },
+  });
+
+  function bumpForElement(el: HTMLElement): void {
+    const messageId = getMessageId(el);
+    const text = getThinkingText(el);
+    const key = `${messageId}|${text.slice(0, 32)}`;
+    if (firedKeys.has(key)) return;
+    trackedByKey.set(key, el);
+    debouncer.bump(key);
+    if (isThinkingComplete(el)) debouncer.markComplete(key);
+  }
+
+  for (const el of findThinkingBlocks(root)) bumpForElement(el);
+
+  const targetNode = (root as { documentElement?: Node }).documentElement ?? (root as unknown as Node);
+  const observer = new MutationObserver((records) => {
+    for (const record of records) {
+      const target = record.target;
+      const targetEl = narrowToHTMLElement(target as Node);
+      if (targetEl !== null) {
+        for (const sel of THINKING_SELECTORS) {
+          const closest = (targetEl.closest?.(sel) ?? null) as HTMLElement | null;
+          if (closest !== null && closest.closest(ASSISTANT_SELECTOR) !== null) {
+            bumpForElement(closest);
+            break;
+          }
+        }
+      }
+      for (const added of Array.from(record.addedNodes)) {
+        const addedEl = narrowToHTMLElement(added);
+        if (addedEl === null) continue;
+        for (const sel of THINKING_SELECTORS) {
+          if (addedEl.matches?.(sel) && addedEl.closest(ASSISTANT_SELECTOR) !== null) {
+            bumpForElement(addedEl);
+          }
+          const sub = addedEl.querySelectorAll?.(sel) ?? [];
+          for (const s of Array.from(sub)) {
+            const candidate = s as HTMLElement;
+            if (candidate.closest(ASSISTANT_SELECTOR) !== null) bumpForElement(candidate);
+          }
+        }
+      }
+    }
+  });
+  observer.observe(targetNode, {
+    childList: true,
+    subtree: true,
+    characterData: true,
+    attributes: true,
+    attributeFilter: ['data-message-id'],
+  });
+
+  return () => {
+    observer.disconnect();
+    debouncer.dispose();
+    trackedByKey.clear();
+  };
+}
+
+export const chatgptThinkingAdapter: ThinkingAdapter = {
+  portalId: PORTAL_ID,
+  matchesHost,
+  findThinkingBlocks,
+  attachThinkingObserver,
+};

--- a/src/content/portals/thinking/adapters/claude.test.ts
+++ b/src/content/portals/thinking/adapters/claude.test.ts
@@ -1,0 +1,11 @@
+// @vitest-environment jsdom
+import { describeThinkingAdapter } from './adapter-spec.js';
+import { claudeThinkingAdapter } from './claude.js';
+
+describeThinkingAdapter({
+  adapter: claudeThinkingAdapter,
+  hostnameMatches: ['claude.ai'],
+  hostnameMisses: ['chatgpt.com', 'gemini.google.com', 'example.com'],
+  fixtureFile: 'claude-thinking.html',
+  expectedThinkingFragment: 'prime factorisation',
+});

--- a/src/content/portals/thinking/adapters/claude.ts
+++ b/src/content/portals/thinking/adapters/claude.ts
@@ -1,0 +1,178 @@
+import type {
+  CapturedThinking,
+  PortalId,
+} from '@/types/portal-response.js';
+import type { ThinkingAdapter } from './types.js';
+import { createStreamEndDebouncer } from '../../debounce.js';
+import { STREAM_END_DEBOUNCE_MS, MAX_DEBOUNCE_LATENCY_MS } from '../../constants.js';
+import { extractMarkdownText, firstAttribute, narrowToHTMLElement } from '../../dom-utils.js';
+
+// Issue #131 (N7c) — Claude.ai thinking adapter.
+//
+// Selector ladder:
+//   1. Turn container: [data-test-render-count] (same as response adapter)
+//   2. Thinking subtree (selector ladder, in order of confidence):
+//        - [data-testid*="thinking" i]
+//        - [data-test-thinking]
+//        - details[aria-label*="thinking" i]
+//        - [aria-label*="thinking" i] (last-resort, may catch UI chrome)
+//   3. Stream-end signal: data-is-streaming="false" on the turn container
+//      (mirrors the response adapter); fall back to debounce.
+//   4. messageId: `claude-thinking:` + data-test-render-count value, with
+//      a text-prefix fallback. Namespaced so a thinking capture and a
+//      response capture for the same turn cannot collide in dedup.
+
+const PORTAL_ID: PortalId = 'claude';
+
+const TURN_SELECTOR = '[data-test-render-count]';
+const THINKING_SELECTORS: readonly string[] = [
+  '[data-testid*="thinking" i]',
+  '[data-test-thinking]',
+  'details[aria-label*="thinking" i]',
+  '[aria-label*="thinking" i]',
+];
+
+function matchesHost(host: string): boolean {
+  return host === 'claude.ai';
+}
+
+function findThinkingBlocks(root: ParentNode): readonly HTMLElement[] {
+  const found = new Set<HTMLElement>();
+  for (const sel of THINKING_SELECTORS) {
+    const list = root.querySelectorAll<HTMLElement>(sel);
+    for (const el of Array.from(list)) found.add(el);
+  }
+  // Filter to thinking blocks that sit inside an assistant turn.
+  return Array.from(found).filter((el) => el.closest(TURN_SELECTOR) !== null);
+}
+
+function getThinkingText(el: HTMLElement): string {
+  return extractMarkdownText(el);
+}
+
+function getMessageId(el: HTMLElement): string {
+  const turn = el.closest(TURN_SELECTOR) as HTMLElement | null;
+  if (turn !== null) {
+    const id = firstAttribute(turn, ['data-test-render-count', 'data-message-id']);
+    if (id !== null) return `claude-thinking:${id}`;
+  }
+  const prefix = (el.textContent ?? '').slice(0, 32).replace(/\s+/g, '_');
+  return `claude-thinking:fallback:${prefix}`;
+}
+
+function isTurnStreaming(turn: HTMLElement | null): boolean {
+  return turn?.getAttribute('data-is-streaming') === 'true';
+}
+
+function isThinkingComplete(el: HTMLElement): boolean {
+  const turn = el.closest(TURN_SELECTOR) as HTMLElement | null;
+  return turn?.getAttribute('data-is-streaming') === 'false';
+}
+
+function conversationIdFromLocation(): string | null {
+  try {
+    const m = window.location.pathname.match(/\/chat\/([^/?#]+)/);
+    return m?.[1] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function buildCapture(el: HTMLElement, key: string): CapturedThinking {
+  const messageId = key.split('|', 1)[0] ?? getMessageId(el);
+  return {
+    portalId: PORTAL_ID,
+    text: getThinkingText(el),
+    capturedAt: Date.now(),
+    conversationId: conversationIdFromLocation(),
+    messageId,
+    streamComplete: isThinkingComplete(el),
+  };
+}
+
+function attachThinkingObserver(
+  root: ParentNode,
+  callback: (cap: CapturedThinking) => void,
+): () => void {
+  const trackedByKey = new Map<string, HTMLElement>();
+  const firedKeys = new Set<string>();
+
+  const debouncer = createStreamEndDebouncer({
+    debounceMs: STREAM_END_DEBOUNCE_MS,
+    maxLatencyMs: MAX_DEBOUNCE_LATENCY_MS,
+    onFire: (key) => {
+      const el = trackedByKey.get(key);
+      trackedByKey.delete(key);
+      firedKeys.add(key);
+      if (el === undefined || !el.isConnected) return;
+      const cap = buildCapture(el, key);
+      if (cap.text.trim().length === 0) return;
+      callback(cap);
+    },
+  });
+
+  function bumpForElement(el: HTMLElement): void {
+    const turn = el.closest(TURN_SELECTOR) as HTMLElement | null;
+    if (isTurnStreaming(turn)) return;
+    const messageId = getMessageId(el);
+    const text = getThinkingText(el);
+    const key = `${messageId}|${text.slice(0, 32)}`;
+    if (firedKeys.has(key)) return;
+    trackedByKey.set(key, el);
+    debouncer.bump(key);
+    if (isThinkingComplete(el)) debouncer.markComplete(key);
+  }
+
+  for (const el of findThinkingBlocks(root)) bumpForElement(el);
+
+  const targetNode = (root as { documentElement?: Node }).documentElement ?? (root as unknown as Node);
+  const observer = new MutationObserver((records) => {
+    for (const record of records) {
+      const target = record.target;
+      const targetEl = narrowToHTMLElement(target as Node);
+      if (targetEl !== null) {
+        for (const sel of THINKING_SELECTORS) {
+          const closest = (targetEl.closest?.(sel) ?? null) as HTMLElement | null;
+          if (closest !== null && closest.closest(TURN_SELECTOR) !== null) {
+            bumpForElement(closest);
+            break;
+          }
+        }
+      }
+      for (const added of Array.from(record.addedNodes)) {
+        const addedEl = narrowToHTMLElement(added);
+        if (addedEl === null) continue;
+        for (const sel of THINKING_SELECTORS) {
+          if (addedEl.matches?.(sel) && addedEl.closest(TURN_SELECTOR) !== null) {
+            bumpForElement(addedEl);
+          }
+          const sub = addedEl.querySelectorAll?.(sel) ?? [];
+          for (const s of Array.from(sub)) {
+            const candidate = s as HTMLElement;
+            if (candidate.closest(TURN_SELECTOR) !== null) bumpForElement(candidate);
+          }
+        }
+      }
+    }
+  });
+  observer.observe(targetNode, {
+    childList: true,
+    subtree: true,
+    characterData: true,
+    attributes: true,
+    attributeFilter: ['data-is-streaming', 'data-test-render-count'],
+  });
+
+  return () => {
+    observer.disconnect();
+    debouncer.dispose();
+    trackedByKey.clear();
+  };
+}
+
+export const claudeThinkingAdapter: ThinkingAdapter = {
+  portalId: PORTAL_ID,
+  matchesHost,
+  findThinkingBlocks,
+  attachThinkingObserver,
+};

--- a/src/content/portals/thinking/adapters/gemini.test.ts
+++ b/src/content/portals/thinking/adapters/gemini.test.ts
@@ -1,0 +1,11 @@
+// @vitest-environment jsdom
+import { describeThinkingAdapter } from './adapter-spec.js';
+import { geminiThinkingAdapter } from './gemini.js';
+
+describeThinkingAdapter({
+  adapter: geminiThinkingAdapter,
+  hostnameMatches: ['gemini.google.com'],
+  hostnameMisses: ['chatgpt.com', 'claude.ai', 'example.com'],
+  fixtureFile: 'gemini-thinking.html',
+  expectedThinkingFragment: 'prime numbers',
+});

--- a/src/content/portals/thinking/adapters/gemini.ts
+++ b/src/content/portals/thinking/adapters/gemini.ts
@@ -1,0 +1,158 @@
+import type {
+  CapturedThinking,
+  PortalId,
+} from '@/types/portal-response.js';
+import type { ThinkingAdapter } from './types.js';
+import { createStreamEndDebouncer } from '../../debounce.js';
+import { STREAM_END_DEBOUNCE_MS, MAX_DEBOUNCE_LATENCY_MS } from '../../constants.js';
+import { extractMarkdownText, narrowToHTMLElement } from '../../dom-utils.js';
+
+// Issue #131 (N7c) — Gemini thinking adapter.
+//
+// Selector ladder:
+//   1. Container:    <model-response> (same parent as the response observer)
+//   2. Thinking:     <model-thoughts> | <thinking-block>
+//                    (these are explicitly EXCLUDED in adapters/gemini.ts:14
+//                    so the response observer never sees them — we INVERT
+//                    that exclusion into a capture here.)
+//   3. messageId:    `gemini-thinking:` + text-prefix hash, namespaced so
+//                    a thinking capture and a response capture for the
+//                    same logical turn cannot collide in the SW dedup
+//                    cache.
+//   4. Stream-end:   reuse the response copy button (`button[aria-label*="Copy" i]`)
+//                    as the most reliable "turn complete" marker on
+//                    Gemini; fall back to debounce.
+//   5. conversationId: parsed from ?c=<id> when present.
+
+const PORTAL_ID: PortalId = 'gemini';
+
+const RESPONSE_SELECTOR = 'model-response';
+const THINKING_SELECTOR = 'model-thoughts, thinking-block';
+const COMPLETION_MARKER_SELECTORS = [
+  'button[aria-label="Copy"]',
+  'button[aria-label*="Copy" i]',
+];
+
+function matchesHost(host: string): boolean {
+  return host === 'gemini.google.com';
+}
+
+function findThinkingBlocks(root: ParentNode): readonly HTMLElement[] {
+  return Array.from(root.querySelectorAll<HTMLElement>(THINKING_SELECTOR));
+}
+
+function getThinkingText(el: HTMLElement): string {
+  return extractMarkdownText(el);
+}
+
+function getMessageId(el: HTMLElement): string {
+  const text = getThinkingText(el);
+  const prefix = text.slice(0, 32).replace(/\s+/g, '_');
+  return `gemini-thinking:${prefix}`;
+}
+
+function isThinkingComplete(el: HTMLElement): boolean {
+  // Climb to the enclosing model-response — the copy button lives there,
+  // not inside the thinking subtree itself.
+  const container = el.closest(RESPONSE_SELECTOR);
+  if (container === null) return false;
+  for (const sel of COMPLETION_MARKER_SELECTORS) {
+    if (container.querySelector(sel) !== null) return true;
+  }
+  return false;
+}
+
+function conversationIdFromLocation(): string | null {
+  try {
+    const params = new URLSearchParams(window.location.search);
+    return params.get('c');
+  } catch {
+    return null;
+  }
+}
+
+function buildCapture(el: HTMLElement, key: string): CapturedThinking {
+  const messageId = key.split('|', 1)[0] ?? getMessageId(el);
+  return {
+    portalId: PORTAL_ID,
+    text: getThinkingText(el),
+    capturedAt: Date.now(),
+    conversationId: conversationIdFromLocation(),
+    messageId,
+    streamComplete: isThinkingComplete(el),
+  };
+}
+
+function attachThinkingObserver(
+  root: ParentNode,
+  callback: (cap: CapturedThinking) => void,
+): () => void {
+  const trackedByKey = new Map<string, HTMLElement>();
+  const firedKeys = new Set<string>();
+
+  const debouncer = createStreamEndDebouncer({
+    debounceMs: STREAM_END_DEBOUNCE_MS,
+    maxLatencyMs: MAX_DEBOUNCE_LATENCY_MS,
+    onFire: (key) => {
+      const el = trackedByKey.get(key);
+      trackedByKey.delete(key);
+      firedKeys.add(key);
+      if (el === undefined || !el.isConnected) return;
+      const cap = buildCapture(el, key);
+      // Empty-text suppression: thinking sections that exist in DOM but
+      // contain no readable text should not produce a capture (the
+      // analyzer would short-circuit anyway, but we save the round-trip).
+      if (cap.text.trim().length === 0) return;
+      callback(cap);
+    },
+  });
+
+  function bumpForElement(el: HTMLElement): void {
+    const messageId = getMessageId(el);
+    const text = getThinkingText(el);
+    const key = `${messageId}|${text.slice(0, 32)}`;
+    if (firedKeys.has(key)) return;
+    trackedByKey.set(key, el);
+    debouncer.bump(key);
+    if (isThinkingComplete(el)) debouncer.markComplete(key);
+  }
+
+  for (const el of findThinkingBlocks(root)) bumpForElement(el);
+
+  const targetNode = (root as { documentElement?: Node }).documentElement ?? (root as unknown as Node);
+  const observer = new MutationObserver((records) => {
+    for (const record of records) {
+      const target = record.target;
+      const targetEl = narrowToHTMLElement(target as Node);
+      if (targetEl !== null) {
+        const closest = (targetEl.closest?.(THINKING_SELECTOR) ?? null) as HTMLElement | null;
+        if (closest !== null) bumpForElement(closest);
+      }
+      for (const added of Array.from(record.addedNodes)) {
+        const addedEl = narrowToHTMLElement(added);
+        if (addedEl === null) continue;
+        if (addedEl.matches?.(THINKING_SELECTOR)) bumpForElement(addedEl);
+        const sub = addedEl.querySelectorAll?.(THINKING_SELECTOR) ?? [];
+        for (const s of Array.from(sub)) bumpForElement(s as HTMLElement);
+      }
+    }
+  });
+  observer.observe(targetNode, {
+    childList: true,
+    subtree: true,
+    characterData: true,
+  });
+
+  return () => {
+    observer.disconnect();
+    debouncer.dispose();
+    trackedByKey.clear();
+  };
+}
+
+export const geminiThinkingAdapter: ThinkingAdapter = {
+  portalId: PORTAL_ID,
+  matchesHost,
+  findThinkingBlocks,
+  attachThinkingObserver,
+};

--- a/src/content/portals/thinking/adapters/types.ts
+++ b/src/content/portals/thinking/adapters/types.ts
@@ -1,0 +1,31 @@
+import type { CapturedThinking, PortalId } from '@/types/portal-response.js';
+
+// Issue #131 (N7c) — thinking-block (reasoning) adapter contract. Lives
+// in a sibling subtree to intercept/ and the response adapters under
+// adapters/. ThinkingAdapter is intentionally independent of
+// PortalAdapter (response): the thinking observer watches a different
+// DOM subtree, has its own debouncer key namespace, and feeds a
+// separate SW analyzer + storage slot, so coupling them via an extended
+// interface would conflate two unrelated concerns.
+
+export interface ThinkingAdapter {
+  readonly portalId: PortalId;
+  matchesHost(hostname: string): boolean;
+  /**
+   * Locate every thinking/reasoning block currently rendered into the
+   * given root. May return [] when the user is not in thinking mode on
+   * this portal — that is the steady-state for most conversations on
+   * most portals and must not be treated as a regression signal.
+   */
+  findThinkingBlocks(root: ParentNode): readonly HTMLElement[];
+  /**
+   * Begin observing the portal DOM for completed thinking blocks. The
+   * adapter uses createStreamEndDebouncer (debounce.ts) plus its own
+   * portal-specific stream-end heuristic to decide when to fire the
+   * callback. Returns a disposer that detaches the observer.
+   */
+  attachThinkingObserver(
+    root: ParentNode,
+    callback: (cap: CapturedThinking) => void,
+  ): () => void;
+}

--- a/src/content/portals/thinking/dispatch.test.ts
+++ b/src/content/portals/thinking/dispatch.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { CapturedThinking } from '@/types/portal-response.js';
+import { sendThinkingCaptured } from './dispatch.js';
+
+const CAPTURE: CapturedThinking = {
+  portalId: 'gemini',
+  text: 'thinking step',
+  capturedAt: 1714400000000,
+  conversationId: 'abc',
+  messageId: 'gemini-thinking:thinking_step',
+  streamComplete: true,
+};
+
+const META = { url: 'https://gemini.google.com/?c=abc', origin: 'https://gemini.google.com' };
+
+interface SentMessage {
+  readonly type: string;
+  readonly capture: CapturedThinking;
+  readonly metadata: { readonly url: string; readonly origin: string };
+  readonly tabId: number;
+}
+
+beforeEach(() => vi.unstubAllGlobals());
+afterEach(() => vi.unstubAllGlobals());
+
+describe('sendThinkingCaptured', () => {
+  it('sends a THINKING_CAPTURED message with the full capture and metadata', async () => {
+    const calls: SentMessage[] = [];
+    vi.stubGlobal('chrome', {
+      runtime: {
+        sendMessage: vi.fn(async (msg: SentMessage) => {
+          calls.push(msg);
+        }),
+        lastError: undefined,
+      },
+    });
+    await sendThinkingCaptured(CAPTURE, META);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.type).toBe('THINKING_CAPTURED');
+    expect(calls[0]?.capture).toEqual(CAPTURE);
+    expect(calls[0]?.metadata).toEqual(META);
+    expect(calls[0]?.tabId).toBe(0);
+  });
+
+  it('swallows transient runtime errors without throwing', async () => {
+    vi.stubGlobal('chrome', {
+      runtime: {
+        sendMessage: vi.fn(async () => {
+          throw new Error('Could not establish connection. Receiving end does not exist.');
+        }),
+        lastError: undefined,
+      },
+    });
+    await expect(sendThinkingCaptured(CAPTURE, META)).resolves.toBeUndefined();
+  });
+
+  it('retries once on a transient connection error', async () => {
+    let calls = 0;
+    vi.stubGlobal('chrome', {
+      runtime: {
+        sendMessage: vi.fn(async () => {
+          calls += 1;
+          if (calls === 1) throw new Error('Could not establish connection.');
+          return undefined;
+        }),
+        lastError: undefined,
+      },
+    });
+    await sendThinkingCaptured(CAPTURE, META);
+    expect(calls).toBe(2);
+  });
+
+  it('swallows non-transient errors without retry', async () => {
+    let calls = 0;
+    vi.stubGlobal('chrome', {
+      runtime: {
+        sendMessage: vi.fn(async () => {
+          calls += 1;
+          throw new Error('something else broke');
+        }),
+        lastError: undefined,
+      },
+    });
+    await expect(sendThinkingCaptured(CAPTURE, META)).resolves.toBeUndefined();
+    expect(calls).toBe(1);
+  });
+});

--- a/src/content/portals/thinking/dispatch.ts
+++ b/src/content/portals/thinking/dispatch.ts
@@ -1,0 +1,51 @@
+import type { CapturedThinking } from '@/types/portal-response.js';
+import type { ThinkingCapturedMessage } from '@/types/messages.js';
+
+// Issue #131 (N7c) — content-script side of the THINKING_CAPTURED RPC.
+// Mirrors dispatch.ts (#126) verbatim with retry-once on transient
+// runtime errors (typical: SW just woke up, the listener isn't yet
+// registered when chrome.runtime.sendMessage lands).
+
+const TRANSIENT_ERROR_FRAGMENTS = [
+  'Could not establish connection',
+  'Receiving end does not exist',
+  'message channel closed',
+];
+
+function isTransient(err: unknown): boolean {
+  const m = err instanceof Error ? err.message : String(err);
+  return TRANSIENT_ERROR_FRAGMENTS.some((f) => m.includes(f));
+}
+
+async function trySend(msg: ThinkingCapturedMessage): Promise<void> {
+  await chrome.runtime.sendMessage(msg);
+}
+
+export async function sendThinkingCaptured(
+  capture: CapturedThinking,
+  metadata: { readonly url: string; readonly origin: string },
+): Promise<void> {
+  const msg: ThinkingCapturedMessage = {
+    type: 'THINKING_CAPTURED',
+    // tabId resolves to sender.tab?.id in the SW; the content-script side
+    // sends 0 as a placeholder per the PageSnapshotMessage convention.
+    tabId: 0,
+    capture,
+    metadata,
+  };
+  try {
+    await trySend(msg);
+  } catch (err) {
+    if (isTransient(err)) {
+      try {
+        await trySend(msg);
+      } catch {
+        // Retry also failed — drop. The popup will show "no thinking
+        // analysed" until the next capture lands.
+      }
+      return;
+    }
+    // Non-transient errors are also dropped — the content script must
+    // never throw into the page's task queue.
+  }
+}

--- a/src/content/portals/thinking/index.test.ts
+++ b/src/content/portals/thinking/index.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { selectThinkingAdapter, attachThinkingObserver } from './index.js';
+
+describe('selectThinkingAdapter', () => {
+  it('returns the chatgpt adapter for chatgpt hostnames', () => {
+    expect(selectThinkingAdapter('chatgpt.com')?.portalId).toBe('chatgpt');
+    expect(selectThinkingAdapter('chat.openai.com')?.portalId).toBe('chatgpt');
+  });
+
+  it('returns the claude adapter for claude.ai', () => {
+    expect(selectThinkingAdapter('claude.ai')?.portalId).toBe('claude');
+  });
+
+  it('returns the gemini adapter for gemini.google.com', () => {
+    expect(selectThinkingAdapter('gemini.google.com')?.portalId).toBe('gemini');
+  });
+
+  it('returns null for non-portal hostnames', () => {
+    expect(selectThinkingAdapter('example.com')).toBeNull();
+    expect(selectThinkingAdapter('attacker.test')).toBeNull();
+  });
+});
+
+describe('attachThinkingObserver', () => {
+  it('returns a disposer; calling it unhooks without throwing', () => {
+    // Smoke test only — the per-portal observer behaviour is covered by
+    // the per-adapter test files. This confirms the wrapper threads the
+    // adapter's disposer through cleanly.
+    const adapter = {
+      portalId: 'gemini' as const,
+      matchesHost: () => true,
+      findThinkingBlocks: () => [] as readonly HTMLElement[],
+      attachThinkingObserver: (_root: ParentNode, _cb: (cap: import('@/types/portal-response.js').CapturedThinking) => void) => {
+        return () => undefined;
+      },
+    };
+    const dispose = attachThinkingObserver({ adapter });
+    expect(() => dispose()).not.toThrow();
+  });
+});

--- a/src/content/portals/thinking/index.ts
+++ b/src/content/portals/thinking/index.ts
@@ -1,0 +1,49 @@
+import type { CapturedThinking } from '@/types/portal-response.js';
+import type { ThinkingAdapter } from './adapters/types.js';
+import { chatgptThinkingAdapter } from './adapters/chatgpt.js';
+import { claudeThinkingAdapter } from './adapters/claude.js';
+import { geminiThinkingAdapter } from './adapters/gemini.js';
+import { sendThinkingCaptured } from './dispatch.js';
+
+// Issue #131 (N7c) — thinking-observer bootstrap helper. Mirrors the
+// intercept module's selectInterceptAdapter / attachInterceptObserver
+// pair so portals/index.ts can attach a third observer alongside the
+// response and intercept observers without growing the import surface
+// or knowing about per-portal selectors.
+
+const THINKING_ADAPTERS: readonly ThinkingAdapter[] = [
+  chatgptThinkingAdapter,
+  claudeThinkingAdapter,
+  geminiThinkingAdapter,
+];
+
+export function selectThinkingAdapter(hostname: string): ThinkingAdapter | null {
+  for (const a of THINKING_ADAPTERS) {
+    if (a.matchesHost(hostname)) return a;
+  }
+  return null;
+}
+
+export interface AttachThinkingObserverOpts {
+  readonly adapter: ThinkingAdapter;
+  readonly metadata?: () => { readonly url: string; readonly origin: string };
+}
+
+function defaultMetadata(): { readonly url: string; readonly origin: string } {
+  return { url: window.location.href, origin: window.location.origin };
+}
+
+/**
+ * Attach the thinking observer for a portal. Returns a disposer that
+ * detaches the underlying MutationObserver and clears the debouncer.
+ * Dispatch errors are swallowed inside sendThinkingCaptured; this
+ * wrapper only ensures the content-script callback path is safe.
+ */
+export function attachThinkingObserver(opts: AttachThinkingObserverOpts): () => void {
+  const buildMetadata = opts.metadata ?? defaultMetadata;
+  return opts.adapter.attachThinkingObserver(document, (cap: CapturedThinking) => {
+    sendThinkingCaptured(cap, buildMetadata()).catch(() => {
+      // dispatch.ts already swallows errors; belt-and-suspenders catch.
+    });
+  });
+}

--- a/src/policy/engine.ts
+++ b/src/policy/engine.ts
@@ -72,6 +72,8 @@ export function evaluatePolicy(
       // Issue #126 — engine-only callers never produce a response verdict;
       // the SW response-analyzer writes it via mergeWithStoredVerdict.
       responseVerdict: null,
+      // Issue #131 — same; the SW thinking-analyzer writes the slot.
+      thinkingVerdict: null,
     };
   }
 
@@ -100,5 +102,7 @@ export function evaluatePolicy(
     entitySummary: null,
     // Issue #126 — engine-only callers never produce a response verdict.
     responseVerdict: null,
+    // Issue #131 — same for the thinking verdict slot.
+    thinkingVerdict: null,
   };
 }

--- a/src/policy/storage.test.ts
+++ b/src/policy/storage.test.ts
@@ -1,9 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { getVerdict, mergeWithStoredVerdict, persistVerdict } from './storage.js';
+import {
+  getVerdict,
+  mergeWithStoredVerdict,
+  persistVerdict,
+  setThinkingVerdictForOrigin,
+} from './storage.js';
 import { STORAGE_KEY_PREFIX } from '@/shared/constants.js';
 import type { SecurityVerdict } from '@/types/verdict.js';
-import type { ResponseVerdict } from '@/types/portal-response.js';
+import type { ResponseVerdict, ThinkingVerdict } from '@/types/portal-response.js';
 
 interface ChromeStorageStub {
   storage: {
@@ -91,6 +96,7 @@ function buildVerdict(overrides: Partial<SecurityVerdict> = {}): SecurityVerdict
     perChunkAnalysis: null,
     entitySummary: null,
     responseVerdict: null,
+    thinkingVerdict: null,
     ...overrides,
   };
 }
@@ -224,6 +230,160 @@ describe('storage — responseVerdict migration', () => {
       const next = buildVerdict({ responseVerdict: RESPONSE_VERDICT });
       const merged = await mergeWithStoredVerdict(next);
       expect(merged.responseVerdict).toEqual(RESPONSE_VERDICT);
+    });
+  });
+});
+
+const THINKING_VERDICT: ThinkingVerdict = {
+  portalId: 'gemini',
+  status: 'SUSPICIOUS',
+  confidence: 0.62,
+  totalScore: 38,
+  probeResults: [],
+  behavioralFlags: {
+    roleDrift: true,
+    exfiltrationIntent: false,
+    instructionFollowing: false,
+    hiddenContentAwareness: false,
+  },
+  timestamp: 1714400500000,
+  thinkingTextHash: 'b'.repeat(64),
+  thinkingTextLength: 482,
+  conversationId: null,
+  messageId: 'gemini-thinking:fallback:I_should_consider',
+  analysisError: null,
+  canaryId: 'gemma-2-2b-mlc',
+};
+
+describe('storage — thinkingVerdict (issue #131)', () => {
+  beforeEach(() => vi.unstubAllGlobals());
+  afterEach(() => vi.unstubAllGlobals());
+
+  describe('getVerdict + persistVerdict', () => {
+    it('round-trips a verdict with thinkingVerdict populated', async () => {
+      stubChrome();
+      await persistVerdict(buildVerdict({ thinkingVerdict: THINKING_VERDICT }));
+      const restored = await getVerdict(URL);
+      expect(restored?.thinkingVerdict).toEqual(THINKING_VERDICT);
+    });
+
+    it('coalesces undefined thinkingVerdict on legacy records to null', async () => {
+      // Legacy record: thinkingVerdict absent (pre-#131 shape).
+      stubChrome({
+        [ORIGIN_KEY]: {
+          status: 'CLEAN',
+          confidence: 0.9,
+          totalScore: 5,
+          timestamp: 1700000000000,
+          url: URL,
+          flags: [],
+          behavioralFlags: {
+            roleDrift: false,
+            exfiltrationIntent: false,
+            instructionFollowing: false,
+            hiddenContentAwareness: false,
+          },
+          analysisError: null,
+          canaryId: null,
+          stamp: null,
+          perChunkAnalysis: null,
+          responseVerdict: null,
+        },
+      });
+      const restored = await getVerdict(URL);
+      expect(restored?.thinkingVerdict).toBeNull();
+    });
+
+    it('does not coalesce when thinkingVerdict is already stored as null', async () => {
+      stubChrome({
+        [ORIGIN_KEY]: {
+          status: 'CLEAN',
+          confidence: 0.9,
+          totalScore: 5,
+          timestamp: 1700000000000,
+          url: URL,
+          flags: [],
+          behavioralFlags: {
+            roleDrift: false,
+            exfiltrationIntent: false,
+            instructionFollowing: false,
+            hiddenContentAwareness: false,
+          },
+          analysisError: null,
+          canaryId: null,
+          stamp: null,
+          perChunkAnalysis: null,
+          responseVerdict: null,
+          thinkingVerdict: null,
+        },
+      });
+      const restored = await getVerdict(URL);
+      expect(restored?.thinkingVerdict).toBeNull();
+    });
+
+    it('persists thinkingVerdict verbatim on persistVerdict', async () => {
+      const { readStore } = stubChrome();
+      await persistVerdict(buildVerdict({ thinkingVerdict: THINKING_VERDICT }));
+      const stored = readStore()[ORIGIN_KEY] as { thinkingVerdict: ThinkingVerdict };
+      expect(stored.thinkingVerdict).toEqual(THINKING_VERDICT);
+    });
+  });
+
+  describe('setThinkingVerdictForOrigin', () => {
+    it('writes only the thinkingVerdict slot on an existing record', async () => {
+      const { readStore } = stubChrome();
+      await persistVerdict(buildVerdict({ responseVerdict: RESPONSE_VERDICT }));
+      const updated = await setThinkingVerdictForOrigin(URL, THINKING_VERDICT);
+      expect(updated).toBe(true);
+      const stored = readStore()[ORIGIN_KEY] as {
+        thinkingVerdict: ThinkingVerdict;
+        responseVerdict: ResponseVerdict;
+        status: string;
+      };
+      expect(stored.thinkingVerdict).toEqual(THINKING_VERDICT);
+      // Pre-existing slots untouched:
+      expect(stored.responseVerdict).toEqual(RESPONSE_VERDICT);
+      expect(stored.status).toBe('CLEAN');
+    });
+
+    it('returns false when no prior record exists', async () => {
+      stubChrome();
+      const updated = await setThinkingVerdictForOrigin(URL, THINKING_VERDICT);
+      expect(updated).toBe(false);
+    });
+  });
+
+  describe('mergeWithStoredVerdict — thinking + response coexistence', () => {
+    it('preserves prior thinkingVerdict on a fresh page-scan write', async () => {
+      stubChrome();
+      await persistVerdict(buildVerdict({ thinkingVerdict: THINKING_VERDICT }));
+      const fresh = buildVerdict({ status: 'SUSPICIOUS', thinkingVerdict: null });
+      const merged = await mergeWithStoredVerdict(fresh);
+      expect(merged.thinkingVerdict).toEqual(THINKING_VERDICT);
+    });
+
+    it('preserves both prior responseVerdict and thinkingVerdict on a fresh page-scan write', async () => {
+      stubChrome();
+      await persistVerdict(buildVerdict({
+        responseVerdict: RESPONSE_VERDICT,
+        thinkingVerdict: THINKING_VERDICT,
+      }));
+      const fresh = buildVerdict({
+        status: 'SUSPICIOUS',
+        responseVerdict: null,
+        thinkingVerdict: null,
+      });
+      const merged = await mergeWithStoredVerdict(fresh);
+      expect(merged.responseVerdict).toEqual(RESPONSE_VERDICT);
+      expect(merged.thinkingVerdict).toEqual(THINKING_VERDICT);
+    });
+
+    it('passes a non-null thinkingVerdict on the input through', async () => {
+      stubChrome();
+      await persistVerdict(buildVerdict({ thinkingVerdict: null }));
+      const next = buildVerdict({ thinkingVerdict: THINKING_VERDICT });
+      const merged = await mergeWithStoredVerdict(next);
+      expect(merged.thinkingVerdict).toEqual(THINKING_VERDICT);
     });
   });
 });

--- a/src/policy/storage.ts
+++ b/src/policy/storage.ts
@@ -61,6 +61,11 @@ export async function persistVerdict(verdict: SecurityVerdict): Promise<void> {
       // chat-portal observer path. Null on origins where no portal response
       // was observed. Page and response verdicts coexist on the same record.
       responseVerdict: verdict.responseVerdict,
+      // Issue #131 (N7c) — additive optional thinking verdict from the
+      // chat-portal thinking observer path. Null on origins where no
+      // thinking block was observed. Page, response, and thinking verdicts
+      // all coexist on the same per-origin record.
+      thinkingVerdict: verdict.thinkingVerdict,
     },
   });
 
@@ -82,8 +87,15 @@ export async function persistVerdict(verdict: SecurityVerdict): Promise<void> {
 export async function mergeWithStoredVerdict(verdict: SecurityVerdict): Promise<SecurityVerdict> {
   const prior = await getVerdict(verdict.url);
   if (prior === null) return verdict;
-  if (verdict.responseVerdict !== null) return verdict;
-  return { ...verdict, responseVerdict: prior.responseVerdict };
+  // Preserve any prior response/thinking verdicts when this rescan's
+  // verdict didn't carry one of its own. Both fields evolve independently
+  // — a page rescan should never clobber a recently-captured chat-portal
+  // analysis on either axis. Each slot is preserved per-axis.
+  return {
+    ...verdict,
+    responseVerdict: verdict.responseVerdict !== null ? verdict.responseVerdict : prior.responseVerdict,
+    thinkingVerdict: verdict.thinkingVerdict !== null ? verdict.thinkingVerdict : prior.thinkingVerdict,
+  };
 }
 
 /**
@@ -111,6 +123,31 @@ export async function setResponseVerdictForOrigin(
   return true;
 }
 
+/**
+ * Issue #131 (N7c) — write only the `thinkingVerdict` slot for an origin,
+ * preserving every page-scan field and the responseVerdict slot on the
+ * prior record byte-for-byte. The thinking analyzer uses this so it
+ * never has to round-trip page-scan fields through persistVerdict.
+ *
+ * Returns true when the prior record existed and was updated. Returns
+ * false when no prior record existed; the caller (analyzer) then writes
+ * a minimal page stub via persistVerdict to give the popup a record to
+ * read on open.
+ */
+export async function setThinkingVerdictForOrigin(
+  url: string,
+  thinkingVerdict: SecurityVerdict['thinkingVerdict'],
+): Promise<boolean> {
+  const key = originKey(url);
+  const result = await chrome.storage.local.get(key);
+  const stored = result[key];
+  if (stored === null || stored === undefined) return false;
+  await chrome.storage.local.set({
+    [key]: { ...(stored as Record<string, unknown>), thinkingVerdict },
+  });
+  return true;
+}
+
 export async function getVerdict(url: string): Promise<SecurityVerdict | null> {
   const key = originKey(url);
   const result = await chrome.storage.local.get(key);
@@ -125,15 +162,19 @@ export async function getVerdict(url: string): Promise<SecurityVerdict | null> {
   // come back with `responseVerdict === undefined`. Coalesce condition
   // is strictly `=== undefined` (never `=== null`) so a migrated record
   // re-saved with a null field round-trips without re-coalescing.
+  // Issue #131 — same migration for thinkingVerdict: pre-#131 verdicts
+  // come back with `thinkingVerdict === undefined`.
   const restored = stored as SecurityVerdict & {
     stamp?: unknown;
     perChunkAnalysis?: unknown;
     responseVerdict?: unknown;
+    thinkingVerdict?: unknown;
   };
   if (
     restored.stamp === undefined ||
     restored.perChunkAnalysis === undefined ||
-    restored.responseVerdict === undefined
+    restored.responseVerdict === undefined ||
+    restored.thinkingVerdict === undefined
   ) {
     return {
       ...(restored as SecurityVerdict),
@@ -144,6 +185,9 @@ export async function getVerdict(url: string): Promise<SecurityVerdict | null> {
       responseVerdict: restored.responseVerdict === undefined
         ? null
         : (restored.responseVerdict as SecurityVerdict['responseVerdict']),
+      thinkingVerdict: restored.thinkingVerdict === undefined
+        ? null
+        : (restored.thinkingVerdict as SecurityVerdict['thinkingVerdict']),
     };
   }
   return restored as SecurityVerdict;

--- a/src/popup/popup-thinking-analysis.test.ts
+++ b/src/popup/popup-thinking-analysis.test.ts
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import type { ThinkingVerdict } from '@/types/portal-response.js';
+import { renderThinkingVerdict } from './thinking-analysis.js';
+
+const VALID: ThinkingVerdict = {
+  portalId: 'gemini',
+  status: 'CLEAN',
+  confidence: 0.94,
+  totalScore: 0,
+  probeResults: [
+    { probeName: 'summarization', passed: true, flags: [], rawOutput: 'ok', score: 0, errorMessage: null },
+    { probeName: 'instruction_detection', passed: true, flags: [], rawOutput: 'ok', score: 0, errorMessage: null },
+  ],
+  behavioralFlags: {
+    roleDrift: false,
+    exfiltrationIntent: false,
+    instructionFollowing: false,
+    hiddenContentAwareness: false,
+  },
+  timestamp: 1714400000000,
+  thinkingTextHash: 'a'.repeat(64),
+  thinkingTextLength: 482,
+  conversationId: 'abc-123',
+  messageId: 'gemini-thinking:I_should_consider',
+  analysisError: null,
+  canaryId: 'gemma-2-2b-mlc',
+};
+
+afterEach(() => {
+  while (document.body.firstChild !== null) document.body.removeChild(document.body.firstChild);
+});
+
+function makeBody(): HTMLElement {
+  const div = document.createElement('div');
+  div.className = 'placeholder';
+  div.id = 'thinking-analysis-body';
+  document.body.appendChild(div);
+  return div;
+}
+
+describe('renderThinkingVerdict', () => {
+  it('renders the placeholder when verdict is undefined', () => {
+    const body = makeBody();
+    renderThinkingVerdict(body, undefined);
+    expect(body.className).toBe('placeholder');
+    expect(body.textContent).toContain('No thinking');
+  });
+
+  it('renders the placeholder when verdict is null', () => {
+    const body = makeBody();
+    renderThinkingVerdict(body, null);
+    expect(body.className).toBe('placeholder');
+    expect(body.textContent).toContain('No thinking');
+  });
+
+  it('renders a CLEAN verdict with portal name and char count', () => {
+    const body = makeBody();
+    renderThinkingVerdict(body, VALID);
+    expect(body.className).toBe('');
+    expect(body.textContent).toContain('CLEAN');
+    expect(body.textContent).toContain('Gemini');
+    expect(body.textContent).toContain('482');
+  });
+
+  it('renders a SUSPICIOUS verdict with the badge class', () => {
+    const body = makeBody();
+    renderThinkingVerdict(body, { ...VALID, status: 'SUSPICIOUS', totalScore: 40 });
+    expect(body.querySelector('.thinking-status-suspicious')).not.toBeNull();
+  });
+
+  it('renders a COMPROMISED verdict with the badge class', () => {
+    const body = makeBody();
+    renderThinkingVerdict(body, { ...VALID, status: 'COMPROMISED', totalScore: 80 });
+    expect(body.querySelector('.thinking-status-compromised')).not.toBeNull();
+  });
+
+  it('renders an UNKNOWN+error verdict with the analysisError message', () => {
+    const body = makeBody();
+    renderThinkingVerdict(body, {
+      ...VALID,
+      status: 'UNKNOWN',
+      probeResults: [],
+      analysisError: 'engine_failure: timeout',
+    });
+    const err = body.querySelector('.thinking-error');
+    expect(err).not.toBeNull();
+    expect(err?.textContent).toContain('engine_failure: timeout');
+  });
+
+  it('renders per-probe rows', () => {
+    const body = makeBody();
+    renderThinkingVerdict(body, VALID);
+    const rows = body.querySelectorAll('.thinking-probe-row');
+    expect(rows.length).toBe(2);
+  });
+
+  it('does not render captured thinking text in the default render', () => {
+    // Privacy posture: thinking text is sensitive enough that the popup
+    // never rolls out an excerpt by default. The accordion shows portal,
+    // chars, score, per-probe rows, and a privacy note — but no body text.
+    const body = makeBody();
+    renderThinkingVerdict(body, {
+      ...VALID,
+      messageId: 'gemini-thinking:secret_user_prompt_text_should_not_render',
+    });
+    expect(body.textContent ?? '').not.toContain('secret_user_prompt_text_should_not_render');
+  });
+
+  it('uses thinking- prefix on every CSS class (no collision with response-)', () => {
+    const body = makeBody();
+    renderThinkingVerdict(body, VALID);
+    expect(body.querySelector('.response-header')).toBeNull();
+    expect(body.querySelector('.response-portal-name')).toBeNull();
+    expect(body.querySelector('.thinking-header')).not.toBeNull();
+    expect(body.querySelector('.thinking-portal-name')).not.toBeNull();
+    expect(body.querySelector('.thinking-privacy-note')).not.toBeNull();
+  });
+});

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -496,6 +496,13 @@
         </div>
       </details>
 
+      <details class="accordion" id="accordion-thinking">
+        <summary>Thinking analysis</summary>
+        <div class="card">
+          <div class="placeholder" id="thinking-analysis-body">No thinking block captured yet — only fires when extended thinking / reasoning is active.</div>
+        </div>
+      </details>
+
       <details class="accordion" id="accordion-mitigations">
         <summary>Mitigations applied</summary>
         <div class="card">

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -25,7 +25,8 @@ import {
 import { renderHunterSummary, type HunterSummary } from './hunter-findings.js';
 import { renderEntitySummary, type EntitySummary } from './entities.js';
 import { renderResponseVerdict } from './response-analysis.js';
-import type { ResponseVerdict } from '@/types/portal-response.js';
+import { renderThinkingVerdict } from './thinking-analysis.js';
+import type { ResponseVerdict, ThinkingVerdict } from '@/types/portal-response.js';
 import { getCacheStats, clearCache } from '@/service-worker/scan-cache.js';
 import { initPendingInterceptPanel } from './pending-intercept.js';
 
@@ -59,6 +60,10 @@ interface StoredVerdict {
   // Issue #126 (N7a) — chat-portal response verdict. Absent on pre-#126
   // verdicts; null on origins where no portal response was observed.
   responseVerdict?: ResponseVerdict | null;
+  // Issue #131 (N7c) — chat-portal thinking-block verdict. Absent on
+  // pre-#131 verdicts; null on origins where no thinking block was
+  // observed (the steady state for most conversations on most portals).
+  thinkingVerdict?: ThinkingVerdict | null;
 }
 
 function $(id: string): HTMLElement {
@@ -392,6 +397,7 @@ async function loadVerdict(): Promise<void> {
   renderHunterSummary($('hunter-findings-body'), verdict.hunterSummary);
   renderEntitySummary($('entities-body'), verdict.entitySummary);
   renderResponseVerdict($('response-analysis-body'), verdict.responseVerdict);
+  renderThinkingVerdict($('thinking-analysis-body'), verdict.thinkingVerdict);
 
   // Issue #113 (N2) — rescan-with-prevention button is verdict-aware:
   // only enabled when the current verdict is SUSPICIOUS or COMPROMISED.

--- a/src/popup/thinking-analysis.ts
+++ b/src/popup/thinking-analysis.ts
@@ -1,0 +1,119 @@
+import type { PortalId, ThinkingVerdict } from '@/types/portal-response.js';
+
+// Issue #131 (N7c) — popup renderer for the chat-portal thinking
+// (reasoning) verdict accordion. Mirrors response-analysis.ts (#126):
+// same `.placeholder` empty state, same `.card` body, same id-based
+// binding (`thinking-analysis-body`). CSS classes prefixed `thinking-`
+// so they don't collide with `response-`.
+//
+// Privacy posture: the accordion shows portal + char count + per-probe
+// rows + a privacy note. It does NOT render the captured thinking text
+// itself by default — thinking blocks frequently contain the user's
+// prompt reformulated, which we treat as more sensitive than the
+// already-public response text.
+
+const PLACEHOLDER_TEXT = 'No thinking block captured yet — only fires when extended thinking / reasoning is active.';
+const PRIVACY_NOTE = 'Thinking analysed locally on-device. Captured text never leaves the browser.';
+
+const PORTAL_DISPLAY_NAME: Record<PortalId, string> = {
+  chatgpt: 'ChatGPT',
+  claude: 'Claude',
+  gemini: 'Gemini',
+};
+
+function statusClass(status: ThinkingVerdict['status']): string {
+  switch (status) {
+    case 'CLEAN':
+      return 'thinking-status-clean';
+    case 'SUSPICIOUS':
+      return 'thinking-status-suspicious';
+    case 'COMPROMISED':
+      return 'thinking-status-compromised';
+    case 'UNKNOWN':
+    default:
+      return 'thinking-status-unknown';
+  }
+}
+
+function renderHeader(verdict: ThinkingVerdict): HTMLElement {
+  const header = document.createElement('div');
+  header.className = 'thinking-header';
+
+  const badge = document.createElement('span');
+  badge.className = `thinking-status-badge ${statusClass(verdict.status)}`;
+  badge.textContent = verdict.status;
+  header.appendChild(badge);
+
+  const portal = document.createElement('span');
+  portal.className = 'thinking-portal-name';
+  portal.textContent = PORTAL_DISPLAY_NAME[verdict.portalId];
+  header.appendChild(portal);
+
+  return header;
+}
+
+function renderMeta(verdict: ThinkingVerdict): HTMLElement {
+  const meta = document.createElement('div');
+  meta.className = 'thinking-meta';
+  meta.textContent = `${verdict.thinkingTextLength} chars · score ${verdict.totalScore}`;
+  return meta;
+}
+
+function renderError(verdict: ThinkingVerdict): HTMLElement {
+  const err = document.createElement('div');
+  err.className = 'thinking-error';
+  err.textContent = `Analysis error: ${verdict.analysisError ?? 'unknown'}`;
+  return err;
+}
+
+function renderProbeRows(verdict: ThinkingVerdict): HTMLElement {
+  const ul = document.createElement('ul');
+  ul.className = 'thinking-probe-list';
+  for (const probe of verdict.probeResults) {
+    const li = document.createElement('li');
+    li.className = `thinking-probe-row ${probe.passed ? 'passed' : 'flagged'}`;
+    const name = document.createElement('span');
+    name.className = 'thinking-probe-name';
+    name.textContent = probe.probeName;
+    const status = document.createElement('span');
+    status.className = 'thinking-probe-status';
+    status.textContent = probe.errorMessage !== null ? 'error' : probe.passed ? 'pass' : 'flag';
+    li.append(name, status);
+    ul.appendChild(li);
+  }
+  return ul;
+}
+
+function renderPrivacyNote(): HTMLElement {
+  const note = document.createElement('div');
+  note.className = 'thinking-privacy-note';
+  note.textContent = PRIVACY_NOTE;
+  return note;
+}
+
+export function renderThinkingVerdict(
+  body: HTMLElement,
+  verdict: ThinkingVerdict | null | undefined,
+): void {
+  if (verdict === null || verdict === undefined) {
+    body.replaceChildren();
+    body.className = 'placeholder';
+    body.textContent = PLACEHOLDER_TEXT;
+    return;
+  }
+
+  const children: Node[] = [renderHeader(verdict), renderMeta(verdict)];
+
+  if (verdict.analysisError !== null) {
+    children.push(renderError(verdict));
+  }
+
+  if (verdict.probeResults.length > 0) {
+    children.push(renderProbeRows(verdict));
+  }
+
+  children.push(renderPrivacyNote());
+
+  body.replaceChildren(...children);
+  body.className = '';
+}

--- a/src/service-worker/dispatch.test.ts
+++ b/src/service-worker/dispatch.test.ts
@@ -64,6 +64,7 @@ function makeVerdict(status: SecurityStatus, analysisError: string | null = null
     perChunkAnalysis: null,
     entitySummary: null,
     responseVerdict: null,
+    thinkingVerdict: null,
   };
 }
 

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -9,6 +9,7 @@ import { createLogger } from '@/shared/logger.js';
 import { startKeepalive } from './keepalive.js';
 import { analyzeSnapshot, AnalysisAbortedError, getInFlightCount, getInFlightTabIds } from './orchestrator.js';
 import { analyzeResponse } from './response-analyzer.js';
+import { analyzeThinking } from './thinking-analyzer.js';
 import { setTabVerdict, handleTabActivated, handleTabRemoved } from './toolbar-icon.js';
 import { ensureInstallSecret } from '@/shared/install-secret.js';
 import { verifyStamp } from './stamp.js';
@@ -89,6 +90,23 @@ chrome.runtime.onMessage.addListener((message: HoneyLLMMessage, sender, sendResp
       }
       analyzeResponse(tabId, message.capture, message.metadata).catch((err) => {
         log.error('Response analysis failed', err);
+      });
+      return;
+    }
+
+    // Issue #131 (N7c) — chat-portal thinking observers dispatch
+    // THINKING_CAPTURED when an assistant reasoning block finishes
+    // streaming. Distinct analyzer + telemetry slot from #126 so a
+    // CLEAN response with SUSPICIOUS thinking is visibly different in
+    // the popup. No mitigations.
+    case 'THINKING_CAPTURED': {
+      const tabId = sender.tab?.id ?? message.tabId;
+      if (tabId === undefined) {
+        log.warn('Received THINKING_CAPTURED without tab ID');
+        return;
+      }
+      analyzeThinking(tabId, message.capture, message.metadata).catch((err) => {
+        log.error('Thinking analysis failed', err);
       });
       return;
     }

--- a/src/service-worker/orchestrator.ts
+++ b/src/service-worker/orchestrator.ts
@@ -147,6 +147,9 @@ export function buildOriginSkippedVerdict(
     // Issue #126 — origin-skipped origins never run portal observers; the
     // response-analyzer path is mutually exclusive with the page-skip path.
     responseVerdict: null,
+    // Issue #131 — same exclusivity: origin-skipped pages never observe a
+    // thinking block.
+    thinkingVerdict: null,
   };
 }
 

--- a/src/service-worker/thinking-analyzer.test.ts
+++ b/src/service-worker/thinking-analyzer.test.ts
@@ -1,0 +1,305 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Chunk } from '@/types/chunk.js';
+import type { ProbeResult } from '@/types/verdict.js';
+import type { CapturedThinking } from '@/types/portal-response.js';
+import {
+  STORAGE_KEY_PREFIX,
+  STORAGE_KEY_THINKING_TELEMETRY,
+  THINKING_CHUNK_INDEX_OFFSET,
+} from '@/shared/constants.js';
+
+// --- mocks must precede the SUT import ---
+
+const runChunkProbesMock =
+  vi.fn<(args: { tabId: number; chunk: string; chunkIndex: number; totalChunks: number; url: string; origin: string; evidencePackets: readonly unknown[] }) =>
+    Promise<{ results: readonly ProbeResult[]; canaryId: string | null; webgpuAdapterMode: string | null }>>();
+
+vi.mock('./orchestrator.js', async () => {
+  const actual = await vi.importActual<typeof import('./orchestrator.js')>('./orchestrator.js');
+  return {
+    ...actual,
+    runChunkProbes: (args: Parameters<typeof runChunkProbesMock>[0]) => runChunkProbesMock(args),
+  };
+});
+
+const chunkTextMock = vi.fn<(text: string) => Promise<readonly Chunk[]>>();
+vi.mock('@/hunters/hawk/chunking.js', () => ({
+  chunkText: (text: string) => chunkTextMock(text),
+}));
+
+vi.mock('./offscreen-manager.js', () => ({
+  ensureOffscreenDocument: async () => undefined,
+}));
+
+import { __resetThinkingDedupCacheForTest, analyzeThinking } from './thinking-analyzer.js';
+
+// --- helpers ---
+
+const URL = 'https://chatgpt.com/c/abc-123';
+const ORIGIN = 'https://chatgpt.com';
+const ORIGIN_KEY = STORAGE_KEY_PREFIX + ORIGIN;
+
+function buildCapture(overrides: Partial<CapturedThinking> = {}): CapturedThinking {
+  return {
+    portalId: 'chatgpt',
+    text: 'I need to think carefully about whether to follow that instruction.',
+    capturedAt: 1714400500000,
+    conversationId: 'abc-123',
+    messageId: 'chatgpt-thinking:msg-1',
+    streamComplete: true,
+    ...overrides,
+  };
+}
+
+function buildChunk(index: number, text: string): Chunk {
+  const hex = (index + 1).toString(16).padStart(64, '0');
+  return { text, start: index * 100, end: index * 100 + text.length, contentHash: hex };
+}
+
+function buildProbeResult(probeName: string, passed: boolean, score: number = 0): ProbeResult {
+  return { probeName, passed, flags: passed ? [] : [`${probeName}:flag`], rawOutput: 'ok', score, errorMessage: null };
+}
+
+interface ChromeContext {
+  readonly readStore: () => Record<string, unknown>;
+  readonly tabsSendMessageMock: ReturnType<typeof vi.fn>;
+}
+
+function setupChrome(initialStore: Record<string, unknown> = {}): ChromeContext {
+  const store: Record<string, unknown> = { ...initialStore };
+  const tabsSendMessageMock = vi.fn(async (_tabId: number, _msg: unknown) => undefined);
+  vi.stubGlobal('chrome', {
+    storage: {
+      local: {
+        get: async (key?: string | string[] | null) => {
+          if (key === undefined || key === null) return { ...store };
+          if (Array.isArray(key)) {
+            const out: Record<string, unknown> = {};
+            for (const k of key) if (k in store) out[k] = store[k];
+            return out;
+          }
+          return key in store ? { [key]: store[key] } : {};
+        },
+        set: async (items: Record<string, unknown>) => {
+          Object.assign(store, items);
+        },
+        remove: async () => undefined,
+      },
+    },
+    tabs: { sendMessage: tabsSendMessageMock },
+  });
+  return { readStore: () => store, tabsSendMessageMock };
+}
+
+function defaultProbeResolver(): readonly ProbeResult[] {
+  return [
+    buildProbeResult('summarization', true, 0),
+    buildProbeResult('instruction_detection', true, 0),
+    buildProbeResult('adversarial_compliance', true, 0),
+  ];
+}
+
+beforeEach(() => {
+  vi.unstubAllGlobals();
+  __resetThinkingDedupCacheForTest();
+  runChunkProbesMock.mockReset();
+  chunkTextMock.mockReset();
+  chunkTextMock.mockImplementation(async (text: string) => [buildChunk(0, text)]);
+  runChunkProbesMock.mockImplementation(async () => ({
+    results: defaultProbeResolver(),
+    canaryId: 'gemma-2-2b-mlc',
+    webgpuAdapterMode: 'core',
+  }));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('analyzeThinking', () => {
+  it('runs chunkText and runChunkProbes once on a small thinking block', async () => {
+    setupChrome();
+    await analyzeThinking(7, buildCapture(), { url: URL, origin: ORIGIN });
+    expect(chunkTextMock).toHaveBeenCalledTimes(1);
+    expect(runChunkProbesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('offsets every chunkIndex by THINKING_CHUNK_INDEX_OFFSET', async () => {
+    setupChrome();
+    chunkTextMock.mockResolvedValueOnce([buildChunk(0, 'A'), buildChunk(1, 'B')]);
+    await analyzeThinking(7, buildCapture({ text: 'AB' }), { url: URL, origin: ORIGIN });
+    expect(runChunkProbesMock).toHaveBeenCalledTimes(2);
+    const indexes = runChunkProbesMock.mock.calls.map((c) => c[0].chunkIndex);
+    expect(indexes).toEqual([
+      THINKING_CHUNK_INDEX_OFFSET,
+      THINKING_CHUNK_INDEX_OFFSET + 1,
+    ]);
+  });
+
+  it('passes empty evidencePackets to runChunkProbes', async () => {
+    setupChrome();
+    await analyzeThinking(7, buildCapture(), { url: URL, origin: ORIGIN });
+    expect(runChunkProbesMock.mock.calls[0]?.[0].evidencePackets).toEqual([]);
+  });
+
+  it('returns UNKNOWN with analysisError "empty_thinking" on whitespace-only text', async () => {
+    setupChrome();
+    const result = await analyzeThinking(7, buildCapture({ text: '   \n  ' }), { url: URL, origin: ORIGIN });
+    expect(result?.status).toBe('UNKNOWN');
+    expect(result?.analysisError).toBe('empty_thinking');
+    expect(chunkTextMock).not.toHaveBeenCalled();
+    expect(runChunkProbesMock).not.toHaveBeenCalled();
+  });
+
+  it('persists thinkingVerdict onto an existing page verdict, preserving page fields', async () => {
+    const { readStore } = setupChrome({
+      [ORIGIN_KEY]: {
+        status: 'CLEAN',
+        confidence: 0.95,
+        totalScore: 0,
+        timestamp: 1700000000000,
+        url: URL,
+        flags: [],
+        behavioralFlags: { roleDrift: false, exfiltrationIntent: false, instructionFollowing: false, hiddenContentAwareness: false },
+        analysisError: null,
+        canaryId: 'gemma-2-2b-mlc',
+        stamp: null,
+        hunterSummary: null,
+        entitySummary: null,
+        responseVerdict: null,
+        thinkingVerdict: null,
+        perChunkAnalysis: null,
+      },
+    });
+    await analyzeThinking(7, buildCapture(), { url: URL, origin: ORIGIN });
+    const stored = readStore()[ORIGIN_KEY] as { status: string; thinkingVerdict: { portalId: string } };
+    expect(stored.status).toBe('CLEAN');
+    expect(stored.thinkingVerdict?.portalId).toBe('chatgpt');
+  });
+
+  it('writes a minimal page-stub with thinkingVerdict when no prior verdict exists', async () => {
+    const { readStore } = setupChrome();
+    await analyzeThinking(7, buildCapture(), { url: URL, origin: ORIGIN });
+    const stored = readStore()[ORIGIN_KEY] as {
+      status: string;
+      analysisError: string | null;
+      thinkingVerdict: { portalId: string };
+      responseVerdict: { portalId: string } | null;
+    };
+    expect(stored.status).toBe('UNKNOWN');
+    expect(stored.analysisError).toBe('page_scan_pending');
+    expect(stored.thinkingVerdict.portalId).toBe('chatgpt');
+    // The thinking-stub never carries a responseVerdict; both slots
+    // evolve independently.
+    expect(stored.responseVerdict).toBeNull();
+  });
+
+  it('dispatches VERDICT to the tab via chrome.tabs.sendMessage', async () => {
+    const { tabsSendMessageMock } = setupChrome();
+    await analyzeThinking(7, buildCapture(), { url: URL, origin: ORIGIN });
+    expect(tabsSendMessageMock).toHaveBeenCalledTimes(1);
+    expect(tabsSendMessageMock.mock.calls[0]?.[0]).toBe(7);
+    const payload = tabsSendMessageMock.mock.calls[0]?.[1] as { type: string };
+    expect(payload.type).toBe('VERDICT');
+  });
+
+  it('never dispatches APPLY_MITIGATION even when probes flag the thinking', async () => {
+    const { tabsSendMessageMock } = setupChrome();
+    runChunkProbesMock.mockResolvedValueOnce({
+      results: [buildProbeResult('summarization', false, 80)],
+      canaryId: 'gemma-2-2b-mlc',
+      webgpuAdapterMode: 'core',
+    });
+    await analyzeThinking(7, buildCapture(), { url: URL, origin: ORIGIN });
+    const types = tabsSendMessageMock.mock.calls.map((c) => (c[1] as { type: string }).type);
+    expect(types).not.toContain('APPLY_MITIGATION');
+  });
+
+  it('dedupes a re-capture of the same (messageId, textHash) for the same tab', async () => {
+    setupChrome();
+    const cap = buildCapture();
+    await analyzeThinking(7, cap, { url: URL, origin: ORIGIN });
+    await analyzeThinking(7, cap, { url: URL, origin: ORIGIN });
+    expect(runChunkProbesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs again when the same messageId carries new text', async () => {
+    setupChrome();
+    await analyzeThinking(7, buildCapture({ text: 'first thought' }), { url: URL, origin: ORIGIN });
+    await analyzeThinking(7, buildCapture({ text: 'second thought (revised)' }), { url: URL, origin: ORIGIN });
+    expect(runChunkProbesMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('truncates input over MAX_THINKING_TEXT_CHARS and surfaces "thinking_truncated"', async () => {
+    const { readStore } = setupChrome();
+    const longText = 'x'.repeat(120_000);
+    await analyzeThinking(7, buildCapture({ text: longText }), { url: URL, origin: ORIGIN });
+    const stored = readStore()[ORIGIN_KEY] as { thinkingVerdict: { thinkingTextLength: number; analysisError: string | null } };
+    expect(stored.thinkingVerdict.thinkingTextLength).toBe(80_000);
+    expect(stored.thinkingVerdict.analysisError).toBe('thinking_truncated');
+  });
+
+  it('surfaces analysisError when runChunkProbes throws', async () => {
+    const { readStore } = setupChrome();
+    runChunkProbesMock.mockRejectedValueOnce(new Error('engine boom'));
+    await analyzeThinking(7, buildCapture(), { url: URL, origin: ORIGIN });
+    const stored = readStore()[ORIGIN_KEY] as { thinkingVerdict: { status: string; analysisError: string | null } };
+    expect(stored.thinkingVerdict.status).toBe('UNKNOWN');
+    expect(stored.thinkingVerdict.analysisError).toContain('engine boom');
+  });
+
+  it('increments per-portal capture and analysis counters in thinking-telemetry', async () => {
+    const { readStore } = setupChrome();
+    await analyzeThinking(7, buildCapture({ portalId: 'claude', messageId: 'claude-thinking:m-1' }), { url: 'https://claude.ai/chat/x', origin: 'https://claude.ai' });
+    await analyzeThinking(7, buildCapture({ portalId: 'gemini', messageId: 'gemini-thinking:m-2' }), { url: 'https://gemini.google.com/?c=y', origin: 'https://gemini.google.com' });
+    const t = readStore()[STORAGE_KEY_THINKING_TELEMETRY] as { captured: Record<string, number>; analysed: Record<string, number> };
+    expect(t.captured.claude).toBe(1);
+    expect(t.captured.gemini).toBe(1);
+    expect(t.analysed.claude).toBe(1);
+    expect(t.analysed.gemini).toBe(1);
+  });
+
+  it('counts SUSPICIOUS verdicts in thinking-telemetry', async () => {
+    const { readStore } = setupChrome();
+    runChunkProbesMock.mockResolvedValueOnce({
+      results: [buildProbeResult('instruction_detection', false, 80)],
+      canaryId: 'gemma-2-2b-mlc',
+      webgpuAdapterMode: 'core',
+    });
+    await analyzeThinking(7, buildCapture(), { url: URL, origin: ORIGIN });
+    const t = readStore()[STORAGE_KEY_THINKING_TELEMETRY] as { suspicious: number };
+    expect(t.suspicious).toBeGreaterThanOrEqual(1);
+  });
+
+  it('preserves a prior responseVerdict slot when writing the thinking slot', async () => {
+    const { readStore } = setupChrome({
+      [ORIGIN_KEY]: {
+        status: 'CLEAN',
+        confidence: 0.95,
+        totalScore: 0,
+        timestamp: 1700000000000,
+        url: URL,
+        flags: [],
+        behavioralFlags: { roleDrift: false, exfiltrationIntent: false, instructionFollowing: false, hiddenContentAwareness: false },
+        analysisError: null,
+        canaryId: 'gemma-2-2b-mlc',
+        stamp: null,
+        hunterSummary: null,
+        entitySummary: null,
+        // Pre-existing responseVerdict stays intact through the thinking write.
+        responseVerdict: { portalId: 'chatgpt', status: 'CLEAN', responseTextLength: 12 },
+        thinkingVerdict: null,
+        perChunkAnalysis: null,
+      },
+    });
+    await analyzeThinking(7, buildCapture(), { url: URL, origin: ORIGIN });
+    const stored = readStore()[ORIGIN_KEY] as {
+      responseVerdict: { portalId: string; responseTextLength: number };
+      thinkingVerdict: { portalId: string };
+    };
+    expect(stored.responseVerdict.portalId).toBe('chatgpt');
+    expect(stored.responseVerdict.responseTextLength).toBe(12);
+    expect(stored.thinkingVerdict.portalId).toBe('chatgpt');
+  });
+});

--- a/src/service-worker/thinking-analyzer.ts
+++ b/src/service-worker/thinking-analyzer.ts
@@ -1,20 +1,20 @@
 import type { ProbeResult, SecurityVerdict } from '@/types/verdict.js';
 import type {
-  CapturedResponse,
+  CapturedThinking,
   PortalId,
-  ResponseVerdict,
+  ThinkingVerdict,
 } from '@/types/portal-response.js';
 import type { VerdictMessage } from '@/types/messages.js';
 import {
-  MAX_RESPONSE_TEXT_CHARS,
-  RESPONSE_CHUNK_INDEX_OFFSET,
-  STORAGE_KEY_RESPONSE_TELEMETRY,
+  MAX_THINKING_TEXT_CHARS,
+  STORAGE_KEY_THINKING_TELEMETRY,
+  THINKING_CHUNK_INDEX_OFFSET,
 } from '@/shared/constants.js';
 import { sha256Hex } from '@/shared/hash.js';
 import { chunkText } from '@/hunters/hawk/chunking.js';
 import { analyzeBehavior } from '@/analysis/behavioral-analyzer.js';
 import { evaluatePolicy } from '@/policy/engine.js';
-import { persistVerdict, setResponseVerdictForOrigin } from '@/policy/storage.js';
+import { persistVerdict, setThinkingVerdictForOrigin } from '@/policy/storage.js';
 import { ensureOffscreenDocument } from './offscreen-manager.js';
 import {
   computeAggregateError,
@@ -23,7 +23,7 @@ import {
 } from './orchestrator.js';
 import { createLogger } from '@/shared/logger.js';
 
-const log = createLogger('ResponseAnalyzer');
+const log = createLogger('ThinkingAnalyzer');
 
 /** Per-tab dedup cache: tabId → set of `${messageId}:${hashPrefix}` keys. */
 const dedupCache = new Map<number, Set<string>>();
@@ -34,7 +34,7 @@ interface PerPortalCounts {
   readonly gemini: number;
 }
 
-interface ResponseTelemetry {
+interface ThinkingTelemetry {
   readonly captured: PerPortalCounts;
   readonly analysed: PerPortalCounts;
   readonly suspicious: number;
@@ -45,7 +45,7 @@ interface ResponseTelemetry {
 
 const ZERO_COUNTS: PerPortalCounts = { chatgpt: 0, claude: 0, gemini: 0 };
 
-function emptyTelemetry(now: number): ResponseTelemetry {
+function emptyTelemetry(now: number): ThinkingTelemetry {
   return {
     captured: { ...ZERO_COUNTS },
     analysed: { ...ZERO_COUNTS },
@@ -56,16 +56,16 @@ function emptyTelemetry(now: number): ResponseTelemetry {
   };
 }
 
-async function readTelemetry(): Promise<ResponseTelemetry> {
+async function readTelemetry(): Promise<ThinkingTelemetry> {
   try {
-    const r = await chrome.storage.local.get(STORAGE_KEY_RESPONSE_TELEMETRY);
-    const v = r[STORAGE_KEY_RESPONSE_TELEMETRY];
+    const r = await chrome.storage.local.get(STORAGE_KEY_THINKING_TELEMETRY);
+    const v = r[STORAGE_KEY_THINKING_TELEMETRY];
     if (
       typeof v === 'object' &&
       v !== null &&
-      typeof (v as ResponseTelemetry).suspicious === 'number'
+      typeof (v as ThinkingTelemetry).suspicious === 'number'
     ) {
-      return v as ResponseTelemetry;
+      return v as ThinkingTelemetry;
     }
   } catch (err) {
     log.warn('readTelemetry failed', err);
@@ -73,9 +73,9 @@ async function readTelemetry(): Promise<ResponseTelemetry> {
   return emptyTelemetry(Date.now());
 }
 
-async function writeTelemetry(t: ResponseTelemetry): Promise<void> {
+async function writeTelemetry(t: ThinkingTelemetry): Promise<void> {
   try {
-    await chrome.storage.local.set({ [STORAGE_KEY_RESPONSE_TELEMETRY]: t });
+    await chrome.storage.local.set({ [STORAGE_KEY_THINKING_TELEMETRY]: t });
   } catch (err) {
     log.warn('writeTelemetry failed', err);
   }
@@ -87,10 +87,10 @@ function bumpPortal(counts: PerPortalCounts, portalId: PortalId): PerPortalCount
 
 async function recordTelemetry(
   portalId: PortalId,
-  outcome: { analysed: boolean; status: ResponseVerdict['status']; error: boolean },
+  outcome: { analysed: boolean; status: ThinkingVerdict['status']; error: boolean },
 ): Promise<void> {
   const prior = await readTelemetry();
-  const next: ResponseTelemetry = {
+  const next: ThinkingTelemetry = {
     ...prior,
     captured: bumpPortal(prior.captured, portalId),
     analysed: outcome.analysed ? bumpPortal(prior.analysed, portalId) : prior.analysed,
@@ -101,7 +101,7 @@ async function recordTelemetry(
   await writeTelemetry(next);
 }
 
-function buildMinimalPageStub(url: string, timestamp: number, responseVerdict: ResponseVerdict): SecurityVerdict {
+function buildMinimalPageStub(url: string, timestamp: number, thinkingVerdict: ThinkingVerdict): SecurityVerdict {
   return {
     status: 'UNKNOWN',
     confidence: 0,
@@ -122,10 +122,8 @@ function buildMinimalPageStub(url: string, timestamp: number, responseVerdict: R
     stamp: null,
     perChunkAnalysis: null,
     entitySummary: null,
-    responseVerdict,
-    // Issue #131 — the response-analyzer's stub never carries a thinking
-    // verdict; the thinking analyzer writes its own slot independently.
-    thinkingVerdict: null,
+    responseVerdict: null,
+    thinkingVerdict,
   };
 }
 
@@ -157,20 +155,20 @@ function markSeen(tabId: number, key: string): void {
   seen.add(key);
 }
 
-function buildResponseVerdict(args: {
-  readonly capture: CapturedResponse;
+function buildThinkingVerdict(args: {
+  readonly capture: CapturedThinking;
   readonly truncated: boolean;
-  readonly status: ResponseVerdict['status'];
+  readonly status: ThinkingVerdict['status'];
   readonly confidence: number;
   readonly totalScore: number;
   readonly probeResults: readonly ProbeResult[];
-  readonly behavioralFlags: ResponseVerdict['behavioralFlags'];
-  readonly responseTextHash: string;
-  readonly responseTextLength: number;
+  readonly behavioralFlags: ThinkingVerdict['behavioralFlags'];
+  readonly thinkingTextHash: string;
+  readonly thinkingTextLength: number;
   readonly analysisError: string | null;
   readonly canaryId: string | null;
   readonly timestamp: number;
-}): ResponseVerdict {
+}): ThinkingVerdict {
   const { capture } = args;
   return {
     portalId: capture.portalId,
@@ -180,11 +178,11 @@ function buildResponseVerdict(args: {
     probeResults: args.probeResults,
     behavioralFlags: args.behavioralFlags,
     timestamp: args.timestamp,
-    responseTextHash: args.responseTextHash,
-    responseTextLength: args.responseTextLength,
+    thinkingTextHash: args.thinkingTextHash,
+    thinkingTextLength: args.thinkingTextLength,
     conversationId: capture.conversationId,
     messageId: capture.messageId,
-    analysisError: args.truncated ? mergeAnalysisError('response_truncated', args.analysisError) : args.analysisError,
+    analysisError: args.truncated ? mergeAnalysisError('thinking_truncated', args.analysisError) : args.analysisError,
     canaryId: args.canaryId,
   };
 }
@@ -195,27 +193,27 @@ function mergeAnalysisError(a: string | null, b: string | null): string | null {
   return `${a}; ${b}`;
 }
 
-
 /**
- * Issue #126 (N7a) — entry point dispatched from the SW's
- * `RESPONSE_CAPTURED` handler. Runs the existing 3-probe stack against
- * the captured chat-portal response text and writes a `ResponseVerdict`
- * onto the per-origin `SecurityVerdict`. Never applies mitigations:
- * response mitigations are out of Stage 2 scope.
+ * Issue #131 (N7c) — entry point dispatched from the SW's
+ * `THINKING_CAPTURED` handler. Runs the existing 3-probe stack against
+ * the captured thinking-block text and writes a `ThinkingVerdict` onto
+ * the per-origin `SecurityVerdict`. Never applies mitigations.
  */
-export async function analyzeResponse(
+export async function analyzeThinking(
   tabId: number,
-  capture: CapturedResponse,
+  capture: CapturedThinking,
   metadata: { readonly url: string; readonly origin: string },
-): Promise<ResponseVerdict | null> {
+): Promise<ThinkingVerdict | null> {
   const trimmed = capture.text.trim();
   const timestamp = Date.now();
-  const truncated = capture.text.length > MAX_RESPONSE_TEXT_CHARS;
-  const effectiveText = truncated ? capture.text.slice(0, MAX_RESPONSE_TEXT_CHARS) : capture.text;
+  const truncated = capture.text.length > MAX_THINKING_TEXT_CHARS;
+  const effectiveText = truncated ? capture.text.slice(0, MAX_THINKING_TEXT_CHARS) : capture.text;
 
-  // Empty-response short-circuit: no chunking, no probes.
+  // Empty-thinking short-circuit: no chunking, no probes. Empty thinking
+  // is the dominant case across portals (most conversations are not in
+  // thinking mode); we want this path to be cheap.
   if (trimmed.length === 0) {
-    const verdict: ResponseVerdict = buildResponseVerdict({
+    const verdict: ThinkingVerdict = buildThinkingVerdict({
       capture,
       truncated: false,
       status: 'UNKNOWN',
@@ -228,19 +226,19 @@ export async function analyzeResponse(
         instructionFollowing: false,
         hiddenContentAwareness: false,
       },
-      responseTextHash: await sha256Hex(''),
-      responseTextLength: 0,
-      analysisError: 'empty_response',
+      thinkingTextHash: await sha256Hex(''),
+      thinkingTextLength: 0,
+      analysisError: 'empty_thinking',
       canaryId: null,
       timestamp,
     });
-    await writeVerdict(tabId, capture, verdict, metadata.url, timestamp);
+    await writeVerdict(tabId, verdict, metadata.url, timestamp);
     await recordTelemetry(capture.portalId, { analysed: false, status: 'UNKNOWN', error: false });
     return verdict;
   }
 
-  const responseTextHash = await sha256Hex(effectiveText);
-  const key = dedupKey(capture.messageId, responseTextHash);
+  const thinkingTextHash = await sha256Hex(effectiveText);
+  const key = dedupKey(capture.messageId, thinkingTextHash);
   if (isDuplicate(tabId, key)) {
     log.info(`[${capture.portalId}] dedup-skip messageId=${capture.messageId}`);
     return null;
@@ -261,7 +259,7 @@ export async function analyzeResponse(
       const r = await runChunkProbes({
         tabId,
         chunk: chunk.text,
-        chunkIndex: i + RESPONSE_CHUNK_INDEX_OFFSET,
+        chunkIndex: i + THINKING_CHUNK_INDEX_OFFSET,
         totalChunks,
         url: metadata.url,
         origin: metadata.origin,
@@ -277,10 +275,8 @@ export async function analyzeResponse(
   }
 
   const behavioralFlags = analyzeBehavior(probeResults);
-  // When the probe stack threw, evaluatePolicy on an empty probeResults
-  // would fall through to score-0 CLEAN — silently masking the engine
-  // failure. Force UNKNOWN with confidence 0 so the popup distinguishes
-  // "analysed and clean" from "couldn't analyse."
+  // Force UNKNOWN on engine failure so a probe-stack error doesn't
+  // silently emerge as score-0 CLEAN; mirrors response-analyzer.ts.
   const verdict0 = chunkError !== null
     ? null
     : evaluatePolicy(
@@ -292,7 +288,7 @@ export async function analyzeResponse(
         null,
       );
 
-  const responseVerdict = buildResponseVerdict({
+  const thinkingVerdict = buildThinkingVerdict({
     capture,
     truncated,
     status: verdict0?.status ?? 'UNKNOWN',
@@ -300,50 +296,49 @@ export async function analyzeResponse(
     totalScore: verdict0?.totalScore ?? 0,
     probeResults,
     behavioralFlags,
-    responseTextHash,
-    responseTextLength: effectiveText.length,
+    thinkingTextHash,
+    thinkingTextLength: effectiveText.length,
     analysisError: chunkError ?? verdict0?.analysisError ?? null,
     canaryId,
     timestamp,
   });
 
-  await writeVerdict(tabId, capture, responseVerdict, metadata.url, timestamp);
+  await writeVerdict(tabId, thinkingVerdict, metadata.url, timestamp);
   await recordTelemetry(capture.portalId, {
     analysed: chunkError === null,
-    status: responseVerdict.status,
+    status: thinkingVerdict.status,
     error: chunkError !== null,
   });
 
   log.info(
-    `[${capture.portalId}] response analysed: status=${responseVerdict.status} chars=${responseVerdict.responseTextLength}`,
+    `[${capture.portalId}] thinking analysed: status=${thinkingVerdict.status} chars=${thinkingVerdict.thinkingTextLength}`,
   );
-  return responseVerdict;
+  return thinkingVerdict;
 }
 
 async function writeVerdict(
   tabId: number,
-  _capture: CapturedResponse,
-  responseVerdict: ResponseVerdict,
+  thinkingVerdict: ThinkingVerdict,
   url: string,
   timestamp: number,
 ): Promise<void> {
-  const updated = await setResponseVerdictForOrigin(url, responseVerdict);
+  const updated = await setThinkingVerdictForOrigin(url, thinkingVerdict);
   if (!updated) {
     // No prior page record — write a minimal stub so the popup has a
     // record to read on open. The eventual page scan will use
-    // mergeWithStoredVerdict to retain the responseVerdict written here.
-    const stub = buildMinimalPageStub(url, timestamp, responseVerdict);
+    // mergeWithStoredVerdict to retain the thinkingVerdict written here.
+    const stub = buildMinimalPageStub(url, timestamp, thinkingVerdict);
     await persistVerdict(stub);
     await notifyTab(tabId, stub);
     return;
   }
   // The popup is the source of truth via storage; the VERDICT message
   // is a refresh trigger. The verdict payload here is best-effort.
-  const stub = buildMinimalPageStub(url, timestamp, responseVerdict);
+  const stub = buildMinimalPageStub(url, timestamp, thinkingVerdict);
   await notifyTab(tabId, stub);
 }
 
 /** Test-only helper — clears the per-tab dedup cache. */
-export function __resetDedupCacheForTest(): void {
+export function __resetThinkingDedupCacheForTest(): void {
   dedupCache.clear();
 }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -451,3 +451,25 @@ export const INTERCEPT_OVERRIDE_WHITELIST_THRESHOLD = 3;
  * tabId. 2_000_000 stays well under Number.MAX_SAFE_INTEGER.
  */
 export const INTERCEPT_CHUNK_INDEX_OFFSET = 2_000_000;
+
+/**
+ * Issue #131 (N7c) — chat-portal thinking-block (reasoning) inspection
+ * storage + tuning.
+ *
+ * STORAGE_KEY_THINKING_TELEMETRY: per-portal capture/analysis counts for
+ * the thinking observer. Same shape as STORAGE_KEY_RESPONSE_TELEMETRY but
+ * a distinct key so the response and thinking surfaces don't trample each
+ * other on read-modify-write.
+ *
+ * THINKING_CHUNK_INDEX_OFFSET: stratifies PROBE_RESULTS routing alongside
+ * RESPONSE_CHUNK_INDEX_OFFSET (1M) and INTERCEPT_CHUNK_INDEX_OFFSET (2M).
+ * 3M stays well under Number.MAX_SAFE_INTEGER and reserves 4M+ for future
+ * observer surfaces.
+ *
+ * MAX_THINKING_TEXT_CHARS: hard cap on captured thinking text length
+ * before truncation. Beyond this size the analyzer truncates and surfaces
+ * `analysisError = 'thinking_truncated'`. Mirrors MAX_RESPONSE_TEXT_CHARS.
+ */
+export const STORAGE_KEY_THINKING_TELEMETRY = 'honeyllm:thinking-telemetry';
+export const THINKING_CHUNK_INDEX_OFFSET = 3_000_000;
+export const MAX_THINKING_TEXT_CHARS = 80_000;

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -1,7 +1,7 @@
 import type { PageSnapshot } from './snapshot.js';
 import type { ProbeResult, SecurityStatus, SecurityVerdict, WebGPUAdapterMode } from './verdict.js';
 import type { VerifyStampResult } from './page-stamp.js';
-import type { CapturedResponse } from './portal-response.js';
+import type { CapturedResponse, CapturedThinking } from './portal-response.js';
 import type { EvidencePacket } from '@/probes/base-probe.js';
 import type { Entity } from '@/hunters/ner/types.js';
 
@@ -63,7 +63,15 @@ export type MessageType =
   | 'INTERCEPT_SCAN_REQUEST'
   | 'INTERCEPT_VERDICT'
   | 'PARSE_HTML_REQUEST'
-  | 'PARSE_HTML_RESULT';
+  | 'PARSE_HTML_RESULT'
+  // Issue #131 (N7c) — chat-portal thinking observer dispatches
+  // THINKING_CAPTURED when an assistant reasoning block finishes
+  // streaming. Handled by the SW's thinking-analyzer; runs the existing
+  // 3-probe stack against the captured thinking text and writes a
+  // ThinkingVerdict back via setThinkingVerdictForOrigin. Distinct from
+  // RESPONSE_CAPTURED — separate analyzer, separate telemetry, separate
+  // dedup cache, separate chunk-index offset.
+  | 'THINKING_CAPTURED';
 
 interface BaseMessage {
   readonly type: MessageType;
@@ -360,6 +368,20 @@ export interface ParseHtmlResultMessage extends BaseMessage {
   readonly errorMessage: string | null;
 }
 
+// Issue #131 (N7c) — content-script dispatches THINKING_CAPTURED to the
+// SW when a chat-portal assistant thinking/reasoning block finishes
+// streaming. Same dispatch shape as ResponseCapturedMessage; the SW
+// thinking-analyzer reads `tabId` from `sender.tab?.id ?? message.tabId`
+// (mirrors the PageSnapshotMessage convention) and routes to
+// `analyzeThinking(tabId, message.capture)`. Page URL/origin travels in
+// `metadata` so the analyzer never needs `chrome.tabs.get`.
+export interface ThinkingCapturedMessage extends BaseMessage {
+  readonly type: 'THINKING_CAPTURED';
+  readonly tabId: number;
+  readonly capture: CapturedThinking;
+  readonly metadata: { readonly url: string; readonly origin: string };
+}
+
 export type HoneyLLMMessage =
   | PageSnapshotMessage
   | RunProbesMessage
@@ -387,4 +409,5 @@ export type HoneyLLMMessage =
   | InterceptScanRequestMessage
   | InterceptVerdictMessage
   | ParseHtmlRequestMessage
-  | ParseHtmlResultMessage;
+  | ParseHtmlResultMessage
+  | ThinkingCapturedMessage;

--- a/src/types/portal-response.test.ts
+++ b/src/types/portal-response.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { isResponseVerdict, type ResponseVerdict } from './portal-response.js';
+import {
+  isResponseVerdict,
+  isThinkingVerdict,
+  type ResponseVerdict,
+  type ThinkingVerdict,
+} from './portal-response.js';
 
 const VALID: ResponseVerdict = {
   portalId: 'chatgpt',
@@ -88,5 +93,70 @@ describe('isResponseVerdict', () => {
 
   it('returns false when canaryId is not string-or-null', () => {
     expect(isResponseVerdict({ ...VALID, canaryId: 42 })).toBe(false);
+  });
+});
+
+const VALID_THINKING: ThinkingVerdict = {
+  portalId: 'gemini',
+  status: 'SUSPICIOUS',
+  confidence: 0.61,
+  totalScore: 38,
+  probeResults: [
+    { probeName: 'instruction_detection', passed: false, flags: ['injection_detected'], rawOutput: 'ok', score: 25, errorMessage: null },
+  ],
+  behavioralFlags: {
+    roleDrift: true,
+    exfiltrationIntent: false,
+    instructionFollowing: false,
+    hiddenContentAwareness: false,
+  },
+  timestamp: 1714400500000,
+  thinkingTextHash: 'b'.repeat(64),
+  thinkingTextLength: 482,
+  conversationId: null,
+  messageId: 'gemini-thinking:fallback:I_should_consider',
+  analysisError: null,
+  canaryId: 'gemma-2-2b-mlc',
+};
+
+describe('isThinkingVerdict', () => {
+  it('returns true for a fully populated record', () => {
+    expect(isThinkingVerdict(VALID_THINKING)).toBe(true);
+  });
+
+  it('returns true when conversationId is null', () => {
+    expect(isThinkingVerdict({ ...VALID_THINKING, conversationId: null })).toBe(true);
+  });
+
+  it('returns true when analysisError is a string', () => {
+    expect(isThinkingVerdict({ ...VALID_THINKING, analysisError: 'thinking_truncated' })).toBe(true);
+  });
+
+  it('returns false for null', () => {
+    expect(isThinkingVerdict(null)).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(isThinkingVerdict(undefined)).toBe(false);
+  });
+
+  it('returns false when thinkingTextHash is the wrong length', () => {
+    expect(isThinkingVerdict({ ...VALID_THINKING, thinkingTextHash: 'too short' })).toBe(false);
+  });
+
+  it('returns false when thinkingTextLength is negative', () => {
+    expect(isThinkingVerdict({ ...VALID_THINKING, thinkingTextLength: -2 })).toBe(false);
+  });
+
+  it('returns false when portalId is an unknown literal', () => {
+    expect(isThinkingVerdict({ ...VALID_THINKING, portalId: 'mystery' })).toBe(false);
+  });
+
+  it('returns false when probeResults is not an array', () => {
+    expect(isThinkingVerdict({ ...VALID_THINKING, probeResults: 'oops' })).toBe(false);
+  });
+
+  it('rejects a ResponseVerdict that lacks thinkingTextHash', () => {
+    expect(isThinkingVerdict(VALID)).toBe(false);
   });
 });

--- a/src/types/portal-response.ts
+++ b/src/types/portal-response.ts
@@ -86,6 +86,65 @@ export interface PortalAdapter {
   ): () => void;
 }
 
+// Issue #131 (N7c) — chat-portal thinking/reasoning inspection contract.
+//
+// Same portals as #126 (ChatGPT o1/o3 reasoning summaries, Claude.ai
+// extended-thinking blocks, Gemini <model-thoughts>/<thinking-block>)
+// expose the model's deliberation in DOM subtrees that #126's response
+// observers explicitly skip. The thinking observer captures those
+// subtrees, the SW thinking-analyzer runs the same 3-probe stack on the
+// captured text, and the popup renders a third accordion alongside
+// pageScanVerdict and responseVerdict. Distinct storage slot, distinct
+// telemetry key, distinct chunk-index offset. No mitigations.
+
+/**
+ * Single portal-side thinking-block capture event. Built by a thinking
+ * adapter when a streaming thinking section settles (debounce + portal-
+ * specific completion-marker hybrid; Claude reuses data-is-streaming
+ * from the turn container, Gemini reuses the response copy button,
+ * ChatGPT falls back to debounce alone).
+ *
+ * `messageId` is adapter-derived in the same shape as CapturedResponse
+ * but namespaced (e.g. `chatgpt-thinking:fallback:<prefix>`) so a thinking
+ * capture and a response capture for the same logical assistant turn
+ * cannot collide in the SW dedup cache.
+ */
+export interface CapturedThinking {
+  readonly portalId: PortalId;
+  readonly text: string;
+  readonly capturedAt: number;
+  readonly conversationId: string | null;
+  readonly messageId: string;
+  readonly streamComplete: boolean;
+}
+
+/**
+ * Verdict from running the 3-probe stack against a captured thinking
+ * block. Lives on `SecurityVerdict.thinkingVerdict` (additive optional).
+ * Latest capture wins per-origin; conversation history is out of scope.
+ *
+ * Identical shape to ResponseVerdict apart from the `thinkingTextHash` /
+ * `thinkingTextLength` field names — the renamed pair signals to popup
+ * and storage code that this verdict reflects deliberation rather than
+ * the visible reply.
+ */
+export interface ThinkingVerdict {
+  readonly portalId: PortalId;
+  readonly status: SecurityStatus;
+  readonly confidence: number;
+  readonly totalScore: number;
+  readonly probeResults: readonly ProbeResult[];
+  readonly behavioralFlags: BehavioralFlags;
+  readonly timestamp: number;
+  /** Full SHA-256 hex of the thinking text (64 lowercase hex chars). */
+  readonly thinkingTextHash: string;
+  readonly thinkingTextLength: number;
+  readonly conversationId: string | null;
+  readonly messageId: string;
+  readonly analysisError: string | null;
+  readonly canaryId: string | null;
+}
+
 function isBehavioralFlags(value: unknown): boolean {
   if (typeof value !== 'object' || value === null) return false;
   const v = value as Record<string, unknown>;
@@ -110,6 +169,27 @@ export function isResponseVerdict(value: unknown): value is ResponseVerdict {
   if (typeof v.timestamp !== 'number') return false;
   if (typeof v.responseTextHash !== 'string' || v.responseTextHash.length !== 64) return false;
   if (typeof v.responseTextLength !== 'number' || v.responseTextLength < 0) return false;
+  if (v.conversationId !== null && typeof v.conversationId !== 'string') return false;
+  if (typeof v.messageId !== 'string') return false;
+  if (v.analysisError !== null && typeof v.analysisError !== 'string') return false;
+  if (v.canaryId !== null && typeof v.canaryId !== 'string') return false;
+
+  return true;
+}
+
+export function isThinkingVerdict(value: unknown): value is ThinkingVerdict {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+
+  if (typeof v.portalId !== 'string' || !PORTAL_IDS.has(v.portalId as PortalId)) return false;
+  if (typeof v.status !== 'string' || !SECURITY_STATUSES.has(v.status as SecurityStatus)) return false;
+  if (typeof v.confidence !== 'number') return false;
+  if (typeof v.totalScore !== 'number') return false;
+  if (!Array.isArray(v.probeResults)) return false;
+  if (!isBehavioralFlags(v.behavioralFlags)) return false;
+  if (typeof v.timestamp !== 'number') return false;
+  if (typeof v.thinkingTextHash !== 'string' || v.thinkingTextHash.length !== 64) return false;
+  if (typeof v.thinkingTextLength !== 'number' || v.thinkingTextLength < 0) return false;
   if (v.conversationId !== null && typeof v.conversationId !== 'string') return false;
   if (typeof v.messageId !== 'string') return false;
   if (v.analysisError !== null && typeof v.analysisError !== 'string') return false;

--- a/src/types/verdict.ts
+++ b/src/types/verdict.ts
@@ -1,5 +1,5 @@
 import type { PageStamp } from './page-stamp.js';
-import type { ResponseVerdict } from './portal-response.js';
+import type { ResponseVerdict, ThinkingVerdict } from './portal-response.js';
 import type { EntitySummary } from '@/hunters/ner/types.js';
 
 export type SecurityStatus = 'CLEAN' | 'SUSPICIOUS' | 'COMPROMISED' | 'UNKNOWN';
@@ -107,6 +107,13 @@ export interface SecurityVerdict {
   // observed, and on the page-scan path itself. The page verdict (parent)
   // and responseVerdict (child) coexist on the same per-origin record.
   readonly responseVerdict: ResponseVerdict | null;
+  // Issue #131 (N7c) — additive optional verdict from running the 3-probe
+  // stack against a captured chat-portal thinking/reasoning block. Same
+  // migration semantics as responseVerdict — pre-#131 records come back
+  // with `thinkingVerdict === undefined`, coalesced to null by getVerdict.
+  // Coexists with responseVerdict; cross-comparison (CLEAN response +
+  // SUSPICIOUS thinking) is the high-signal use case this slot enables.
+  readonly thinkingVerdict: ThinkingVerdict | null;
 }
 
 export interface AISecurityReport {


### PR DESCRIPTION
## Summary

Phase 6 Stage 4 — closes #131. Adds a third per-portal observer that captures the model's **thinking / reasoning blocks** (currently EXCLUDED by every #126 response adapter) and runs the existing 3-probe stack against them. The popup gains a "Thinking analysis" accordion alongside Page scan and Response analysis. **No mitigations**, **no in-page UI**, popup-only surface.

Why thinking matters: a model can produce a sanitized final response while its *reasoning* shows it actually followed injected instructions. CLEAN response + SUSPICIOUS thinking on the same origin is a high-signal prompt-injection smell that #126 alone can't catch.

## Architecture

Mirrors #126's primitives verbatim:
- **`src/content/portals/thinking/`** — sibling subtree to `intercept/`, three per-portal adapters + dispatch + bootstrap helper
- **`src/service-worker/thinking-analyzer.ts`** — copy-rename of `response-analyzer.ts`. `THINKING_CHUNK_INDEX_OFFSET = 3_000_000` (1M response, 2M intercept, 3M thinking — no PROBE_RESULTS collisions when all three observers fire on the same tab)
- **Additive `thinkingVerdict` slot** on `SecurityVerdict`; storage `=== undefined` migration coalesce mirrors #126's `responseVerdict` pattern. `setThinkingVerdictForOrigin` writes only that slot. `mergeWithStoredVerdict` preserves both response *and* thinking slots independently across page rescans.
- **Popup `thinking-analysis.ts`** — `thinking-` CSS prefix avoids collision with `response-`. Privacy posture: no captured text excerpt by default (thinking often paraphrases the user's prompt; we treat it as more sensitive than the public response).

## Per-portal selectors

| Portal | Confidence | Approach |
|---|---|---|
| Gemini | HIGH | `model-thoughts, thinking-block` inside `<model-response>` — already named in `geminiAdapter` exclusion list (gemini.ts:14); copy-button stream-end signal reused |
| Claude.ai | MEDIUM | Selector ladder (`[data-testid*="thinking" i]` → `[data-test-thinking]` → `details[aria-label*="thinking" i]` → `[aria-label*="thinking" i]`); `data-is-streaming="false"` on the turn container is the stream-end signal |
| ChatGPT | LOW | Selector ladder (`[data-message-author-role="reasoning"]` → `[data-testid*="reasoning" i]` → `[data-testid*="thinking" i]` → `details[data-testid]` → `.reasoning-summary`); same copy-turn / regenerate stream-end signals as response adapter |

ChatGPT selector intel is unverified against current DOM; the ladder + selector-regression watchdog is the safety net. **Empty-thinking is suppressed at adapter layer** (callback skipped when trimmed text is empty) and **at analyzer layer** (`'empty_thinking'` short-circuit) so portals that never expose thinking blocks stay silent.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — **1081 / 1081** passing (was 1008; +73 new tests)
- [x] `npm run build` — clean
- [x] `npm audit` — 0 vulnerabilities
- [x] AIza secret grep (≥20-char suffix) clean per `feedback_precommit_secret_audit.md`
- [x] Bootstrap regression: existing `portals/index.test.ts` (6/6) still passes
- [x] Per-portal adapter tests + dispatch tests + analyzer tests + popup renderer tests + storage migration tests
- [ ] Manual smoke: load `dist/` unpacked, visit Gemini in thinking mode, confirm popup "Thinking analysis" accordion populates after a thinking-eligible turn

## Hard constraints satisfied

- No changes to `docs/testing/inbrowser-results.json` (Phase 2 byte-locked)
- `TierDecision` shape untouched
- `runChunkProbes` reused verbatim from `orchestrator.ts:533`
- `ThinkingVerdict` storage is purely additive; existing `chrome.storage.local` schema migrates via `=== undefined` coalesce
- TypeScript strict, no `any`
- All new files <250 lines (well under 800 cap)
- No new manifest entries — thinking module ships in existing `dist/content/portals/index.js`

## Telemetry follow-up

`honeyllm:thinking-telemetry` (per-portal captured/analysed counts, suspicious/compromised totals) starts accumulating on merge. Combined with #126/#127/#130 telemetry, the ~2026-05-14 review window will surface: capture rates, divergence stat (how often thinking-status disagrees with response-status on the same origin), and any Claude/ChatGPT selector misses that the regression watchdog catches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)