### PR TITLE
feat(registry-#51): SR-B multi-factor fingerprint hasher

### DIFF
--- a/src/registry/__tests__/fingerprint.test.ts
+++ b/src/registry/__tests__/fingerprint.test.ts
@@ -1,0 +1,132 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { extractZones } from '../extract-zones.js';
+import { fingerprintZone } from '../fingerprint.js';
+import type { ZoneText } from '@/types/registry.js';
+
+const FRAME_SELECTORS = ['nav', 'header', 'footer'] as const;
+
+const SHA256_OF_EMPTY = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855';
+
+const baseHtml = (greeting: string, mainText: string, lang = 'en'): string => `<!doctype html>
+<html lang="${lang}">
+  <head><title>Acme</title></head>
+  <body>
+    <header>
+      <a href="/" class="logo">Acme</a>
+      <span class="user-greeting">${greeting}</span>
+    </header>
+    <nav>
+      <ul>
+        <li><a href="/products">Products</a></li>
+        <li><a href="/pricing">Pricing</a></li>
+        <li><a href="/about">About</a></li>
+      </ul>
+    </nav>
+    <article>${mainText}</article>
+    <footer>
+      <p>© 2026 Acme Corp</p>
+    </footer>
+  </body>
+</html>`;
+
+const findZone = (zones: readonly ZoneText[], selector: string): ZoneText => {
+  const z = zones.find((x) => x.zoneId.startsWith(selector + '#'));
+  if (z === undefined) throw new Error(`no zone for selector ${selector}`);
+  return z;
+};
+
+describe('fingerprintZone', () => {
+  it('produces an identical structural hash across locale variants of the same DOM', async () => {
+    const en = baseHtml('Welcome guest', '<p>EN body</p>', 'en');
+    const es = baseHtml('Bienvenido invitado', '<p>ES body</p>', 'es');
+
+    const enZones = extractZones(en, [...FRAME_SELECTORS], []);
+    const esZones = extractZones(es, [...FRAME_SELECTORS], []);
+
+    for (const enZone of enZones) {
+      const esZone = findZone(esZones, enZone.zoneId.split('#')[0]);
+      const enFp = await fingerprintZone(enZone);
+      const esFp = await fingerprintZone(esZone);
+      expect(esFp.structural).toBe(enFp.structural);
+    }
+
+    const enHeader = await fingerprintZone(findZone(enZones, 'header'));
+    const esHeader = await fingerprintZone(findZone(esZones, 'header'));
+    expect(esHeader.tokens).not.toBe(enHeader.tokens);
+  });
+
+  it('produces an identical tokens hash across DOM-shape variants that preserve visible text', async () => {
+    const wrappedInP = `<!doctype html><html><body><nav><p>Same Visible Text</p></nav></body></html>`;
+    const wrappedInSpan = `<!doctype html><html><body><nav><span>Same Visible Text</span></nav></body></html>`;
+
+    const [pZone] = extractZones(wrappedInP, ['nav'], []);
+    const [spanZone] = extractZones(wrappedInSpan, ['nav'], []);
+
+    expect(pZone.normalisedText).toBe(spanZone.normalisedText);
+    expect(pZone.structureSkeleton).not.toBe(spanZone.structureSkeleton);
+
+    const pFp = await fingerprintZone(pZone);
+    const spanFp = await fingerprintZone(spanZone);
+
+    expect(spanFp.tokens).toBe(pFp.tokens);
+    expect(spanFp.structural).not.toBe(pFp.structural);
+  });
+
+  it('flips both structural and tokens hashes when content is injected', async () => {
+    const original = `<!doctype html><html><body><nav><a href="/">Home</a></nav></body></html>`;
+    const injected = `<!doctype html><html><body><nav><a href="/">Home</a><p>injected paragraph</p></nav></body></html>`;
+
+    const [origZone] = extractZones(original, ['nav'], []);
+    const [injZone] = extractZones(injected, ['nav'], []);
+
+    const origFp = await fingerprintZone(origZone);
+    const injFp = await fingerprintZone(injZone);
+
+    expect(injFp.structural).not.toBe(origFp.structural);
+    expect(injFp.tokens).not.toBe(origFp.tokens);
+  });
+
+  it('returns SHA-256 of empty string for both factors when given an empty ZoneText', async () => {
+    const empty: ZoneText = {
+      zoneId: 'header#0',
+      htmlSnippet: '',
+      normalisedText: '',
+      structureSkeleton: '',
+    };
+
+    const fp = await fingerprintZone(empty);
+
+    expect(fp.structural).toBe(SHA256_OF_EMPTY);
+    expect(fp.tokens).toBe(SHA256_OF_EMPTY);
+    expect(fp.version).toBeUndefined();
+  });
+
+  it('returns version undefined in v1 (signing arrives in SR-D)', async () => {
+    const html = `<!doctype html><html><body><nav><a href="/">x</a></nav></body></html>`;
+    const [zone] = extractZones(html, ['nav'], []);
+    const fp = await fingerprintZone(zone);
+
+    expect(fp.version).toBeUndefined();
+  });
+
+  it('returns 64-character lowercase hex SHA-256 strings for both factors', async () => {
+    const html = `<!doctype html><html><body><nav><a href="/">x</a></nav></body></html>`;
+    const [zone] = extractZones(html, ['nav'], []);
+    const fp = await fingerprintZone(zone);
+
+    expect(fp.structural).toMatch(/^[0-9a-f]{64}$/);
+    expect(fp.tokens).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('is deterministic — repeated calls on the same ZoneText yield identical hashes', async () => {
+    const html = `<!doctype html><html><body><header><h1>Title</h1></header></body></html>`;
+    const [zone] = extractZones(html, ['header'], []);
+
+    const a = await fingerprintZone(zone);
+    const b = await fingerprintZone(zone);
+
+    expect(b.structural).toBe(a.structural);
+    expect(b.tokens).toBe(a.tokens);
+  });
+});

--- a/src/registry/fingerprint.ts
+++ b/src/registry/fingerprint.ts
@@ -1,0 +1,10 @@
+import { sha256Hex } from '@/shared/hash.js';
+import type { ZoneFingerprint, ZoneText } from '@/types/registry.js';
+
+export async function fingerprintZone(zone: ZoneText): Promise<ZoneFingerprint> {
+  const [structural, tokens] = await Promise.all([
+    sha256Hex(zone.structureSkeleton),
+    sha256Hex(zone.normalisedText),
+  ]);
+  return { structural, tokens };
+}


### PR DESCRIPTION
## Summary

Stage 3 of the site-structure registry RFC (#51). Adds the multi-factor fingerprint hasher that consumes SR-A's `ZoneText` shape and produces a `ZoneFingerprint`.

- `src/registry/fingerprint.ts` — `async fingerprintZone(zone: ZoneText): Promise<ZoneFingerprint>`. Pure (no `chrome.*`, no I/O, no DOM). Reuses `sha256Hex()` from `src/shared/hash.ts`. ~10 LOC.
- `src/registry/__tests__/fingerprint.test.ts` — 7 TDD-first cases driven through `extractZones()` so the SR-A → SR-B contract is exercised end-to-end (not mocked).

Both factors are full SHA-256 (not the truncated 512-char content-hash used elsewhere in the SW). Registry zones are short-string inputs and full hashing eliminates collision risk for the future orchestrator comparison contract.

## RFC §Q2 properties covered

- `structural` is invariant under text translation (locale): EN vs ES variants of the same DOM produce identical `structural` hashes
- `tokens` is invariant under DOM-shape variation that preserves visible text: `<p>X</p>` vs `<span>X</span>` yields the same `tokens` hash
- Injection (extra paragraph) flips both `structural` and `tokens`
- Empty `ZoneText` returns the well-known SHA-256 of empty string (`e3b0c44...b855`) for both factors — deterministic, never `undefined`/`null`
- `version` stays `undefined` in v1 (SR-D introduces signing)
- 64-char lowercase hex output for both factors
- Repeat-call determinism

## Out of scope

- No crawler (SR-C)
- No signing / Ed25519 (SR-D)
- No orchestrator wiring (SR-F)
- No new dependencies
- `ZoneFingerprint` / `ZoneText` shapes from SR-A are reused as-is — not reshaped

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 1157 passed (1150 → 1157, +7)
- [x] `npm run build` — clean
- [x] `npm audit --omit=dev` — 0 vulnerabilities
- [x] AIza ≥20-char secret grep — clean
- [x] Phase 2 byte-locked baseline (`docs/testing/inbrowser-results.json`) NOT touched
- [x] `src/types/registry.ts` NOT modified (SR-A contract preserved)
- [x] `src/service-worker/orchestrator.ts` NOT modified (SR-F territory)

## Refs

Refs #51 (registry is multi-stage; SR-B is 1 of 8 sub-items — do not close)