### PR TITLE
feat(registry-#51): SR-E bundled distribution

### DIFF
--- a/.github/workflows/registry-crawl.yml
+++ b/.github/workflows/registry-crawl.yml
@@ -96,15 +96,26 @@ jobs:
             --prior registry/sites \
             --output registry/sites
 
+      # SR-E (registry-#51) — sign aggregated entries. The private key never
+      # leaves this runner; only the SignedRegistryBundle is committed. If
+      # the secret is unset (fork or pre-rollout), this step is skipped.
+      - name: Sign registry bundle
+        if: ${{ env.HONEYLLM_REGISTRY_SIGNING_KEY != '' }}
+        env:
+          HONEYLLM_REGISTRY_SIGNING_KEY: ${{ secrets.HONEYLLM_REGISTRY_SIGNING_KEY }}
+        run: npm run sign:registry
+
       - name: Open PR if registry changed
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          add-paths: registry/sites/*.json
+          add-paths: |
+            registry/sites/*.json
+            registry/signed-registry.json
           branch: chore/registry-auto-refresh
           delete-branch: true
-          commit-message: 'chore(registry-#51): refresh registry/sites/*.json'
-          title: 'chore(registry-#51): refresh registry/sites/*.json'
+          commit-message: 'chore(registry-#51): refresh registry/sites/*.json + signed-registry.json'
+          title: 'chore(registry-#51): refresh registry/sites/*.json + signed-registry.json'
           body: |
             Automated registry crawl (multi-vantage-point matrix:
             ubuntu-latest + windows-latest + macos-latest GH-hosted runners)

--- a/build.ts
+++ b/build.ts
@@ -1,13 +1,16 @@
 import { build } from 'vite';
 import { resolve } from 'path';
-import { copyFileSync, mkdirSync, existsSync, rmSync } from 'fs';
+import { existsSync, rmSync } from 'fs';
+
+import { BUILD_ASSETS, copyBuildAssets } from './scripts/build-assets.js';
 
 // Issue #156 — @huggingface/transformers ships a prebuilt minified browser
 // ESM bundle at `dist/transformers.web.min.js` (~432 KB). We mark the
 // package as `external` for Vite's offscreen entry so Rollup does not
 // re-bundle it into a multi-megabyte chunk; instead the prebuilt bundle is
-// copied verbatim into `dist/transformers/` and loaded at runtime via
-// `chrome.runtime.getURL` (see src/offscreen/transformers-runtime.ts).
+// copied verbatim into `dist/transformers/` (see BUILD_ASSETS) and loaded
+// at runtime via `chrome.runtime.getURL` (see
+// src/offscreen/transformers-runtime.ts).
 const TRANSFORMERS_EXTERNAL = ['@huggingface/transformers'];
 
 const __dirname = resolve('.');
@@ -20,9 +23,7 @@ interface BuildEntry {
   // package external so Rollup leaves the runtime `import()` call intact.
   // The transformers-runtime singleton rewrites the import URL to a
   // `chrome.runtime.getURL('dist/transformers/transformers.web.min.js')`
-  // path at runtime, where the prebuilt minified browser bundle is served
-  // from. Keeps the offscreen entry small (~6 MB) and the bundle delta
-  // bounded (~432 KB for the prebuilt bundle, copied below).
+  // path at runtime.
   readonly external?: readonly string[];
 }
 
@@ -78,30 +79,14 @@ async function main() {
     });
   }
 
-  const assets: [string, string][] = [
-    ['src/offscreen/offscreen.html', 'dist/offscreen/offscreen.html'],
-    ['src/popup/popup.html', 'dist/popup/popup.html'],
-    ['src/tests/phase3/builtin-harness.html', 'dist/tests/phase3/builtin-harness.html'],
-    // Issue #156 — prebuilt minified browser bundle of @huggingface/transformers
-    // (~432 KB). Loaded via `chrome.runtime.getURL` from the offscreen doc; the
-    // adjacent `.mjs` file is the JSEP loader companion that ONNX Runtime
-    // imports lazily. WASM kernels and the actual NER model are NOT shipped —
-    // they lazy-fetch from the HF/jsdelivr CDN at first use and cache via
-    // the Cache API.
-    [
-      'node_modules/@huggingface/transformers/dist/transformers.web.min.js',
-      'dist/transformers/transformers.web.min.js',
-    ],
-    [
-      'node_modules/@huggingface/transformers/dist/ort-wasm-simd-threaded.jsep.mjs',
-      'dist/transformers/ort-wasm-simd-threaded.jsep.mjs',
-    ],
-  ];
-  for (const [src, dest] of assets) {
-    const destDir = resolve(__dirname, dest, '..');
-    if (!existsSync(destDir)) mkdirSync(destDir, { recursive: true });
-    copyFileSync(resolve(__dirname, src), resolve(__dirname, dest));
-  }
+  copyBuildAssets(BUILD_ASSETS, {
+    projectRoot: __dirname,
+    onSkip: (src) => {
+      console.warn(
+        `[build] asset missing, skipping copy: ${src} (this is expected for registry/signed-registry.json before SR-E maintainer signing has produced the first bundle)`,
+      );
+    },
+  });
 
   console.log('Build complete.');
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev": "vite build --watch",
     "build": "tsc --noEmit && npx tsx build.ts",
     "build:simple": "tsc --noEmit && vite build",
+    "sign:registry": "tsx scripts/sign-registry.ts --input registry/sites --output registry/signed-registry.json",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/scripts/__tests__/build-assets.test.ts
+++ b/scripts/__tests__/build-assets.test.ts
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from 'vitest';
+import { existsSync } from 'node:fs';
+import { mkdtemp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+import * as ed from '@noble/ed25519';
+
+import { BUILD_ASSETS, copyBuildAssets } from '../build-assets.js';
+import { signRegistryFromDir } from '../sign-registry.js';
+import { bytesToHex } from '@/registry/canonical-bundle.js';
+import { verifyRegistry } from '@/registry/verify.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..', '..');
+
+describe('BUILD_ASSETS', () => {
+  it('declares the signed registry bundle as a copy target into dist/', () => {
+    const pair = BUILD_ASSETS.find(([src]) => src === 'registry/signed-registry.json');
+    expect(pair).toBeDefined();
+    expect(pair?.[1]).toBe('dist/registry/signed-registry.json');
+  });
+});
+
+describe('copyBuildAssets', () => {
+  let tmp: string;
+
+  beforeEach(async () => {
+    tmp = await mkdtemp(join(tmpdir(), 'sr-e-build-assets-'));
+  });
+  afterEach(async () => {
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  it('copies present sources to their destinations under the project root', async () => {
+    const srcRel = 'tmp-fixture/source.txt';
+    const destRel = 'tmp-fixture/dest.txt';
+    await mkdir(join(tmp, 'tmp-fixture'), { recursive: true });
+    await writeFile(join(tmp, srcRel), 'hello', 'utf8');
+
+    copyBuildAssets([[srcRel, destRel]], { projectRoot: tmp });
+
+    const written = await readFile(join(tmp, destRel), 'utf8');
+    expect(written).toBe('hello');
+  });
+
+  it('skips (does not throw) when a source asset is missing — required for SR-E ramp-up', () => {
+    // signed-registry.json may not be committed yet during the SR-E rollout
+    // window; the build must remain green so unrelated work is not blocked.
+    expect(() =>
+      copyBuildAssets([['missing/file.txt', 'dist/missing/file.txt']], { projectRoot: tmp }),
+    ).not.toThrow();
+    expect(existsSync(join(tmp, 'dist/missing/file.txt'))).toBe(false);
+  });
+});
+
+// Real-input round-trip: signing the currently-committed registry/sites/ with
+// a fresh keypair must produce a verifying SignedRegistryBundle. This is the
+// SR-E "smaller scripts-side test" alternative to a full build-output assertion
+// (the latter would require the v1 maintainer private key in the test env,
+// which intentionally never enters the repo or test fixtures).
+describe('signRegistryFromDir against committed registry/sites/', () => {
+  let privHex: string;
+  let pubHex: string;
+  let outDir: string;
+
+  beforeAll(async () => {
+    const priv = ed.utils.randomPrivateKey();
+    privHex = bytesToHex(priv);
+    pubHex = bytesToHex(await ed.getPublicKeyAsync(priv));
+  });
+  beforeEach(async () => {
+    outDir = await mkdtemp(join(tmpdir(), 'sr-e-sign-real-'));
+  });
+  afterEach(async () => {
+    await rm(outDir, { recursive: true, force: true });
+  });
+
+  it('signs every committed RegistryEntry JSON and the bundle verifies', async () => {
+    const sitesDir = join(REPO_ROOT, 'registry/sites');
+    const committedJsons = (await readdir(sitesDir)).filter(
+      (n) => n.endsWith('.json') && n !== 'manifest.json',
+    );
+    expect(committedJsons.length).toBeGreaterThan(0);
+
+    const outPath = join(outDir, 'signed-registry.json');
+    const bundle = await signRegistryFromDir({
+      inputDir: sitesDir,
+      outputPath: outPath,
+      privateKeyHex: privHex,
+      now: () => 1_700_000_000_999,
+    });
+
+    expect(bundle.entries.length).toBe(committedJsons.length);
+    expect(bundle.publicKeyHex).toBe(pubHex);
+
+    const written = JSON.parse(await readFile(outPath, 'utf8'));
+    expect(await verifyRegistry(written, { publicKeyHex: pubHex })).toBe(true);
+
+    // Entries must be sorted by origin (deterministic — see SR-D drift
+    // choice (e)). Future SR-E maintainer / CI signing reuses this contract.
+    const sorted = [...bundle.entries.map((e) => e.origin)].sort();
+    expect(bundle.entries.map((e) => e.origin)).toEqual(sorted);
+  });
+});

--- a/scripts/build-assets.ts
+++ b/scripts/build-assets.ts
@@ -1,0 +1,63 @@
+// Pure asset-copy helpers + manifest used by build.ts. Lives in scripts/ so
+// tests can import without pulling in Vite's loader chain (which would drag
+// esbuild into the jsdom test environment and fail to initialise).
+import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+export type AssetPair = readonly [src: string, dest: string];
+
+// SR-D / SR-E (registry-#51) — `registry/signed-registry.json` is the
+// SignedRegistryBundle produced by `scripts/sign-registry.ts` (locally by
+// the maintainer, or by the registry-crawl GH Action with the
+// HONEYLLM_REGISTRY_SIGNING_KEY secret). It is copied verbatim into
+// `dist/registry/signed-registry.json` so the SW can `chrome.runtime.getURL`
+// + fetch + verifyRegistry on startup. Copying (not Vite-importing) keeps
+// the bundle outside the SW JS chunk so future SR-F/SR-G changes don't need
+// a rebuild to swap registries.
+//
+// Issue #156 — `@huggingface/transformers` ships a prebuilt minified browser
+// ESM bundle copied verbatim and loaded via `chrome.runtime.getURL` from
+// `src/offscreen/transformers-runtime.ts`.
+export const BUILD_ASSETS: readonly AssetPair[] = [
+  ['src/offscreen/offscreen.html', 'dist/offscreen/offscreen.html'],
+  ['src/popup/popup.html', 'dist/popup/popup.html'],
+  ['src/tests/phase3/builtin-harness.html', 'dist/tests/phase3/builtin-harness.html'],
+  [
+    'node_modules/@huggingface/transformers/dist/transformers.web.min.js',
+    'dist/transformers/transformers.web.min.js',
+  ],
+  [
+    'node_modules/@huggingface/transformers/dist/ort-wasm-simd-threaded.jsep.mjs',
+    'dist/transformers/ort-wasm-simd-threaded.jsep.mjs',
+  ],
+  ['registry/signed-registry.json', 'dist/registry/signed-registry.json'],
+];
+
+export interface CopyBuildAssetsOptions {
+  readonly projectRoot?: string;
+  readonly onSkip?: (src: string) => void;
+}
+
+export function copyBuildAssets(
+  assets: readonly AssetPair[],
+  opts: CopyBuildAssetsOptions = {},
+): void {
+  const root = opts.projectRoot ?? resolve('.');
+  for (const [src, dest] of assets) {
+    const absSrc = resolve(root, src);
+    const absDest = resolve(root, dest);
+    if (!existsSync(absSrc)) {
+      // SR-E ramp-up: `registry/signed-registry.json` may not exist on the
+      // first build after merging this PR (the maintainer signs locally or
+      // the registry-crawl Action signs in CI; both produce the file as a
+      // follow-up commit). Skip-with-warning instead of failing so the
+      // wider build pipeline stays green during the rollout. SR-H gates
+      // this hard at production-release time.
+      opts.onSkip?.(src);
+      continue;
+    }
+    const destDir = dirname(absDest);
+    if (!existsSync(destDir)) mkdirSync(destDir, { recursive: true });
+    copyFileSync(absSrc, absDest);
+  }
+}


### PR DESCRIPTION
## Summary

Stage 6 of #51 — wires `registry/signed-registry.json` (the SR-D output) into `build.ts` so the `SignedRegistryBundle` ships in `dist/registry/signed-registry.json` alongside the existing entry points. The maintainer signing tool stops being a "local maintainer tool" only here: the registry-crawl GH Action gains a signing step before `peter-evans/create-pull-request@v6`, so the auto-refresh PR commits both the per-origin `RegistryEntry` JSONs **and** the regenerated bundle, and the next extension build picks up the fresh trust root automatically.

SR-F can then `chrome.runtime.getURL` + fetch + `verifyRegistry` on SW startup without manifest churn — SW-internal `chrome-extension://` fetches do not require a `web_accessible_resources` entry.

## What ships

- **`scripts/build-assets.ts`** (new) — `BUILD_ASSETS` manifest + `copyBuildAssets()` helper. Vite-free so vitest can import without dragging esbuild into the jsdom test environment. Adds the `registry/signed-registry.json -> dist/registry/signed-registry.json` pair; copies gracefully skip a missing source with a `[build]` warning so the wider build pipeline stays green during the SR-E ramp-up window. SR-H gates this hard at production-release time.
- **`build.ts`** — slimmer; imports `BUILD_ASSETS` + `copyBuildAssets()`. Behaviour unchanged for existing assets; new graceful-skip path for the registry pair.
- **`package.json`** — added `npm run sign:registry` for maintainer ergonomics. Wraps `tsx scripts/sign-registry.ts --input registry/sites --output registry/signed-registry.json`. The CI workflow uses the same script.
- **`.github/workflows/registry-crawl.yml`** — added the sign step to the aggregate job, gated on `env.HONEYLLM_REGISTRY_SIGNING_KEY != ''` so a fork or pre-rollout state (where the secret is unset) skips silently rather than failing. The PR step now adds both `registry/sites/*.json` and `registry/signed-registry.json` to the auto-refresh PR; commit message and PR title updated to reflect the dual artifact.

## Bundle size delta (RFC §Q4 ≤50 KB target)

Measured locally with the 7 currently-committed `RegistryEntry` JSONs (claude.ai, docs.google.com, github.com, gmail.com, linkedin.com, notion.com, slack.com) signed by an ephemeral keypair:

| Form | Size |
| --- | --- |
| Raw JSON | 7,952 bytes |
| Gzipped | 2,261 bytes |

Well under the 50 KB target. Headroom for ~25× growth in covered origins before the budget tightens.

## TDD

`scripts/__tests__/build-assets.test.ts` (new, 4 cases):
1. `BUILD_ASSETS` declares the `registry/signed-registry.json -> dist/registry/signed-registry.json` pair with the correct src/dest mapping.
2. `copyBuildAssets` copies present sources to their destinations.
3. `copyBuildAssets` gracefully skips (does not throw) when a source is missing — required for the SR-E ramp-up before the maintainer or CI has produced the first bundle.
4. Real-input round-trip: `signRegistryFromDir` against the live `registry/sites/` with a fresh keypair produces a verifying `SignedRegistryBundle` whose entries are sorted by origin per [SR-D drift choice (e)](../tree/main/.claude/plans/no-scheduling-now-please-valiant-feigenbaum.md).

**Tradeoff (per kickoff escape hatch):** the kickoff suggested a fuller "build-output assertion via embedded `REGISTRY_PUBLIC_KEY_HEX`" path. That requires the v1 maintainer private key in the test env, which intentionally never enters the repo or test fixtures (see SR-D PR #176 maintainer rotation procedure). The scripts-side test above is the kickoff-sanctioned alternative — it exercises the same `signRegistryFromDir → verifyRegistry` contract against the real registry inputs, just with a fresh keypair instead of the embedded trust root.

**Suite delta:** 1186 → 1190 (+4). Typecheck + build clean. `npm audit`: 0 vulnerabilities. Phase 2 byte-locked baseline (162 rows in `docs/testing/inbrowser-results.json`) untouched.

## Bootstrap path (for the maintainer / CI)

The build currently warns and skips `registry/signed-registry.json` because it is not yet committed. To bootstrap:

1. **Local maintainer path:** `HONEYLLM_REGISTRY_SIGNING_KEY=<v1 priv> npm run sign:registry` → commit the produced `registry/signed-registry.json` → next `npm run build` ships it in `dist/`.
2. **CI path:** add `HONEYLLM_REGISTRY_SIGNING_KEY` to the repository secrets → trigger the registry-crawl workflow (workflow_dispatch or wait for the Monday cron) → the workflow signs and opens a PR adding `registry/signed-registry.json` → reviewer merges → main has the bundle → next build ships it.

The PR deliberately does **not** ship a committed `signed-registry.json`. The SR-D PR explicitly flagged the v1 keypair as a development placeholder and asked the maintainer to regenerate offline before SR-E lands. Generating + signing inside this Claude session would extend the development-placeholder caveat through SR-H rather than letting the maintainer establish a clean production trust root.

## SR-F integration carry-forward (load-bearing)

- **SW reads bundle via `chrome.runtime.getURL` + `fetch`**, not static import. Static import would require either moving `signed-registry.json` into `src/` (against `tsc rootDir: src`) or a Vite virtual module plugin; the asset-copy path mirrors the `@huggingface/transformers` pattern and keeps the bundle out of the SW JS chunk so future swaps don't need a rebuild. SW-internal fetches via `chrome-extension://` URLs do not need a `web_accessible_resources` entry (manifest unchanged).
- **`verifyRegistry` is called once at SW startup** (`chrome.runtime.onStartup` + `chrome.runtime.onInstalled`), with the parsed bundle held in a module-level cache. This is the SR-F orchestrator hook point: the cache (or a "registry not loaded" fallback to MISS) is the short-circuit input to `runChunkProbes`.

## Out of scope (handed forward)

- SR-F: SW orchestrator wiring of `verifyRegistry()` on startup (next stage).
- SR-G: registry telemetry counters.
- SR-H: adversarial regression suite + first production release.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 1190/1190 pass (+4 new)
- [x] `npm run build` — clean (warns on missing `registry/signed-registry.json`, expected)
- [x] `npm audit` — 0 vulnerabilities
- [x] End-to-end: temp keypair + `npm run sign:registry --output /tmp/...` + `npm run build` with the produced bundle copied to `registry/signed-registry.json` → `dist/registry/signed-registry.json` written, 7,952 bytes.

Refs #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)