### PR TITLE
feat(registry-#51): SR-A zone-extraction primitive + registry schema

### DIFF
--- a/src/registry/__tests__/extract-zones.test.ts
+++ b/src/registry/__tests__/extract-zones.test.ts
@@ -1,0 +1,166 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { extractZones } from '../extract-zones.js';
+import type { ZoneText } from '@/types/registry.js';
+
+const FRAME_SELECTORS = ['nav', 'header', 'footer'] as const;
+
+const baseHtml = (greeting: string, mainText: string, lang = 'en'): string => `<!doctype html>
+<html lang="${lang}">
+  <head><title>Acme</title></head>
+  <body>
+    <header>
+      <a href="/" class="logo">Acme</a>
+      <span class="user-greeting">${greeting}</span>
+    </header>
+    <nav>
+      <ul>
+        <li><a href="/products">Products</a></li>
+        <li><a href="/pricing">Pricing</a></li>
+        <li><a href="/about">About</a></li>
+      </ul>
+    </nav>
+    <article>${mainText}</article>
+    <footer>
+      <p>© 2026 Acme Corp</p>
+    </footer>
+  </body>
+</html>`;
+
+const findZone = (zones: readonly ZoneText[], selector: string): ZoneText => {
+  const z = zones.find((x) => x.zoneId.startsWith(selector + '#'));
+  if (z === undefined) throw new Error(`no zone for selector ${selector}`);
+  return z;
+};
+
+describe('extractZones', () => {
+  it('extracts only static-frame zones (nav/header/footer); skips article', () => {
+    const html = baseHtml('Welcome guest', '<p>marketing copy that varies per visit</p>');
+    const zones = extractZones(html, [...FRAME_SELECTORS], []);
+
+    const ids = zones.map((z) => z.zoneId).sort();
+    expect(ids).toEqual(['footer#0', 'header#0', 'nav#0']);
+
+    for (const zone of zones) {
+      expect(zone.htmlSnippet).not.toContain('marketing copy');
+      expect(zone.normalisedText).not.toContain('marketing copy');
+    }
+  });
+
+  it('produces an identical structureSkeleton across locale variants of the same page', () => {
+    const en = baseHtml('Welcome guest', '<p>EN body</p>', 'en');
+    const es = baseHtml('Bienvenido invitado', '<p>ES body</p>', 'es');
+
+    const enZones = extractZones(en, [...FRAME_SELECTORS], []);
+    const esZones = extractZones(es, [...FRAME_SELECTORS], []);
+
+    expect(enZones).toHaveLength(esZones.length);
+    for (const enZone of enZones) {
+      const esZone = findZone(esZones, enZone.zoneId.split('#')[0]);
+      expect(esZone.structureSkeleton).toBe(enZone.structureSkeleton);
+    }
+
+    const enHeader = findZone(enZones, 'header');
+    const esHeader = findZone(esZones, 'header');
+    expect(esHeader.normalisedText).not.toBe(enHeader.normalisedText);
+    expect(enHeader.normalisedText).toContain('Welcome guest');
+    expect(esHeader.normalisedText).toContain('Bienvenido invitado');
+  });
+
+  it('tolerates signed-in vs signed-out chrome via excluded selectors', () => {
+    const signedOut = baseHtml('Welcome guest', '<p>body</p>');
+    const signedIn = baseHtml('Welcome, Alice 👋', '<p>body</p>');
+
+    const excluded = ['.user-greeting'];
+    const outZones = extractZones(signedOut, [...FRAME_SELECTORS], excluded);
+    const inZones = extractZones(signedIn, [...FRAME_SELECTORS], excluded);
+
+    const outHeader = findZone(outZones, 'header');
+    const inHeader = findZone(inZones, 'header');
+
+    expect(inHeader.normalisedText).toBe(outHeader.normalisedText);
+    expect(inHeader.htmlSnippet).toBe(outHeader.htmlSnippet);
+    expect(inHeader.structureSkeleton).toBe(outHeader.structureSkeleton);
+
+    expect(outHeader.normalisedText).not.toContain('Welcome guest');
+    expect(inHeader.normalisedText).not.toContain('Alice');
+  });
+
+  it('drops a frame match whose element itself matches an excluded selector', () => {
+    const html = `<!doctype html><html><body>
+      <header class="experimental">should be dropped</header>
+      <nav><a href="/">Home</a></nav>
+      <footer>fine</footer>
+    </body></html>`;
+    const zones = extractZones(html, [...FRAME_SELECTORS], ['header.experimental']);
+    const ids = zones.map((z) => z.zoneId).sort();
+    expect(ids).toEqual(['footer#0', 'nav#0']);
+  });
+
+  it('returns an empty array for empty HTML', () => {
+    expect(extractZones('', [...FRAME_SELECTORS], [])).toEqual([]);
+    expect(extractZones('<!doctype html><html></html>', [...FRAME_SELECTORS], [])).toEqual([]);
+  });
+
+  it('does not throw on malformed HTML', () => {
+    const malformed = '<!doctype html><html><body><nav><ul><li><a href="/">x';
+    expect(() => extractZones(malformed, [...FRAME_SELECTORS], [])).not.toThrow();
+    const zones = extractZones(malformed, [...FRAME_SELECTORS], []);
+    expect(zones.length).toBeGreaterThanOrEqual(0);
+  });
+
+  it('produces deterministic, doc-order zoneIds when a selector matches multiple elements', () => {
+    const html = `<!doctype html><html><body>
+      <nav id="top"><a href="/">Top</a></nav>
+      <main><p>x</p></main>
+      <nav id="side"><a href="/">Side</a></nav>
+      <footer>f</footer>
+    </body></html>`;
+    const zones = extractZones(html, ['nav', 'footer'], []);
+    expect(zones.map((z) => z.zoneId)).toEqual(['nav#0', 'nav#1', 'footer#0']);
+    expect(zones[0].htmlSnippet).toContain('id="top"');
+    expect(zones[1].htmlSnippet).toContain('id="side"');
+  });
+
+  it('deduplicates zones when multiple selectors match the same element', () => {
+    const html = `<!doctype html><html><body>
+      <header><nav><a href="/">Home</a></nav></header>
+    </body></html>`;
+    const zones = extractZones(html, ['header', 'header > nav'], []);
+    expect(zones.map((z) => z.zoneId)).toEqual(['header#0', 'header > nav#0']);
+    expect(zones).toHaveLength(2);
+  });
+
+  it('prunes excluded descendants from htmlSnippet, normalisedText, and structureSkeleton', () => {
+    const html = `<!doctype html><html><body>
+      <header>
+        <a href="/" class="logo">Acme</a>
+        <div class="locale-banner">Browsing from US — switch?</div>
+      </header>
+    </body></html>`;
+    const zones = extractZones(html, ['header'], ['.locale-banner']);
+    expect(zones).toHaveLength(1);
+    const header = zones[0];
+    expect(header.htmlSnippet).not.toContain('locale-banner');
+    expect(header.htmlSnippet).not.toContain('Browsing from US');
+    expect(header.normalisedText).not.toContain('Browsing from US');
+    expect(header.normalisedText).toContain('Acme');
+    expect(header.structureSkeleton).not.toContain('locale-banner');
+  });
+
+  it('exposes the documented ZoneText shape', () => {
+    const html = `<!doctype html><html><body><nav><a href="/">x</a></nav></body></html>`;
+    const [zone] = extractZones(html, ['nav'], []);
+    expect(zone).toBeDefined();
+    expect(typeof zone.zoneId).toBe('string');
+    expect(typeof zone.htmlSnippet).toBe('string');
+    expect(typeof zone.normalisedText).toBe('string');
+    expect(typeof zone.structureSkeleton).toBe('string');
+    expect(Object.keys(zone).sort()).toEqual([
+      'htmlSnippet',
+      'normalisedText',
+      'structureSkeleton',
+      'zoneId',
+    ]);
+  });
+});

--- a/src/registry/extract-zones.ts
+++ b/src/registry/extract-zones.ts
@@ -1,0 +1,116 @@
+import type { ZoneText } from '@/types/registry.js';
+
+const SKIP_TAGS = new Set(['SCRIPT', 'STYLE', 'NOSCRIPT', 'SVG', 'TEMPLATE']);
+
+export function extractZones(
+  html: string,
+  frameSelectors: readonly string[],
+  excludedSelectors: readonly string[],
+): readonly ZoneText[] {
+  if (html.length === 0 || frameSelectors.length === 0) return [];
+
+  let doc: Document;
+  try {
+    doc = new DOMParser().parseFromString(html, 'text/html');
+  } catch {
+    return [];
+  }
+  const body = doc.body;
+  if (body === null || body === undefined) return [];
+
+  const seen = new Set<Element>();
+  const zones: ZoneText[] = [];
+
+  for (const selector of frameSelectors) {
+    const matches = safeQueryAll(body, selector);
+    let ordinal = 0;
+    for (const el of matches) {
+      if (seen.has(el)) continue;
+      if (matchesAny(el, excludedSelectors)) continue;
+      seen.add(el);
+
+      const clone = pruneExcluded(el, excludedSelectors);
+      zones.push({
+        zoneId: `${selector}#${ordinal}`,
+        htmlSnippet: clone.outerHTML,
+        normalisedText: extractNormalisedText(clone),
+        structureSkeleton: buildStructureSkeleton(clone),
+      });
+      ordinal += 1;
+    }
+  }
+
+  return zones;
+}
+
+function safeQueryAll(root: Element, selector: string): readonly Element[] {
+  try {
+    return Array.from(root.querySelectorAll(selector));
+  } catch {
+    return [];
+  }
+}
+
+function matchesAny(el: Element, selectors: readonly string[]): boolean {
+  for (const selector of selectors) {
+    try {
+      if (el.matches(selector)) return true;
+    } catch {
+      continue;
+    }
+  }
+  return false;
+}
+
+function pruneExcluded(el: Element, excludedSelectors: readonly string[]): Element {
+  const clone = el.cloneNode(true) as Element;
+  if (excludedSelectors.length === 0) return clone;
+  const joined = excludedSelectors.join(',');
+  let removed: readonly Element[] = [];
+  try {
+    removed = Array.from(clone.querySelectorAll(joined));
+  } catch {
+    removed = excludedSelectors.flatMap((s) => safeQueryAll(clone, s));
+  }
+  for (const node of removed) {
+    node.parentNode?.removeChild(node);
+  }
+  return clone;
+}
+
+function extractNormalisedText(el: Element): string {
+  const doc = el.ownerDocument;
+  if (doc === null) return '';
+  const walker = doc.createTreeWalker(el, NodeFilter.SHOW_TEXT, {
+    acceptNode(node) {
+      const parent = node.parentElement;
+      if (parent === null) return NodeFilter.FILTER_REJECT;
+      if (SKIP_TAGS.has(parent.tagName)) return NodeFilter.FILTER_REJECT;
+      const text = node.textContent;
+      if (text === null || text.trim().length === 0) return NodeFilter.FILTER_REJECT;
+      return NodeFilter.FILTER_ACCEPT;
+    },
+  });
+
+  const parts: string[] = [];
+  while (walker.nextNode()) {
+    const text = walker.currentNode.textContent ?? '';
+    parts.push(text.replace(/\s+/g, ' ').trim());
+  }
+  return parts.filter((p) => p.length > 0).join(' ');
+}
+
+function buildStructureSkeleton(el: Element): string {
+  const parts: string[] = [];
+  walkSkeleton(el, parts);
+  return parts.join('');
+}
+
+function walkSkeleton(el: Element, parts: string[]): void {
+  if (SKIP_TAGS.has(el.tagName)) return;
+  parts.push('<', el.tagName.toLowerCase(), '>');
+  for (const child of Array.from(el.children)) {
+    walkSkeleton(child, parts);
+  }
+  parts.push('</', el.tagName.toLowerCase(), '>');
+}

--- a/src/types/registry.ts
+++ b/src/types/registry.ts
@@ -1,0 +1,26 @@
+export interface ZoneFingerprint {
+  readonly structural: string;
+  readonly tokens: string;
+  readonly version?: string;
+}
+
+export interface RegistryZone {
+  readonly zoneId: string;
+  readonly selector: string;
+  readonly fingerprint: ZoneFingerprint;
+}
+
+export interface RegistryEntry {
+  readonly origin: string;
+  readonly capturedAt: number;
+  readonly schemaVersion: 1;
+  readonly zones: readonly RegistryZone[];
+  readonly excludedSelectors: readonly string[];
+}
+
+export interface ZoneText {
+  readonly zoneId: string;
+  readonly htmlSnippet: string;
+  readonly normalisedText: string;
+  readonly structureSkeleton: string;
+}


### PR DESCRIPTION
## Summary

Implements **SR-A** from `docs/registry/SITE_STRUCTURE_REGISTRY.md` (item 13 Stage 2 of the master execution plan): the zone-extraction primitive plus the registry TypeScript schema. No crawler, no signing, no orchestrator wiring — those land in SR-C, SR-D, SR-F.

- **`src/types/registry.ts`** — `RegistryEntry`, `RegistryZone`, `ZoneFingerprint`, `ZoneText`, with the multi-factor `{ structural, tokens, version? }` shape from RFC §Q2.
- **`src/registry/extract-zones.ts`** — pure function `extractZones(html, frameSelectors, excludedSelectors): readonly ZoneText[]`. Uses `DOMParser`, prunes excluded descendants, emits a tag-only `structureSkeleton` (locale-stable) and whitespace-collapsed `normalisedText` (the inputs SR-B will hash).
- **`src/registry/__tests__/extract-zones.test.ts`** — TDD-first, 10 cases covering static-frame extraction, locale invariance, signed-in/out tolerance via excluded selectors, frame-level exclusion, descendant pruning, dedupe, deterministic doc-order zoneIds, ZoneText shape, and empty/malformed input safety.

No new runtime dependencies. Phase 2 byte-locked baseline untouched. SR-B will consume this `ZoneText` shape directly.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 1150/1150 pass (+10 vs. 1140 baseline; ≥6 SR-A target met)
- [x] `npm run build` clean
- [x] `npm audit --omit=dev` — 0 vulnerabilities
- [x] AIza secret grep across `src/`, `scripts/`, `docs/registry/` — no hits

Refs #51 (DO NOT close — SR-A is one of eight registry sub-stages).