### PR TITLE
feat(harness-#17): engine-health probe at init time

### DIFF
--- a/src/offscreen/engine-health.test.ts
+++ b/src/offscreen/engine-health.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from 'vitest';
+import { runEngineHealthProbe } from './engine-health.js';
+
+interface FakeEngine {
+  id: string;
+  generate: (system: string, user: string) => Promise<string>;
+}
+
+function makeEngine(id: string, response: string | (() => Promise<string>)): FakeEngine {
+  return {
+    id,
+    generate: typeof response === 'function'
+      ? vi.fn(response)
+      : vi.fn(async () => response),
+  };
+}
+
+describe('runEngineHealthProbe (issue #17)', () => {
+  it('returns true when generate yields non-empty output', async () => {
+    const engine = makeEngine('test-model', 'pong');
+    const ok = await runEngineHealthProbe(engine);
+    expect(ok).toBe(true);
+  });
+
+  it('returns false when generate yields empty string', async () => {
+    const engine = makeEngine('broken-model', '');
+    const ok = await runEngineHealthProbe(engine);
+    expect(ok).toBe(false);
+  });
+
+  it('returns false when generate yields whitespace-only output', async () => {
+    const engine = makeEngine('lazy-model', '   \n\t  ');
+    const ok = await runEngineHealthProbe(engine);
+    expect(ok).toBe(false);
+  });
+
+  it('returns false when generate throws', async () => {
+    const engine = makeEngine('throwing-model', async () => {
+      throw new Error('engine exploded');
+    });
+    const ok = await runEngineHealthProbe(engine);
+    expect(ok).toBe(false);
+  });
+
+  it('calls generate exactly once with a minimal ping prompt', async () => {
+    const engine = makeEngine('counted-model', 'pong');
+    await runEngineHealthProbe(engine);
+    expect(engine.generate).toHaveBeenCalledTimes(1);
+    const [systemPrompt, userMessage] = (engine.generate as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(typeof systemPrompt).toBe('string');
+    expect(typeof userMessage).toBe('string');
+    expect(userMessage.length).toBeGreaterThan(0);
+  });
+});

--- a/src/offscreen/engine-health.ts
+++ b/src/offscreen/engine-health.ts
@@ -1,0 +1,37 @@
+/**
+ * Engine health probe (issue #17).
+ *
+ * Phase 4B.3 added single-flight init + a ready gate so concurrent probe
+ * callers no longer race on cold-start. But "init resolved" is not the
+ * same as "model inference returns output" — we've previously seen MLC
+ * return an adapter that yields empty strings on its first real call
+ * (see docs/testing/phase4/mlc-root-cause.md §Open items).
+ *
+ * Running a one-token dummy inference at init time catches that
+ * degenerate case immediately and lets the engine-level fallback chain
+ * (MODEL_PRIMARY → MODEL_FALLBACK) route around a broken primary
+ * instead of blowing up the first user-triggered probe.
+ *
+ * Split out of `engine.ts` so it can be unit-tested without pulling in
+ * the @mlc-ai/web-llm dependency tree.
+ */
+
+interface HealthProbeEngine {
+  generate(systemPrompt: string, userMessage: string): Promise<string>;
+}
+
+const HEALTH_PROBE_SYSTEM_PROMPT = '';
+const HEALTH_PROBE_USER_PROMPT = 'ping';
+
+/**
+ * Returns true when the engine produces non-empty output for a trivial
+ * "ping" prompt. Catches both thrown errors and silent-empty returns.
+ */
+export async function runEngineHealthProbe(engine: HealthProbeEngine): Promise<boolean> {
+  try {
+    const reply = await engine.generate(HEALTH_PROBE_SYSTEM_PROMPT, HEALTH_PROBE_USER_PROMPT);
+    return reply.trim().length > 0;
+  } catch {
+    return false;
+  }
+}

--- a/src/offscreen/engine.ts
+++ b/src/offscreen/engine.ts
@@ -12,6 +12,7 @@ import {
 } from '@/shared/constants.js';
 import { createLogger } from '@/shared/logger.js';
 import { resolveNanoCreateParams, type NanoParamBounds } from './engine-params.js';
+import { runEngineHealthProbe } from './engine-health.js';
 import { probeWebGPUAdapter, type AdapterIntrospection } from './webgpu-introspection.js';
 
 // Phase 4 Stage 4D.1 — dual-path engine.
@@ -249,18 +250,7 @@ async function resolveCanary(choice: CanaryId): Promise<CanaryDefinition> {
   return CANARY_CATALOG['gemma-2-2b-mlc'];
 }
 
-async function createMlcEngineAdapter(modelId: string): Promise<CompletionEngine> {
-  let mlc: MLCEngine;
-  let effectiveModelId = modelId;
-  try {
-    mlc = await CreateMLCEngine(modelId, { initProgressCallback: reportProgress });
-  } catch (err) {
-    log.warn(`Primary model failed, falling back to ${MODEL_FALLBACK}`, err);
-    effectiveModelId = MODEL_FALLBACK;
-    loadedModelId = MODEL_FALLBACK;
-    mlc = await CreateMLCEngine(MODEL_FALLBACK, { initProgressCallback: reportProgress });
-  }
-  loadedModelId = effectiveModelId;
+function buildMlcAdapter(mlc: MLCEngine, effectiveModelId: string): CompletionEngine {
   return {
     id: effectiveModelId,
     async generate(systemPrompt: string, userMessage: string, _opts?: CompletionOptions): Promise<string> {
@@ -278,6 +268,33 @@ async function createMlcEngineAdapter(modelId: string): Promise<CompletionEngine
       return response.choices[0]?.message?.content ?? '';
     },
   };
+}
+
+async function createMlcEngineAdapter(modelId: string): Promise<CompletionEngine> {
+  let mlc: MLCEngine;
+  let effectiveModelId = modelId;
+  try {
+    mlc = await CreateMLCEngine(modelId, { initProgressCallback: reportProgress });
+  } catch (err) {
+    log.warn(`Primary model failed, falling back to ${MODEL_FALLBACK}`, err);
+    effectiveModelId = MODEL_FALLBACK;
+    mlc = await CreateMLCEngine(MODEL_FALLBACK, { initProgressCallback: reportProgress });
+  }
+  let adapter = buildMlcAdapter(mlc, effectiveModelId);
+
+  // Issue #17 — engine-health probe. "Init resolved" ≠ "inference works"
+  // (see Phase 4B.2 silent-empty bug). Run a ping before declaring ready
+  // so MODEL_PRIMARY → MODEL_FALLBACK can route around a broken primary
+  // that loaded but produces no output.
+  if (effectiveModelId !== MODEL_FALLBACK && !(await runEngineHealthProbe(adapter))) {
+    log.warn(`Health probe failed on ${effectiveModelId}; falling back to ${MODEL_FALLBACK}`);
+    effectiveModelId = MODEL_FALLBACK;
+    mlc = await CreateMLCEngine(MODEL_FALLBACK, { initProgressCallback: reportProgress });
+    adapter = buildMlcAdapter(mlc, effectiveModelId);
+  }
+
+  loadedModelId = effectiveModelId;
+  return adapter;
 }
 
 /**
@@ -318,7 +335,7 @@ async function createNanoEngineAdapter(modelId: string): Promise<CompletionEngin
   log.info(
     `Nano adapter initialising for ${modelId} (availability=${avail})`,
   );
-  return {
+  const adapter: CompletionEngine = {
     id: modelId,
     async generate(systemPrompt: string, userMessage: string, opts?: CompletionOptions): Promise<string> {
       const session = await api.create({
@@ -354,6 +371,15 @@ async function createNanoEngineAdapter(modelId: string): Promise<CompletionEngin
       }
     },
   };
+
+  // Issue #17 — engine-health probe. Nano has no per-adapter fallback
+  // chain (resolveCanary already picked a single canary), so a failed
+  // probe throws and clears initPromise; the next initEngine() call
+  // retries from canary selection.
+  if (!(await runEngineHealthProbe(adapter))) {
+    throw new Error(`Nano health probe failed for ${modelId} (engine loaded but ping returned empty)`);
+  }
+  return adapter;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds `runEngineHealthProbe(engine)` helper (`src/offscreen/engine-health.ts`) that runs a one-token "ping" inference and returns whether the engine produced non-empty output.
- Wires it into both adapters in `src/offscreen/engine.ts`. For MLC, a failed probe automatically falls through `MODEL_PRIMARY → MODEL_FALLBACK`; for Nano, it throws so `initEngine()` clears `initPromise` and the next caller retries.
- Catches the Phase 4B.2 silent-empty class at init time instead of first-probe time.

## Why

"Init resolved" ≠ "inference returns output". Phase 4B.3 (commit 3b2feea) fixed the concurrent-init race, but a degenerate scenario where `CreateMLCEngine` resolves an adapter that returns empty strings on its first real call still leaks an UNKNOWN verdict to the user. The engine-level fallback chain now gets a chance to route around the broken primary.

## Test plan

- [x] `npx vitest run src/offscreen/engine-health.test.ts` — 5/5 pass
- [x] `npm run typecheck` — clean
- [x] `npm test` — 1108/1108 pass (+5 from new health-probe tests)
- [x] `npm run build` — clean
- [x] `npm audit` — 0 vulnerabilities

Closes #17