### PR TITLE
fix(harness-#86): exclude file:// URLs from content_scripts matches

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -18,6 +18,7 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
+      "exclude_matches": ["file:///*"],
       "js": ["dist/content/index.js"],
       "run_at": "document_idle",
       "world": "ISOLATED"


### PR DESCRIPTION
## Summary

- Add `exclude_matches: ["file:///*"]` to the broad-injection `content_scripts` entry in `manifest.json`.
- Restores the manual Nano harness path (`test-pages/nano-harness.html`): HoneyLLM no longer competes with the harness for Chrome's `LanguageModel` session, so `LanguageModel.availability()` resolves rather than hanging indefinitely.
- Unblocks issue #14 (Nano replicate-sampling) by allowing the local harness page to operate without disabling the extension.

## Why this approach

Per the issue body's recommendation (Option #1 — manifest-level exclusion):

> Most conservative default, cheapest code change, user can always re-enable via the file-URLs toggle if they do want extension activity on local files.

The portal-observer `content_scripts` entry already uses HTTPS-specific patterns (chatgpt.com, claude.ai, gemini.google.com), so no change is needed there. `web_accessible_resources` keep `<all_urls>` — they only matter when a content script loads them, and the content script no longer runs on file://.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 1088 / 1088 passing (no regressions)
- [x] `npm run build` — `dist/` regenerates cleanly
- [ ] Manual smoke: load `dist/` unpacked at `chrome://extensions/`, open `file:///<repo>/test-pages/nano-harness.html` → service-worker console shows no `PAGE_SNAPSHOT` for the file URL; harness's own `LanguageModel.availability()` resolves normally
- [ ] Manual smoke: open a regular `https://` page → content script still injects (verified by `Starting analysis for ...` log)

## Notes

No unit tests added — manifest is declarative; behavior is enforced by Chrome's match-pattern resolver. Manual smoke is the right verification surface.

Closes #86.