### PR TITLE
feat(registry-#51): SR-C crawler MVP scaffold (1 site)

### DIFF
--- a/.github/workflows/registry-crawl.yml
+++ b/.github/workflows/registry-crawl.yml
@@ -1,0 +1,64 @@
+name: Registry Crawl
+
+# Site-Structure Registry crawler (issue #51 / SR-C Stage 4a).
+# Fetches each site listed in registry/sites/manifest.json, extracts the
+# stable structural zones, hashes them, and writes one JSON file per site
+# under registry/sites/. When the crawl produces a diff, opens a PR so a
+# human can review whether the structural drift is legitimate.
+#
+# Workflow inputs are static. No github.event.* values are interpolated
+# into run: steps or shell commands; all PR metadata is hard-coded below.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Mondays at 06:00 UTC. Adjust cadence in Stage 4b once the gate exists.
+    - cron: '0 6 * * 1'
+
+concurrency:
+  group: registry-crawl
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  crawl:
+    name: crawl + diff PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run crawler
+        run: npx tsx scripts/crawl-registry.ts
+
+      - name: Open PR if registry changed
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          add-paths: registry/sites/*.json
+          branch: chore/registry-auto-refresh
+          delete-branch: true
+          commit-message: 'chore(registry-#51): refresh registry/sites/*.json'
+          title: 'chore(registry-#51): refresh registry/sites/*.json'
+          body: |
+            Automated registry crawl produced a diff in `registry/sites/*.json`.
+
+            Refs #51. SR-C Stage 4a (Stage 4b adds the multi-location matrix
+            and diversity gate). Review the structural-fingerprint changes
+            before merging - a legitimate site redesign should produce one
+            cohesive PR; isolated single-zone churn may indicate a brittle
+            selector.

--- a/registry/sites/gmail.com.json
+++ b/registry/sites/gmail.com.json
@@ -1,0 +1,36 @@
+{
+  "origin": "gmail.com",
+  "capturedAt": 1777529370554,
+  "schemaVersion": 1,
+  "zones": [
+    {
+      "zoneId": "header.TemplateHeader_header#0",
+      "selector": "header.TemplateHeader_header",
+      "fingerprint": {
+        "structural": "4a9cd9d7496358e29716c268d2cf631f042bbf88126e482910566a9021bef920",
+        "tokens": "f4e27a3ba6cfed5bc17306e1ae66e7192d2b961e0360a3126baf13e9b9e6ce1d"
+      }
+    },
+    {
+      "zoneId": "nav.TemplateHeader_headerNav#0",
+      "selector": "nav.TemplateHeader_headerNav",
+      "fingerprint": {
+        "structural": "4ff9916ad9a220a0ba8278ce5f988e9d49458603c37e73f382feb65b6b935a67",
+        "tokens": "c887f134c26ea8310e1fb4bd6fbab7b640393bd1b556e62691c7a442be92ec2a"
+      }
+    },
+    {
+      "zoneId": "footer#0",
+      "selector": "footer",
+      "fingerprint": {
+        "structural": "65d8df46a8c508719b6597ae3203db1005ae07e85f8fc68fe42946ce02130ad0",
+        "tokens": "bcd448fa7683119786df488394a22ce8c35b5392c8d8d02feebb12e2d60a42fc"
+      }
+    }
+  ],
+  "excludedSelectors": [
+    "nav.dropdown-menu",
+    "[aria-hidden=\"true\"]",
+    "[data-user-name]"
+  ]
+}

--- a/registry/sites/manifest.json
+++ b/registry/sites/manifest.json
@@ -1,0 +1,16 @@
+[
+  {
+    "origin": "gmail.com",
+    "url": "https://www.google.com/gmail/about/",
+    "frameSelectors": [
+      "header.TemplateHeader_header",
+      "nav.TemplateHeader_headerNav",
+      "footer"
+    ],
+    "excludedSelectors": [
+      "nav.dropdown-menu",
+      "[aria-hidden=\"true\"]",
+      "[data-user-name]"
+    ]
+  }
+]

--- a/scripts/__tests__/crawl-registry.test.ts
+++ b/scripts/__tests__/crawl-registry.test.ts
@@ -1,0 +1,235 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, readFile, readdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { crawlRegistry } from '../crawl-registry.js';
+import type { SiteManifestEntry } from '../crawl-registry.js';
+import type { RegistryEntry } from '@/types/registry.js';
+
+const HEX64 = /^[0-9a-f]{64}$/;
+
+const baseHtml = (greeting: string): string => `<!doctype html>
+<html lang="en">
+  <head><title>Acme</title></head>
+  <body>
+    <header>
+      <a href="/" class="logo">Acme</a>
+      <span class="user-greeting">${greeting}</span>
+    </header>
+    <nav><ul><li><a href="/">Home</a></li></ul></nav>
+    <article><p>variable content</p></article>
+    <footer><p>(c) Acme</p></footer>
+  </body>
+</html>`;
+
+const okResponse = (html: string): Response =>
+  new Response(html, { status: 200, headers: { 'content-type': 'text/html' } });
+
+type FetchHandler = Response | Error | (() => Response | Promise<Response>);
+
+const makeFetch = (responses: Readonly<Record<string, FetchHandler>>) =>
+  async (input: RequestInfo | URL): Promise<Response> => {
+    const url = typeof input === 'string' ? input : input.toString();
+    const handler = responses[url];
+    if (handler === undefined) throw new Error(`unmocked URL ${url}`);
+    if (handler instanceof Error) throw handler;
+    return typeof handler === 'function' ? handler() : handler;
+  };
+
+const silentLogger = { info: (): void => {}, warn: (): void => {} };
+
+let outputDir: string;
+
+beforeEach(async () => {
+  outputDir = await mkdtemp(join(tmpdir(), 'crawl-registry-'));
+});
+
+afterEach(async () => {
+  await rm(outputDir, { recursive: true, force: true });
+});
+
+describe('crawlRegistry', () => {
+  it('writes a schema-valid RegistryEntry per site in the manifest', async () => {
+    const manifest: readonly SiteManifestEntry[] = [
+      {
+        origin: 'acme.test',
+        url: 'https://acme.test/',
+        frameSelectors: ['nav', 'header', 'footer'],
+        excludedSelectors: ['.user-greeting'],
+      },
+    ];
+    const fetchFn = makeFetch({
+      'https://acme.test/': okResponse(baseHtml('Welcome guest')),
+    });
+
+    const result = await crawlRegistry({
+      manifest,
+      outputDir,
+      fetchFn,
+      now: () => 1735689600000,
+      logger: silentLogger,
+    });
+
+    expect(result.written).toHaveLength(1);
+    expect(result.skipped).toHaveLength(0);
+
+    const path = join(outputDir, 'acme.test.json');
+    const entry = JSON.parse(await readFile(path, 'utf8')) as RegistryEntry;
+
+    expect(entry.origin).toBe('acme.test');
+    expect(entry.schemaVersion).toBe(1);
+    expect(entry.capturedAt).toBe(1735689600000);
+    expect(entry.excludedSelectors).toEqual(['.user-greeting']);
+    expect(entry.zones.length).toBe(3);
+  });
+
+  it('produces 64-char hex fingerprints (structural + tokens) per zone', async () => {
+    const manifest: readonly SiteManifestEntry[] = [
+      {
+        origin: 'acme.test',
+        url: 'https://acme.test/',
+        frameSelectors: ['header', 'nav', 'footer'],
+        excludedSelectors: [],
+      },
+    ];
+    const fetchFn = makeFetch({
+      'https://acme.test/': okResponse(baseHtml('Hi')),
+    });
+
+    const result = await crawlRegistry({
+      manifest,
+      outputDir,
+      fetchFn,
+      logger: silentLogger,
+    });
+
+    const entry = JSON.parse(await readFile(result.written[0], 'utf8')) as RegistryEntry;
+    expect(entry.zones.length).toBeGreaterThan(0);
+    for (const zone of entry.zones) {
+      expect(typeof zone.zoneId).toBe('string');
+      expect(typeof zone.selector).toBe('string');
+      expect(zone.zoneId.startsWith(`${zone.selector}#`)).toBe(true);
+      expect(zone.fingerprint.structural).toMatch(HEX64);
+      expect(zone.fingerprint.tokens).toMatch(HEX64);
+    }
+  });
+
+  it('skips a site when fetch throws and continues with the rest', async () => {
+    const manifest: readonly SiteManifestEntry[] = [
+      {
+        origin: 'broken.test',
+        url: 'https://broken.test/',
+        frameSelectors: ['nav', 'header', 'footer'],
+        excludedSelectors: [],
+      },
+      {
+        origin: 'ok.test',
+        url: 'https://ok.test/',
+        frameSelectors: ['nav', 'header', 'footer'],
+        excludedSelectors: [],
+      },
+    ];
+    const fetchFn = makeFetch({
+      'https://broken.test/': new Error('connection refused'),
+      'https://ok.test/': okResponse(baseHtml('Hi')),
+    });
+
+    const result = await crawlRegistry({
+      manifest,
+      outputDir,
+      fetchFn,
+      logger: silentLogger,
+    });
+
+    expect(result.skipped.map((s) => s.origin)).toEqual(['broken.test']);
+    expect(result.skipped[0].reason).toBe('fetch-failed');
+    expect(result.written).toHaveLength(1);
+    expect(result.written[0]).toContain('ok.test.json');
+
+    const files = await readdir(outputDir);
+    expect(files.sort()).toEqual(['ok.test.json']);
+  });
+
+  it('skips a site when fetch returns a non-ok status', async () => {
+    const manifest: readonly SiteManifestEntry[] = [
+      {
+        origin: 'forbidden.test',
+        url: 'https://forbidden.test/',
+        frameSelectors: ['nav'],
+        excludedSelectors: [],
+      },
+    ];
+    const fetchFn = makeFetch({
+      'https://forbidden.test/': new Response('forbidden', { status: 403 }),
+    });
+
+    const result = await crawlRegistry({
+      manifest,
+      outputDir,
+      fetchFn,
+      logger: silentLogger,
+    });
+
+    expect(result.written).toHaveLength(0);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0].reason).toBe('fetch-failed');
+    expect(result.skipped[0].detail).toContain('403');
+  });
+
+  it('skips a site when extractZones returns no zones', async () => {
+    const manifest: readonly SiteManifestEntry[] = [
+      {
+        origin: 'empty.test',
+        url: 'https://empty.test/',
+        frameSelectors: ['nav', 'header', 'footer'],
+        excludedSelectors: [],
+      },
+    ];
+    const fetchFn = makeFetch({
+      'https://empty.test/': okResponse(
+        '<!doctype html><html><body><main>only main</main></body></html>',
+      ),
+    });
+
+    const result = await crawlRegistry({
+      manifest,
+      outputDir,
+      fetchFn,
+      logger: silentLogger,
+    });
+
+    expect(result.written).toHaveLength(0);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0].reason).toBe('no-zones');
+
+    const files = await readdir(outputDir);
+    expect(files).toEqual([]);
+  });
+
+  it('persists excludedSelectors verbatim from the manifest entry', async () => {
+    const excluded = ['.user-greeting', '[data-user-name]'];
+    const manifest: readonly SiteManifestEntry[] = [
+      {
+        origin: 'acme.test',
+        url: 'https://acme.test/',
+        frameSelectors: ['header'],
+        excludedSelectors: excluded,
+      },
+    ];
+    const fetchFn = makeFetch({
+      'https://acme.test/': okResponse(baseHtml('Hi')),
+    });
+
+    const result = await crawlRegistry({
+      manifest,
+      outputDir,
+      fetchFn,
+      logger: silentLogger,
+    });
+
+    const entry = JSON.parse(await readFile(result.written[0], 'utf8')) as RegistryEntry;
+    expect(entry.excludedSelectors).toEqual(excluded);
+  });
+});

--- a/scripts/crawl-registry.ts
+++ b/scripts/crawl-registry.ts
@@ -1,0 +1,185 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { JSDOM } from 'jsdom';
+
+import { extractZones } from '../src/registry/extract-zones.js';
+import { fingerprintZone } from '../src/registry/fingerprint.js';
+import type {
+  RegistryEntry,
+  RegistryZone,
+  ZoneFingerprint,
+  ZoneText,
+} from '../src/types/registry.js';
+
+export interface SiteManifestEntry {
+  readonly origin: string;
+  readonly url: string;
+  readonly frameSelectors: readonly string[];
+  readonly excludedSelectors: readonly string[];
+}
+
+export interface CrawlLogger {
+  readonly info: (message: string) => void;
+  readonly warn: (message: string) => void;
+}
+
+export interface CrawlOptions {
+  readonly manifest: readonly SiteManifestEntry[];
+  readonly outputDir: string;
+  readonly fetchFn?: typeof fetch;
+  readonly now?: () => number;
+  readonly logger?: CrawlLogger;
+}
+
+export type CrawlSkipReason = 'fetch-failed' | 'no-zones';
+
+export interface CrawlSkipped {
+  readonly origin: string;
+  readonly reason: CrawlSkipReason;
+  readonly detail: string;
+}
+
+export interface CrawlResult {
+  readonly written: readonly string[];
+  readonly skipped: readonly CrawlSkipped[];
+}
+
+export async function crawlRegistry(options: CrawlOptions): Promise<CrawlResult> {
+  ensureBrowserGlobals();
+
+  const fetchFn = options.fetchFn ?? fetch;
+  const now = options.now ?? Date.now;
+  const logger = options.logger ?? defaultLogger;
+
+  await mkdir(options.outputDir, { recursive: true });
+
+  const written: string[] = [];
+  const skipped: CrawlSkipped[] = [];
+
+  for (const site of options.manifest) {
+    const outcome = await crawlOne(site, fetchFn, now, logger);
+    if (outcome.kind === 'skipped') {
+      skipped.push({
+        origin: outcome.origin,
+        reason: outcome.reason,
+        detail: outcome.detail,
+      });
+      continue;
+    }
+    const path = join(options.outputDir, `${site.origin}.json`);
+    await writeFile(path, `${JSON.stringify(outcome.entry, null, 2)}\n`, 'utf8');
+    written.push(path);
+    logger.info(`wrote ${path} (${outcome.entry.zones.length} zones)`);
+  }
+
+  return { written, skipped };
+}
+
+interface CrawlOk {
+  readonly kind: 'ok';
+  readonly entry: RegistryEntry;
+}
+
+interface CrawlSkippedInternal {
+  readonly kind: 'skipped';
+  readonly origin: string;
+  readonly reason: CrawlSkipReason;
+  readonly detail: string;
+}
+
+async function crawlOne(
+  site: SiteManifestEntry,
+  fetchFn: typeof fetch,
+  now: () => number,
+  logger: CrawlLogger,
+): Promise<CrawlOk | CrawlSkippedInternal> {
+  let html: string;
+  try {
+    const res = await fetchFn(site.url, { redirect: 'follow' });
+    if (!res.ok) {
+      const detail = `status ${res.status}`;
+      logger.warn(`${site.origin}: fetch failed (${detail})`);
+      return { kind: 'skipped', origin: site.origin, reason: 'fetch-failed', detail };
+    }
+    html = await res.text();
+  } catch (err: unknown) {
+    const detail = err instanceof Error ? err.message : String(err);
+    logger.warn(`${site.origin}: fetch error: ${detail}`);
+    return { kind: 'skipped', origin: site.origin, reason: 'fetch-failed', detail };
+  }
+
+  const zones: readonly ZoneText[] = extractZones(
+    html,
+    site.frameSelectors,
+    site.excludedSelectors,
+  );
+  if (zones.length === 0) {
+    const detail = 'extractZones returned 0 zones';
+    logger.warn(`${site.origin}: ${detail}`);
+    return { kind: 'skipped', origin: site.origin, reason: 'no-zones', detail };
+  }
+
+  const fingerprints: readonly ZoneFingerprint[] = await Promise.all(
+    zones.map((zone) => fingerprintZone(zone)),
+  );
+  const registryZones: readonly RegistryZone[] = zones.map((zone, idx) => ({
+    zoneId: zone.zoneId,
+    selector: zone.zoneId.split('#')[0] ?? zone.zoneId,
+    fingerprint: fingerprints[idx],
+  }));
+
+  const entry: RegistryEntry = {
+    origin: site.origin,
+    capturedAt: now(),
+    schemaVersion: 1,
+    zones: registryZones,
+    excludedSelectors: site.excludedSelectors,
+  };
+  return { kind: 'ok', entry };
+}
+
+function ensureBrowserGlobals(): void {
+  const g = globalThis as {
+    DOMParser?: typeof DOMParser;
+    NodeFilter?: typeof NodeFilter;
+    Node?: typeof Node;
+  };
+  if (typeof g.DOMParser !== 'undefined' && typeof g.NodeFilter !== 'undefined') return;
+  const dom = new JSDOM('<!doctype html><html><body></body></html>');
+  g.DOMParser ??= dom.window.DOMParser;
+  g.NodeFilter ??= dom.window.NodeFilter;
+  g.Node ??= dom.window.Node;
+}
+
+const defaultLogger: CrawlLogger = {
+  info: (message) => process.stdout.write(`${message}\n`),
+  warn: (message) => process.stderr.write(`${message}\n`),
+};
+
+async function runCli(): Promise<void> {
+  const cwd = process.cwd();
+  const manifestPath = join(cwd, 'registry/sites/manifest.json');
+  const outputDir = join(cwd, 'registry/sites');
+
+  const raw = await readFile(manifestPath, 'utf8');
+  const manifest = JSON.parse(raw) as readonly SiteManifestEntry[];
+
+  const result = await crawlRegistry({ manifest, outputDir });
+  process.stdout.write(
+    `crawl complete: wrote ${result.written.length}, skipped ${result.skipped.length}\n`,
+  );
+  if (result.skipped.length > 0) {
+    for (const s of result.skipped) {
+      process.stdout.write(`  skipped ${s.origin}: ${s.reason} (${s.detail})\n`);
+    }
+  }
+}
+
+const isMain = process.argv[1] !== undefined && import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  runCli().catch((err: unknown) => {
+    const msg = err instanceof Error ? err.stack ?? err.message : String(err);
+    process.stderr.write(`crawl-registry failed: ${msg}\n`);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

Stage 4a of the site-structure registry pipeline (`docs/registry/SITE_STRUCTURE_REGISTRY.md` §Q3 + §Q4). Lands the server-side crawler skeleton end-to-end for one site (gmail.com); Stage 4b will add the multi-location matrix and the diversity gate.

- `scripts/crawl-registry.ts` — Node entry point; fetches each manifest entry, shims jsdom `DOMParser` / `NodeFilter` so the SR-A primitive runs server-side, calls `extractZones()` + `fingerprintZone()` per site, writes one `RegistryEntry` JSON per origin. Skips (does not abort) on fetch failure or zero-zone extraction.
- `scripts/__tests__/crawl-registry.test.ts` — 6 TDD-first cases: schema-valid output, 64-char hex fingerprints, fetch error, non-ok status, no-zones, excludedSelectors persistence.
- `registry/sites/manifest.json` — 1 entry (gmail.com). Stage 4b adds 9 more.
- `registry/sites/gmail.com.json` — produced by running the crawler against `https://www.google.com/gmail/about/`; 3 zones (header / nav / footer).
- `.github/workflows/registry-crawl.yml` — `workflow_dispatch` + weekly cron; opens a diff PR via `peter-evans/create-pull-request@v6` (no untrusted input is interpolated into `run:` steps).

Test count: 1157 → 1163. Refs #51 (do not close — SR-C is one of eight sub-items).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 1163 / 1163 (+6)
- [x] `npm run build` — clean
- [x] `npm audit` — 0 vulns
- [x] Crawler CLI run locally against gmail.com about page produces a valid 3-zone `gmail.com.json`
- [ ] CI green on this PR
- [ ] (Post-merge, optional) Trigger `Registry Crawl` workflow via `workflow_dispatch` to verify the GH Action

## Notes for reviewers

- **Stage 4a scope is intentionally tight**: 1 site, no multi-location matrix, no diversity gate, no signing (SR-D). Scope creep deferred to Stage 4b.
- **`capturedAt` will produce a noisy diff every run** — `Date.now()` always changes. Stage 4b will preserve `capturedAt` when fingerprints are unchanged. Acceptable for the scaffold.
- **DOMParser-in-Node strategy chosen**: the crawler shims `globalThis.DOMParser` / `NodeFilter` / `Node` from a one-shot `JSDOM` instance rather than refactoring the SR-A `extractZones()` signature. This preserves the SR-A contract (do-not-reshape per RFC).
- **PR-creation pattern is new for this repo**: `peter-evans/create-pull-request@v6` with the default `GITHUB_TOKEN` — no PAT required. The workflow grants `contents: write` + `pull-requests: write` only.

Refs #51