### PR TITLE
fix(probe-#48): graceful non-English language handling in Prompt API

### DIFF
--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -337,14 +337,23 @@ async function loadVerdict(): Promise<void> {
   // Issue #20 — recognise the `origin_denied:` prefix so policy-skips don't
   // read as engine failures. The per-site card already shows the skip reason
   // in-context; here we just suppress the red "analysis incomplete" card.
+  // Issue #48 — recognise the `unsupported_language:` prefix so non-English
+  // pages render an informational message rather than the engine-failure
+  // wording.
   const errorCard = $('error-card');
   const errorMessageEl = $('error-message');
   const isOriginDenied = verdict.analysisError?.startsWith('origin_denied:') ?? false;
+  const isUnsupportedLang = verdict.analysisError?.startsWith('unsupported_language:') ?? false;
   if (verdict.analysisError && !isOriginDenied) {
     errorCard.style.display = 'block';
-    errorMessageEl.textContent = verdict.status === 'UNKNOWN'
-      ? `Analysis incomplete: ${verdict.analysisError}`
-      : `Partial analysis failure: ${verdict.analysisError}`;
+    if (isUnsupportedLang) {
+      const lang = verdict.analysisError.slice('unsupported_language: '.length);
+      errorMessageEl.textContent = `Not analysed — page is in ${lang}`;
+    } else {
+      errorMessageEl.textContent = verdict.status === 'UNKNOWN'
+        ? `Analysis incomplete: ${verdict.analysisError}`
+        : `Partial analysis failure: ${verdict.analysisError}`;
+    }
   } else {
     errorCard.style.display = 'none';
   }

--- a/src/service-worker/orchestrator.integration.test.ts
+++ b/src/service-worker/orchestrator.integration.test.ts
@@ -4,6 +4,7 @@ import type { HunterResult } from '@/hunters/base-hunter.js';
 import type { Chunk } from '@/types/chunk.js';
 import type { PageSnapshot } from '@/types/snapshot.js';
 import type { ProbeResult } from '@/types/verdict.js';
+import type { LanguageDetectionResult } from '@/hunters/hawk/language-router.js';
 
 // Mocks must be declared before importing the orchestrator so vi.mock
 // rewrites the module graph correctly.
@@ -16,6 +17,14 @@ vi.mock('@/hunters/hunt-runner.js', () => ({
 const chunkTextMock = vi.fn<(text: string) => Promise<readonly Chunk[]>>();
 vi.mock('@/hunters/hawk/chunking.js', () => ({
   chunkText: (text: string) => chunkTextMock(text),
+}));
+
+// Issue #48 — orchestrator pre-flight uses detectLanguage to gate non-English
+// pages out of the probe pipeline. Mock at the module level so each test can
+// drive the language verdict (default: 'und' so existing tests proceed).
+const detectLanguageMock = vi.fn<(text: string) => Promise<LanguageDetectionResult>>();
+vi.mock('@/hunters/hawk/language-router.js', () => ({
+  detectLanguage: (text: string) => detectLanguageMock(text),
 }));
 
 vi.mock('./offscreen-manager.js', () => ({
@@ -163,6 +172,10 @@ describe('analyzeSnapshot tier-router integration (issue #112)', () => {
   beforeEach(() => {
     runHuntersMock.mockReset();
     chunkTextMock.mockReset();
+    detectLanguageMock.mockReset();
+    // Default to 'und' so existing tier-router tests proceed past the
+    // issue #48 language gate without explicit configuration.
+    detectLanguageMock.mockResolvedValue({ lang: 'und', confidence: 0, source: 'chrome-api' });
   });
 
   afterEach(() => {
@@ -427,6 +440,8 @@ describe('analyzeSnapshot evidence-packet routing (issue #118)', () => {
   beforeEach(() => {
     runHuntersMock.mockReset();
     chunkTextMock.mockReset();
+    detectLanguageMock.mockReset();
+    detectLanguageMock.mockResolvedValue({ lang: 'und', confidence: 0, source: 'chrome-api' });
   });
 
   afterEach(() => {
@@ -518,6 +533,8 @@ describe('analyzeSnapshot early-exit on shouldSkipProbes (issue #145)', () => {
   beforeEach(() => {
     runHuntersMock.mockReset();
     chunkTextMock.mockReset();
+    detectLanguageMock.mockReset();
+    detectLanguageMock.mockResolvedValue({ lang: 'und', confidence: 0, source: 'chrome-api' });
   });
 
   afterEach(() => {
@@ -615,5 +632,109 @@ describe('analyzeSnapshot early-exit on shouldSkipProbes (issue #145)', () => {
       expect(entry.notScanned).toBeUndefined();
     });
     expect(verdict.analysisError).not.toBe('early_exit_high_confidence');
+  });
+});
+
+describe('analyzeSnapshot language gate (issue #48)', () => {
+  beforeEach(() => {
+    runHuntersMock.mockReset();
+    chunkTextMock.mockReset();
+    detectLanguageMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('short-circuits with unsupported_language verdict when detected language is Spanish', async () => {
+    detectLanguageMock.mockResolvedValue({ lang: 'es', confidence: 0.95, source: 'chrome-api' });
+    chunkTextMock.mockResolvedValue([buildChunk(0, 'hola mundo')]);
+    const ctx = setupChrome([SAMPLE_PROBE_RESULT]);
+
+    const verdict = await analyzeSnapshot(401, snapshotFixture());
+
+    expect(verdict.status).toBe('UNKNOWN');
+    expect(verdict.analysisError).toBe('unsupported_language: es');
+    expect(verdict.confidence).toBe(0);
+    expect(verdict.totalScore).toBe(0);
+    expect(ctx.runProbesCalls.length).toBe(0);
+    expect(verdict.perChunkAnalysis).toBeNull();
+    expect(verdict.stamp).toBeNull();
+  });
+
+  it('short-circuits when detected language is Japanese', async () => {
+    detectLanguageMock.mockResolvedValue({ lang: 'ja', confidence: 0.99, source: 'chrome-api' });
+    chunkTextMock.mockResolvedValue([buildChunk(0, '東京の天気')]);
+    const ctx = setupChrome([SAMPLE_PROBE_RESULT]);
+
+    const verdict = await analyzeSnapshot(402, snapshotFixture());
+
+    expect(verdict.analysisError).toBe('unsupported_language: ja');
+    expect(ctx.runProbesCalls.length).toBe(0);
+    expect(runHuntersMock).not.toHaveBeenCalled();
+  });
+
+  it('proceeds with normal flow when detected language is English', async () => {
+    detectLanguageMock.mockResolvedValue({ lang: 'en', confidence: 0.99, source: 'chrome-api' });
+    chunkTextMock.mockResolvedValue([buildChunk(0, 'hello world')]);
+    runHuntersMock.mockResolvedValue(
+      buildHuntReport([
+        { name: 'spider', matched: false },
+        { name: 'hawk', matched: false },
+      ]),
+    );
+    setupChrome([SAMPLE_PROBE_RESULT]);
+
+    const verdict = await analyzeSnapshot(403, snapshotFixture());
+
+    expect(verdict.analysisError).toBeNull();
+    expect(verdict.status).toBe('CLEAN');
+  });
+
+  it('proceeds when language is undetermined (und) — defensive against false-skip on short pages', async () => {
+    detectLanguageMock.mockResolvedValue({ lang: 'und', confidence: 0, source: 'chrome-api' });
+    chunkTextMock.mockResolvedValue([buildChunk(0, 'short')]);
+    runHuntersMock.mockResolvedValue(
+      buildHuntReport([
+        { name: 'spider', matched: false },
+        { name: 'hawk', matched: false },
+      ]),
+    );
+    setupChrome([SAMPLE_PROBE_RESULT]);
+
+    const verdict = await analyzeSnapshot(404, snapshotFixture());
+
+    expect(verdict.analysisError).toBeNull();
+    expect(verdict.status).toBe('CLEAN');
+  });
+
+  it('proceeds when detectLanguage rejects — defensive catch falls back to und', async () => {
+    detectLanguageMock.mockRejectedValue(new Error('detector unreachable'));
+    chunkTextMock.mockResolvedValue([buildChunk(0, 'hello')]);
+    runHuntersMock.mockResolvedValue(
+      buildHuntReport([
+        { name: 'spider', matched: false },
+        { name: 'hawk', matched: false },
+      ]),
+    );
+    setupChrome([SAMPLE_PROBE_RESULT]);
+
+    const verdict = await analyzeSnapshot(405, snapshotFixture());
+
+    expect(verdict.analysisError).toBeNull();
+  });
+
+  it('language gate runs after origin-skip resolution — origin denial takes precedence', async () => {
+    // Existing tier-router tests assert origin-policy mock returns 'scan';
+    // here we keep that and just confirm the language gate runs when
+    // the origin allows scanning. The orchestrator unit test covers the
+    // origin-denied path; this test confirms the two checks compose.
+    detectLanguageMock.mockResolvedValue({ lang: 'fr', confidence: 0.9, source: 'chrome-api' });
+    chunkTextMock.mockResolvedValue([buildChunk(0, 'bonjour')]);
+    setupChrome([SAMPLE_PROBE_RESULT]);
+
+    const verdict = await analyzeSnapshot(406, snapshotFixture());
+
+    expect(verdict.analysisError).toBe('unsupported_language: fr');
   });
 });

--- a/src/service-worker/orchestrator.test.ts
+++ b/src/service-worker/orchestrator.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   mergeErrors,
   buildOriginSkippedVerdict,
+  buildUnsupportedLanguageVerdict,
   swapInFlightController,
   AnalysisAbortedError,
 } from './orchestrator.js';
@@ -136,6 +137,73 @@ describe('buildOriginSkippedVerdict (issue #20)', () => {
       'user_override_skip',
     );
     expect(userOverride.stamp).toBeNull();
+  });
+});
+
+describe('buildUnsupportedLanguageVerdict (issue #48)', () => {
+  it('produces UNKNOWN status with zero confidence and zero score', () => {
+    const verdict = buildUnsupportedLanguageVerdict(snapshotFixture(), 'ja');
+    expect(verdict.status).toBe('UNKNOWN');
+    expect(verdict.confidence).toBe(0);
+    expect(verdict.totalScore).toBe(0);
+  });
+
+  it('stamps analysisError with unsupported_language: prefix and the detected language', () => {
+    const ja = buildUnsupportedLanguageVerdict(snapshotFixture(), 'ja');
+    expect(ja.analysisError).toBe('unsupported_language: ja');
+
+    const es = buildUnsupportedLanguageVerdict(snapshotFixture(), 'es');
+    expect(es.analysisError).toBe('unsupported_language: es');
+
+    const fr = buildUnsupportedLanguageVerdict(snapshotFixture(), 'fr');
+    expect(fr.analysisError).toBe('unsupported_language: fr');
+  });
+
+  it('carries the snapshot URL through to the verdict', () => {
+    const verdict = buildUnsupportedLanguageVerdict(
+      snapshotFixture({ url: 'https://ja.wikipedia.org/wiki/Tokyo' }),
+      'ja',
+    );
+    expect(verdict.url).toBe('https://ja.wikipedia.org/wiki/Tokyo');
+  });
+
+  it('has empty probeResults and default-false behavioralFlags', () => {
+    const verdict = buildUnsupportedLanguageVerdict(snapshotFixture(), 'es');
+    expect(verdict.probeResults).toEqual([]);
+    expect(verdict.behavioralFlags).toEqual({
+      roleDrift: false,
+      exfiltrationIntent: false,
+      instructionFollowing: false,
+      hiddenContentAwareness: false,
+    });
+    expect(verdict.mitigationsApplied).toEqual([]);
+  });
+
+  it('leaves canaryId null (no canary was consulted)', () => {
+    const verdict = buildUnsupportedLanguageVerdict(snapshotFixture(), 'ja');
+    expect(verdict.canaryId).toBeNull();
+  });
+
+  it('emits stamp: null — unsupported-language verdicts mirror origin-skip (no scan attempted)', () => {
+    const verdict = buildUnsupportedLanguageVerdict(snapshotFixture(), 'ja');
+    expect(verdict.stamp).toBeNull();
+  });
+
+  it('emits perChunkAnalysis: null and entitySummary: null — chunk loop never ran', () => {
+    const verdict = buildUnsupportedLanguageVerdict(snapshotFixture(), 'ja');
+    expect(verdict.perChunkAnalysis).toBeNull();
+    expect(verdict.entitySummary).toBeNull();
+  });
+
+  it('emits responseVerdict: null and thinkingVerdict: null — portal observers do not run', () => {
+    const verdict = buildUnsupportedLanguageVerdict(snapshotFixture(), 'ja');
+    expect(verdict.responseVerdict).toBeNull();
+    expect(verdict.thinkingVerdict).toBeNull();
+  });
+
+  it('emits webgpuAdapterMode: null — engine was not consulted', () => {
+    const verdict = buildUnsupportedLanguageVerdict(snapshotFixture(), 'ja');
+    expect(verdict.webgpuAdapterMode).toBeNull();
   });
 });
 

--- a/src/service-worker/orchestrator.ts
+++ b/src/service-worker/orchestrator.ts
@@ -7,8 +7,10 @@ import {
   EARLY_EXIT_ANALYSIS_ERROR,
   HUNTER_RULES_VERSION,
   CACHE_SCHEMA_VERSION,
+  SUPPORTED_PROBE_LANGUAGES,
 } from '@/shared/constants.js';
 import { chunkText } from '@/hunters/hawk/chunking.js';
+import { detectLanguage } from '@/hunters/hawk/language-router.js';
 import { runHunters } from '@/hunters/hunt-runner.js';
 import { spiderHunter } from '@/hunters/spider/index.js';
 import { hawkHunter } from '@/hunters/hawk/index.js';
@@ -154,6 +156,44 @@ export function buildOriginSkippedVerdict(
 }
 
 /**
+ * Build the synthetic "skipped because page language is outside the
+ * probe stack's supported set" verdict (issue #48). Mirrors
+ * buildOriginSkippedVerdict so popup/storage/icon paths render the
+ * skip cleanly rather than as engine-failure UNKNOWN. The
+ * `unsupported_language:` analysisError prefix is the contract popup
+ * uses to render an informational message rather than the red error
+ * card.
+ */
+export function buildUnsupportedLanguageVerdict(
+  snapshot: PageSnapshot,
+  detectedLang: string,
+): SecurityVerdict {
+  return {
+    status: 'UNKNOWN',
+    confidence: 0,
+    totalScore: 0,
+    probeResults: [],
+    behavioralFlags: {
+      roleDrift: false,
+      exfiltrationIntent: false,
+      instructionFollowing: false,
+      hiddenContentAwareness: false,
+    },
+    mitigationsApplied: [],
+    timestamp: Date.now(),
+    url: snapshot.metadata.url,
+    analysisError: `unsupported_language: ${detectedLang}`,
+    canaryId: null,
+    webgpuAdapterMode: null,
+    stamp: null,
+    perChunkAnalysis: null,
+    entitySummary: null,
+    responseVerdict: null,
+    thinkingVerdict: null,
+  };
+}
+
+/**
  * Abort any in-flight analysis for `tabId`, returning a fresh
  * `AbortController` for the new run. Called at the start of every
  * `analyzeSnapshot` so a refresh mid-scan cancels the prior work. Issue #11.
@@ -223,6 +263,30 @@ export async function analyzeSnapshot(
   connectOffscreenPort();
 
   const fullText = buildAnalysisText(snapshot);
+
+  // Issue #48 — pre-flight language gate. Probes are English-only;
+  // running them on non-English text produces NotSupportedError
+  // cascades (UNKNOWN with confusing engine-failure messages). Mirror
+  // the origin-skip path: build a synthetic 'unsupported_language'
+  // verdict and persist before any chunking / probe work. `'und'`
+  // (returned for short text or detector failure) proceeds — only an
+  // affirmatively-detected non-English lang triggers the skip.
+  const langResult = await detectLanguage(fullText).catch(
+    () => ({ lang: 'und' as const, confidence: 0, source: 'chrome-api' as const }),
+  );
+  if (
+    langResult.lang !== 'und' &&
+    !SUPPORTED_PROBE_LANGUAGES.includes(langResult.lang as typeof SUPPORTED_PROBE_LANGUAGES[number])
+  ) {
+    log.info(
+      `Skipping analysis for ${snapshot.metadata.url} (unsupported language: ${langResult.lang})`,
+    );
+    const verdict = buildUnsupportedLanguageVerdict(snapshot, langResult.lang);
+    await persistVerdict(verdict);
+    releaseInFlightController(tabId, controller);
+    return verdict;
+  }
+
   const allChunks = await chunkText(fullText);
 
   // Phase 4 Stage 4B — enforce MAX_CHUNKS_PER_PAGE cap to bound latency and

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -473,3 +473,20 @@ export const INTERCEPT_CHUNK_INDEX_OFFSET = 2_000_000;
 export const STORAGE_KEY_THINKING_TELEMETRY = 'honeyllm:thinking-telemetry';
 export const THINKING_CHUNK_INDEX_OFFSET = 3_000_000;
 export const MAX_THINKING_TEXT_CHARS = 80_000;
+
+/**
+ * Issue #48 — set of page languages where the LLM probe stack is known to
+ * produce signal. The orchestrator pre-flight calls detectLanguage() and
+ * short-circuits with a synthetic `unsupported_language: <lang>` verdict
+ * when the detected language is outside this set.
+ *
+ * English-only because the v1 / v2 classifier strings (e.g. "I have been
+ * compromised", "DAN mode enabled") are English idioms — they do not catch
+ * compliance phrasing in other languages, so running probes on a Japanese
+ * Wikipedia page produces a confusing UNKNOWN cascade rather than useful
+ * signal. `'und'` (returned by detectLanguage for short text or detector
+ * failure) is intentionally NOT pre-judged: the gate proceeds on `'und'`
+ * to avoid false-skipping short pages.
+ */
+export const SUPPORTED_PROBE_LANGUAGES = ['en'] as const;
+export type SupportedProbeLanguage = (typeof SUPPORTED_PROBE_LANGUAGES)[number];


### PR DESCRIPTION
## Summary

Adds a pre-flight language gate in `analyzeSnapshot` that short-circuits non-English pages with a clean `analysisError: 'unsupported_language: <lang>'` verdict instead of cascading to confusing engine-failure UNKNOWN through the Prompt API's `NotSupportedError`.

Probes are English-only — the v1/v2 classifier strings (`'I have been compromised'`, `'DAN mode enabled'`, etc.) are English idioms; running them on Japanese or Spanish text produces no useful signal. The gate keeps the supported set narrow at `['en']` and proceeds defensively on `'und'` so short pages aren't false-skipped.

Mirrors the existing origin-skip pattern (`buildOriginSkippedVerdict` from issue #20).

## Changes

- **`src/shared/constants.ts`** — new `SUPPORTED_PROBE_LANGUAGES = ['en'] as const`.
- **`src/service-worker/orchestrator.ts`** — `buildUnsupportedLanguageVerdict()` mirrors `buildOriginSkippedVerdict` shape (status `UNKNOWN`, all per-chunk + stamp fields null). `analyzeSnapshot` runs `detectLanguage(fullText)` after `ensureOffscreenDocument()` and before chunking; affirmatively non-English (and not in the supported set) → persist + return the unsupported-language verdict, releasing the in-flight controller cleanly.
- **`src/popup/popup.ts`** — recognises the `unsupported_language:` prefix and renders "Not analysed — page is in `<lang>`" rather than the red engine-failure card.

## Decision points

- **`'und'` proceeds.** Pages with very short body text (< 20 chars) and detector failures both return `'und'` from `detectLanguage`; treating them as unsupported would cause false-skip on the entire short-text class. `und → proceed` is the correct default.
- **No confidence threshold.** If the detector says `'ja'` with confidence 0.4, our English classifiers still won't catch Japanese-language compliance strings — skipping is the right call.
- **Supported set stays `['en']`.** `NANO_CAPABILITY_OPTIONS` continues to declare English-only inputs/outputs. Widening the set is intentionally Option B work (deferred per issue body) — multilingual probe curation is its own multi-day project.
- **Pre-flight runs after `ensureOffscreenDocument()`.** `language-router.ts` routes detection through the offscreen doc via `DETECT_LANGUAGE` RPC, so the offscreen lifecycle must be up before we ask.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 1103 / 1103 passing (was 1088; +15 new)
  - `+9` unit tests on `buildUnsupportedLanguageVerdict` shape
  - `+6` integration tests on `analyzeSnapshot` gate path: 'es', 'ja', 'en', 'und', detector-rejects, gate-composes-with-origin-policy
- [x] `npm run build` — `dist/` regenerates cleanly
- [ ] Manual smoke: load `dist/` unpacked, open Japanese Wikipedia → popup shows "Not analysed — page is in ja" rather than engine-failure UNKNOWN
- [ ] Manual smoke: open English Wikipedia → normal CLEAN/SUSPICIOUS/COMPROMISED verdict
- [ ] Manual smoke: open a near-empty page → analysis proceeds (should be `'und'` → defensive proceed)

Closes #48.