### PR TITLE
fix(harness-#84): Gemini pro-thinking timeout

### DIFF
--- a/scripts/run-b5-agent-simulation-helpers.test.ts
+++ b/scripts/run-b5-agent-simulation-helpers.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import {
+  extractVisibleText,
+  geminiCallConfig,
+  GEMINI_PRO_TIMEOUT_MS,
+  GEMINI_DEFAULT_TIMEOUT_MS,
+} from './run-b5-agent-simulation-helpers.js';
+
+describe('extractVisibleText (issue #84)', () => {
+  it('drops <script> blocks including their inner JS', () => {
+    const html = '<p>Hello</p><script>alert("xss")</script><p>World</p>';
+    const out = extractVisibleText(html);
+    expect(out).not.toContain('alert');
+    expect(out).toContain('Hello');
+    expect(out).toContain('World');
+  });
+
+  it('drops <style> blocks including their inner CSS', () => {
+    const html = '<style>body { color: red; font-family: comic-sans; }</style><p>Visible</p>';
+    const out = extractVisibleText(html);
+    expect(out).not.toContain('color');
+    expect(out).not.toContain('comic-sans');
+    expect(out).toContain('Visible');
+  });
+
+  it('strips remaining HTML tags', () => {
+    const html = '<div class="x"><p>Para <span>span</span></p></div>';
+    const out = extractVisibleText(html);
+    expect(out).not.toMatch(/<[^>]+>/);
+    expect(out).toContain('Para');
+    expect(out).toContain('span');
+  });
+
+  it('collapses whitespace runs to single spaces', () => {
+    const html = '<p>A   B\n\nC\t\tD</p>';
+    const out = extractVisibleText(html);
+    expect(out).toBe('A B C D');
+  });
+
+  it('produces meaningfully shorter output than the source HTML on a realistic page', () => {
+    const html = `<html><head><style>${'x'.repeat(500)}</style></head><body><script>${'y'.repeat(500)}</script><p>The visible body is short.</p></body></html>`;
+    const out = extractVisibleText(html);
+    expect(out.length).toBeLessThan(html.length / 4);
+    expect(out).toContain('The visible body is short.');
+  });
+
+  it('handles empty / whitespace-only input without throwing', () => {
+    expect(extractVisibleText('')).toBe('');
+    expect(extractVisibleText('   ')).toBe('');
+  });
+});
+
+describe('geminiCallConfig (issue #84)', () => {
+  const HTML = '<html><body><p>Page contents.</p></body></html>';
+
+  it('flash models keep raw HTML and use the default 120s timeout', () => {
+    const cfg = geminiCallConfig('gemini-3-flash-preview', HTML);
+    expect(cfg.timeoutMs).toBe(GEMINI_DEFAULT_TIMEOUT_MS);
+    expect(cfg.payloadHtml).toBe(HTML);
+  });
+
+  it('pro models pre-extract visible text to shrink the prompt', () => {
+    const cfg = geminiCallConfig('gemini-3.1-pro-preview', HTML);
+    expect(cfg.payloadHtml).not.toContain('<html>');
+    expect(cfg.payloadHtml).toContain('Page contents.');
+  });
+
+  it('pro models bump the timeout to GEMINI_PRO_TIMEOUT_MS so unbounded thinking does not silently stall', () => {
+    const cfg = geminiCallConfig('gemini-3.1-pro-preview', HTML);
+    expect(cfg.timeoutMs).toBe(GEMINI_PRO_TIMEOUT_MS);
+    expect(GEMINI_PRO_TIMEOUT_MS).toBeGreaterThan(GEMINI_DEFAULT_TIMEOUT_MS);
+  });
+
+  it('matches the /pro/ heuristic (any model id containing "pro" gets the pro path)', () => {
+    const variants = ['gemini-3-pro', 'gemini-3.1-pro-preview', 'GEMINI-PRO'];
+    for (const v of variants) {
+      const cfg = geminiCallConfig(v, HTML);
+      expect(cfg.timeoutMs, `model=${v}`).toBe(GEMINI_PRO_TIMEOUT_MS);
+    }
+  });
+});

--- a/scripts/run-b5-agent-simulation-helpers.ts
+++ b/scripts/run-b5-agent-simulation-helpers.ts
@@ -1,0 +1,61 @@
+/**
+ * Helpers for `run-b5-agent-simulation.ts` (issue #84).
+ *
+ * Split out so the script's helpers can be unit-tested without invoking
+ * the script's top-level env-var validation + main() entrypoint.
+ *
+ * Mitigation for the gemini-3.1-pro-preview agent-mode timeout class:
+ *
+ * - Pro-thinking models spend unbounded wall-clock reasoning over raw HTML.
+ *   `extractVisibleText` strips scripts/styles/tags before the prompt is
+ *   built, shrinking ~3KB of HTML to a few hundred bytes of prose. That
+ *   removes most of what the model is "thinking" about.
+ *
+ * - Even with shorter inputs, pro-thinking can still be slower than the
+ *   stock 120s timeout. `geminiCallConfig` raises the cap to 300s when
+ *   the model id matches `/pro/`. Flash models stay at 120s — they don't
+ *   need it.
+ *
+ * Together these match issue #84's "(1) extract visible text + (3) default
+ * to flash" recommendation. The default model in the script also flips to
+ * flash so the typical run never hits the pro timeout class at all.
+ */
+
+export const GEMINI_DEFAULT_TIMEOUT_MS = 120_000;
+export const GEMINI_PRO_TIMEOUT_MS = 300_000;
+
+export interface GeminiCallConfig {
+  readonly timeoutMs: number;
+  readonly payloadHtml: string;
+}
+
+const SCRIPT_BLOCK = /<script[^>]*>[\s\S]*?<\/script>/gi;
+const STYLE_BLOCK = /<style[^>]*>[\s\S]*?<\/style>/gi;
+const ANY_TAG = /<[^>]+>/g;
+const WHITESPACE_RUN = /\s+/g;
+
+export function extractVisibleText(html: string): string {
+  return html
+    .replace(SCRIPT_BLOCK, ' ')
+    .replace(STYLE_BLOCK, ' ')
+    .replace(ANY_TAG, ' ')
+    .replace(WHITESPACE_RUN, ' ')
+    .trim();
+}
+
+export function isProModel(model: string): boolean {
+  return /pro/i.test(model);
+}
+
+export function geminiCallConfig(model: string, html: string): GeminiCallConfig {
+  if (isProModel(model)) {
+    return {
+      timeoutMs: GEMINI_PRO_TIMEOUT_MS,
+      payloadHtml: extractVisibleText(html),
+    };
+  }
+  return {
+    timeoutMs: GEMINI_DEFAULT_TIMEOUT_MS,
+    payloadHtml: html,
+  };
+}

--- a/scripts/run-b5-agent-simulation.ts
+++ b/scripts/run-b5-agent-simulation.ts
@@ -24,6 +24,7 @@
 import { writeFileSync, mkdirSync, existsSync, readFileSync } from 'fs';
 import { resolve } from 'path';
 import Anthropic from '@anthropic-ai/sdk';
+import { geminiCallConfig } from './run-b5-agent-simulation-helpers.js';
 
 const REPO_ROOT = resolve(import.meta.dirname!, '..');
 const OUT_PATH = resolve(REPO_ROOT, 'docs/testing/phase3/STAGE_B5_SCRIPTED_RESULTS.json');
@@ -58,12 +59,15 @@ const FIXTURES = [
 // Per-provider model choice is env-overridable so errored/timed-out providers
 // can be re-run with a different model without touching code. On 2026-04-21
 // the initial gemini-3.1-pro-preview run lost 4/7 cells to thinking-mode
-// timeouts; swap to gemini-3-flash-preview for retries per STAGE_B5_RESULTS.md
-// recommendation.
+// timeouts; #84 confirmed pro-thinking on raw HTML is structurally bad
+// (5/7 timeouts vs 1/189 for the direct text-only baseline). Default flips
+// to flash; opt back into pro via B5_GOOGLE_MODEL when running a focused
+// re-test (in which case `geminiCallConfig` extracts visible text and
+// raises the timeout to 300s).
 const AGENTS = [
   { provider: 'anthropic' as const, model: process.env.B5_ANTHROPIC_MODEL ?? 'claude-opus-4-7' },
   { provider: 'openai' as const, model: process.env.B5_OPENAI_MODEL ?? 'gpt-5.4' },
-  { provider: 'google' as const, model: process.env.B5_GOOGLE_MODEL ?? 'gemini-3.1-pro-preview' },
+  { provider: 'google' as const, model: process.env.B5_GOOGLE_MODEL ?? 'gemini-3-flash-preview' },
 ];
 
 // Agent-mode system prompt mimics a "browsing assistant" wrapper — open-ended
@@ -146,17 +150,21 @@ async function callOpenAI(model: string, html: string, url: string): Promise<str
 }
 
 async function callGemini(model: string, html: string, url: string): Promise<string> {
-  const isPro = /pro/.test(model);
+  // Issue #84 — pro-thinking models stall on raw HTML (5/7 B5 timeouts at
+  // 120s). geminiCallConfig pre-extracts visible text and raises the
+  // timeout to 300s when the model id is a pro variant; flash models
+  // keep the raw payload + 120s default.
+  const { timeoutMs, payloadHtml } = geminiCallConfig(model, html);
+  const isPro = /pro/i.test(model);
   const body = {
     systemInstruction: { parts: [{ text: AGENT_SYSTEM_PROMPT }] },
-    contents: [{ parts: [{ text: AGENT_USER_PROMPT(url, html) }] }],
+    contents: [{ parts: [{ text: AGENT_USER_PROMPT(url, payloadHtml) }] }],
     generationConfig: {
       temperature: 0.1,
       maxOutputTokens: 4096,
       thinkingConfig: { thinkingBudget: isPro ? 1024 : 0 },
     },
   };
-  const timeoutMs = 120_000;
   const data = await Promise.race([
     (async () => {
       const res = await fetch(


### PR DESCRIPTION
## Summary

- Default `B5_GOOGLE_MODEL` flips from `gemini-3.1-pro-preview` to `gemini-3-flash-preview` — typical run no longer hits the pro-thinking timeout class at all.
- New `geminiCallConfig(model, html)` helper: pro variants get visible-text extraction (`<script>`/`<style>`/tags stripped) + 300s timeout; flash variants keep raw HTML + the existing 120s.
- Helpers split into `scripts/run-b5-agent-simulation-helpers.ts` so they unit-test cleanly without the script's top-level env-var validation + `main()` entrypoint.

## Why

Pro-thinking models stalled silently at 120s on 4/7 B5 cells because `thinkingBudget` caps emitted thinking tokens, not wall-clock time, over ~3KB of raw HTML. The direct text-only baseline saw 1/189 timeouts on the same model — a ~140× regression driven by prompt complexity. Issue #84's recommendation was "(1) extract visible text + (3) default to flash"; this PR ships both.

## Test plan

- [x] `npx vitest run scripts/run-b5-agent-simulation-helpers.test.ts` — 10/10
- [x] `npm run typecheck` — clean
- [x] `npm test` — 1113/1113 pass (+10 from new helpers)
- [x] `npm run build` — clean
- [x] `npm audit` — 0 vulnerabilities

Closes #84