### PR TITLE
feat(registry-#51): SR-F SW orchestrator integration

### DIFF
--- a/src/content/ingestion/extractor.ts
+++ b/src/content/ingestion/extractor.ts
@@ -9,6 +9,9 @@ export async function extractPageSnapshot(): Promise<PageSnapshot> {
   const hiddenText = extractHiddenText();
   const scriptFingerprints = await extractScriptFingerprints();
   const metadata = extractMetadata();
+  // SR-F (registry-#51) — capture the raw outer HTML so the SW can fingerprint
+  // static-frame zones against the signed registry. Absent → registry MISS.
+  const pageHtml = document.documentElement.outerHTML;
 
   return {
     visibleText,
@@ -17,5 +20,6 @@ export async function extractPageSnapshot(): Promise<PageSnapshot> {
     metadata,
     extractedAt: Date.now(),
     charCount: visibleText.length + hiddenText.length,
+    pageHtml,
   };
 }

--- a/src/registry/__tests__/lookup.test.ts
+++ b/src/registry/__tests__/lookup.test.ts
@@ -1,0 +1,227 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as ed from '@noble/ed25519';
+
+import { signRegistry } from '../sign.js';
+import { extractZones } from '../extract-zones.js';
+import { fingerprintZone } from '../fingerprint.js';
+import { bytesToHex, type SignedRegistryBundle } from '../canonical-bundle.js';
+import type { RegistryEntry, RegistryZone } from '@/types/registry.js';
+
+import {
+  loadRegistryOnce,
+  lookupRegistry,
+  __resetRegistryForTests,
+} from '../lookup.js';
+
+const SAMPLE_HTML = `<!doctype html>
+<html lang="en">
+  <body>
+    <header><a href="/">Acme</a></header>
+    <nav><ul><li><a href="/x">X</a></li></ul></nav>
+    <article><p>varies</p></article>
+    <footer><p>© 2026 Acme</p></footer>
+  </body>
+</html>`;
+
+const FRAME_SELECTORS = ['header', 'nav', 'footer'] as const;
+
+async function buildEntryFromHtml(origin: string, html: string): Promise<RegistryEntry> {
+  const zones = extractZones(html, [...FRAME_SELECTORS], []);
+  const registryZones: RegistryZone[] = await Promise.all(
+    zones.map(async (z) => ({
+      zoneId: z.zoneId,
+      selector: z.zoneId.split('#')[0]!,
+      fingerprint: await fingerprintZone(z),
+    })),
+  );
+  return {
+    origin,
+    capturedAt: 1_700_000_000_000,
+    schemaVersion: 1,
+    zones: registryZones,
+    excludedSelectors: [],
+  };
+}
+
+interface ChromeStub {
+  fetchMock: ReturnType<typeof vi.fn>;
+  setBundleResponse(bundle: unknown | null, status?: number): void;
+}
+
+function setupChrome(): ChromeStub {
+  let nextResponse: { ok: boolean; status: number; body: unknown | null } = {
+    ok: false,
+    status: 404,
+    body: null,
+  };
+
+  const fetchMock = vi.fn(async (_url: string) => ({
+    ok: nextResponse.ok,
+    status: nextResponse.status,
+    json: async () => nextResponse.body,
+  }));
+
+  vi.stubGlobal('fetch', fetchMock);
+  vi.stubGlobal('chrome', {
+    runtime: {
+      getURL: (path: string) => `chrome-extension://test/${path}`,
+    },
+  });
+
+  return {
+    fetchMock,
+    setBundleResponse(bundle: unknown | null, status: number = 200) {
+      nextResponse = bundle === null
+        ? { ok: false, status, body: null }
+        : { ok: true, status: 200, body: bundle };
+    },
+  };
+}
+
+let signerPrivHex: string;
+let signerPubHex: string;
+let sampleBundle: SignedRegistryBundle;
+let sampleEntry: RegistryEntry;
+
+describe('registry lookup module', () => {
+  beforeEach(async () => {
+    if (signerPrivHex === undefined) {
+      const priv = ed.utils.randomPrivateKey();
+      signerPrivHex = bytesToHex(priv);
+      signerPubHex = bytesToHex(await ed.getPublicKeyAsync(priv));
+      sampleEntry = await buildEntryFromHtml('acme.test', SAMPLE_HTML);
+      sampleBundle = await signRegistry({
+        entries: [sampleEntry],
+        privateKeyHex: signerPrivHex,
+        now: () => 1_700_000_000_999,
+      });
+    }
+    __resetRegistryForTests();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('loadRegistryOnce — fetches the bundle, verifies, caches; second call is a no-op fetch', async () => {
+    const stub = setupChrome();
+    stub.setBundleResponse(sampleBundle);
+
+    await loadRegistryOnce({ trustedPublicKeyHex: signerPubHex });
+    await loadRegistryOnce({ trustedPublicKeyHex: signerPubHex });
+
+    expect(stub.fetchMock).toHaveBeenCalledTimes(1);
+    expect(stub.fetchMock.mock.calls[0]![0]).toBe(
+      'chrome-extension://test/dist/registry/signed-registry.json',
+    );
+  });
+
+  it('loadRegistryOnce — when fetch returns 404, lookup misses for the rest of the SW lifetime (fail-safe)', async () => {
+    const stub = setupChrome();
+    stub.setBundleResponse(null, 404);
+
+    await loadRegistryOnce({ trustedPublicKeyHex: signerPubHex });
+
+    const result = await lookupRegistry('acme.test', SAMPLE_HTML);
+    expect(result.matched).toBe(false);
+    expect(result.zoneIds).toEqual([]);
+  });
+
+  it('loadRegistryOnce — when verify fails (wrong trust root), lookup misses for the rest of the SW lifetime', async () => {
+    const stub = setupChrome();
+    stub.setBundleResponse(sampleBundle);
+
+    const wrongPriv = ed.utils.randomPrivateKey();
+    const wrongPub = bytesToHex(await ed.getPublicKeyAsync(wrongPriv));
+
+    await loadRegistryOnce({ trustedPublicKeyHex: wrongPub });
+
+    const result = await lookupRegistry('acme.test', SAMPLE_HTML);
+    expect(result.matched).toBe(false);
+  });
+
+  it('lookupRegistry — returns matched=true with all zoneIds when origin + every fingerprint matches', async () => {
+    const stub = setupChrome();
+    stub.setBundleResponse(sampleBundle);
+
+    await loadRegistryOnce({ trustedPublicKeyHex: signerPubHex });
+
+    const result = await lookupRegistry('acme.test', SAMPLE_HTML);
+
+    expect(result.matched).toBe(true);
+    expect([...result.zoneIds].sort()).toEqual(
+      [...sampleEntry.zones.map((z) => z.zoneId)].sort(),
+    );
+  });
+
+  it('lookupRegistry — returns matched=false when origin has no entry in the registry', async () => {
+    const stub = setupChrome();
+    stub.setBundleResponse(sampleBundle);
+
+    await loadRegistryOnce({ trustedPublicKeyHex: signerPubHex });
+
+    const result = await lookupRegistry('different.test', SAMPLE_HTML);
+    expect(result.matched).toBe(false);
+    expect(result.zoneIds).toEqual([]);
+  });
+
+  it('lookupRegistry — returns matched=false when one zone fingerprint drifts (content injected into footer)', async () => {
+    const stub = setupChrome();
+    stub.setBundleResponse(sampleBundle);
+
+    await loadRegistryOnce({ trustedPublicKeyHex: signerPubHex });
+
+    const drifted = SAMPLE_HTML.replace(
+      '<footer><p>© 2026 Acme</p></footer>',
+      '<footer><p>© 2026 Acme</p><p>injected</p></footer>',
+    );
+
+    const result = await lookupRegistry('acme.test', drifted);
+    expect(result.matched).toBe(false);
+  });
+
+  it('lookupRegistry — partial-zone match returns matched=false (registry only short-circuits on full agreement)', async () => {
+    const stub = setupChrome();
+    stub.setBundleResponse(sampleBundle);
+
+    await loadRegistryOnce({ trustedPublicKeyHex: signerPubHex });
+
+    // Drop the <nav> entirely — the registry expects all 3 zones; only 2 will be extracted.
+    const partialHtml = SAMPLE_HTML.replace(
+      /<nav>[\s\S]*?<\/nav>/,
+      '',
+    );
+
+    const result = await lookupRegistry('acme.test', partialHtml);
+    expect(result.matched).toBe(false);
+  });
+
+  it('lookupRegistry — returns matched=false when called before loadRegistryOnce (registry not loaded sentinel)', async () => {
+    setupChrome();
+    // No loadRegistryOnce call.
+    const result = await lookupRegistry('acme.test', SAMPLE_HTML);
+    expect(result.matched).toBe(false);
+    expect(result.zoneIds).toEqual([]);
+  });
+
+  it('lookupRegistry — returns matched=false when snapshotHtml is empty (fail-safe path)', async () => {
+    const stub = setupChrome();
+    stub.setBundleResponse(sampleBundle);
+
+    await loadRegistryOnce({ trustedPublicKeyHex: signerPubHex });
+
+    const result = await lookupRegistry('acme.test', '');
+    expect(result.matched).toBe(false);
+  });
+
+  it('lookupRegistry — normalises a URL-shaped origin (https://acme.test) to host-only for match', async () => {
+    const stub = setupChrome();
+    stub.setBundleResponse(sampleBundle);
+
+    await loadRegistryOnce({ trustedPublicKeyHex: signerPubHex });
+
+    const result = await lookupRegistry('https://acme.test', SAMPLE_HTML);
+    expect(result.matched).toBe(true);
+  });
+});

--- a/src/registry/lookup.ts
+++ b/src/registry/lookup.ts
@@ -1,0 +1,125 @@
+import { createLogger } from '@/shared/logger.js';
+import { extractZones } from './extract-zones.js';
+import { fingerprintZone } from './fingerprint.js';
+import { verifyRegistry } from './verify.js';
+import type { SignedRegistryBundle } from './canonical-bundle.js';
+import type { RegistryEntry } from '@/types/registry.js';
+
+const log = createLogger('RegistryLookup');
+
+const REGISTRY_BUNDLE_PATH = 'dist/registry/signed-registry.json';
+
+export interface LookupResult {
+  readonly matched: boolean;
+  readonly zoneIds: readonly string[];
+}
+
+export interface LoadRegistryOptions {
+  readonly trustedPublicKeyHex?: string;
+}
+
+let cachedBundle: SignedRegistryBundle | null = null;
+let loadPromise: Promise<void> | null = null;
+
+export async function loadRegistryOnce(opts: LoadRegistryOptions = {}): Promise<void> {
+  if (loadPromise !== null) return loadPromise;
+  loadPromise = doLoad(opts);
+  return loadPromise;
+}
+
+async function doLoad(opts: LoadRegistryOptions): Promise<void> {
+  try {
+    const url = chrome.runtime.getURL(REGISTRY_BUNDLE_PATH);
+    const resp = await fetch(url);
+    if (!resp.ok) {
+      log.warn(`Registry bundle fetch failed: HTTP ${resp.status} (registry MISS for SW lifetime)`);
+      return;
+    }
+    const parsed: unknown = await resp.json();
+    const verifyOpts =
+      opts.trustedPublicKeyHex === undefined
+        ? undefined
+        : { publicKeyHex: opts.trustedPublicKeyHex };
+    const ok = await verifyRegistry(parsed, verifyOpts);
+    if (!ok) {
+      log.warn('Registry bundle verification failed (registry MISS for SW lifetime)');
+      return;
+    }
+    cachedBundle = parsed as SignedRegistryBundle;
+    log.info(`Registry loaded with ${cachedBundle.entries.length} entries`);
+  } catch (err) {
+    log.warn('Registry load threw; treating as MISS for SW lifetime', err);
+  }
+}
+
+export async function lookupRegistry(
+  origin: string,
+  snapshotHtml: string,
+): Promise<LookupResult> {
+  if (cachedBundle === null) return EMPTY_RESULT;
+  if (snapshotHtml.length === 0) return EMPTY_RESULT;
+
+  const normalised = normaliseOrigin(origin);
+  const entry = findEntry(cachedBundle.entries, normalised);
+  if (entry === null) return EMPTY_RESULT;
+
+  const frameSelectors = uniqueSelectors(entry.zones);
+  const extracted = extractZones(snapshotHtml, frameSelectors, entry.excludedSelectors);
+
+  const matchedIds: string[] = [];
+  for (const entryZone of entry.zones) {
+    const ext = extracted.find((z) => z.zoneId === entryZone.zoneId);
+    if (ext === undefined) return EMPTY_RESULT;
+    const fp = await fingerprintZone(ext);
+    if (
+      fp.structural !== entryZone.fingerprint.structural ||
+      fp.tokens !== entryZone.fingerprint.tokens
+    ) {
+      return EMPTY_RESULT;
+    }
+    matchedIds.push(entryZone.zoneId);
+  }
+
+  return { matched: true, zoneIds: matchedIds };
+}
+
+const EMPTY_RESULT: LookupResult = { matched: false, zoneIds: [] };
+
+function normaliseOrigin(origin: string): string {
+  const trimmed = origin.trim().toLowerCase();
+  if (trimmed.includes('://')) {
+    try {
+      return new URL(trimmed).host;
+    } catch {
+      return trimmed;
+    }
+  }
+  return trimmed;
+}
+
+function findEntry(
+  entries: readonly RegistryEntry[],
+  normalisedHost: string,
+): RegistryEntry | null {
+  for (const e of entries) {
+    if (normaliseOrigin(e.origin) === normalisedHost) return e;
+  }
+  return null;
+}
+
+function uniqueSelectors(zones: readonly RegistryEntry['zones'][number][]): readonly string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const z of zones) {
+    if (!seen.has(z.selector)) {
+      seen.add(z.selector);
+      out.push(z.selector);
+    }
+  }
+  return out;
+}
+
+export function __resetRegistryForTests(): void {
+  cachedBundle = null;
+  loadPromise = null;
+}

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -15,6 +15,7 @@ import { ensureInstallSecret } from '@/shared/install-secret.js';
 import { verifyStamp } from './stamp.js';
 import { dispatchVerdictMessages, handleRescanWithMitigation, handleRescanPage } from './dispatch.js';
 import { scanUrl } from './url-scanner.js';
+import { loadRegistryOnce } from '@/registry/lookup.js';
 
 const log = createLogger('ServiceWorker');
 
@@ -29,16 +30,31 @@ function bootstrapInstallSecret(): void {
   });
 }
 
+// SR-F (registry-#51) — bootstrap the signed site-structure registry on
+// every SW wakeup. loadRegistryOnce is idempotent (cached promise) and
+// fail-safe: any of fetch-404 / parse-error / verify-fail leaves the
+// cached bundle null, so lookupRegistry misses for the rest of the SW
+// lifetime and analyzeSnapshot falls through to full analysis. Doing
+// the load + verify once at startup amortises the ~5 ms verify cost
+// over the SW's lifetime instead of paying it on the first PAGE_SNAPSHOT.
+function bootstrapRegistry(): void {
+  loadRegistryOnce().catch((err) => {
+    log.warn('Registry bootstrap failed; treating as MISS for SW lifetime', err);
+  });
+}
+
 chrome.runtime.onInstalled.addListener(() => {
   log.info('HoneyLLM installed');
   startKeepalive();
   bootstrapInstallSecret();
+  bootstrapRegistry();
 });
 
 chrome.runtime.onStartup.addListener(() => {
   log.info('HoneyLLM startup');
   startKeepalive();
   bootstrapInstallSecret();
+  bootstrapRegistry();
 });
 
 // Phase 4 Stage 4D.4 — per-tab icon state lifecycle hooks.

--- a/src/service-worker/orchestrator.registry.test.ts
+++ b/src/service-worker/orchestrator.registry.test.ts
@@ -1,0 +1,346 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, beforeAll, vi } from 'vitest';
+import * as ed from '@noble/ed25519';
+
+import type { PageSnapshot } from '@/types/snapshot.js';
+import type { LanguageDetectionResult } from '@/hunters/hawk/language-router.js';
+import type { Chunk } from '@/types/chunk.js';
+import type { HuntReport } from '@/hunters/hunt-runner.js';
+import type { RegistryEntry, RegistryZone } from '@/types/registry.js';
+
+import { signRegistry } from '@/registry/sign.js';
+import { extractZones } from '@/registry/extract-zones.js';
+import { fingerprintZone } from '@/registry/fingerprint.js';
+import { bytesToHex, type SignedRegistryBundle } from '@/registry/canonical-bundle.js';
+
+// Register the same module mocks as the main integration test so the
+// orchestrator wiring is identical except for the registry path.
+const runHuntersMock = vi.fn<(hunters: unknown, chunk: string) => Promise<HuntReport>>();
+vi.mock('@/hunters/hunt-runner.js', () => ({
+  runHunters: (...args: [unknown, string]) => runHuntersMock(...args),
+  SHORT_CIRCUIT_CONFIDENCE: 0.75,
+}));
+
+const chunkTextMock = vi.fn<(text: string) => Promise<readonly Chunk[]>>();
+vi.mock('@/hunters/hawk/chunking.js', () => ({
+  chunkText: (text: string) => chunkTextMock(text),
+}));
+
+const detectLanguageMock = vi.fn<(text: string) => Promise<LanguageDetectionResult>>();
+vi.mock('@/hunters/hawk/language-router.js', () => ({
+  detectLanguage: (text: string) => detectLanguageMock(text),
+}));
+
+vi.mock('./offscreen-manager.js', () => ({
+  ensureOffscreenDocument: async () => undefined,
+}));
+vi.mock('./keepalive.js', () => ({
+  connectOffscreenPort: () => undefined,
+}));
+interface MockPolicy {
+  readonly action: 'scan' | 'skip';
+  readonly reason: string;
+  readonly matchedRule: string | null;
+}
+const resolveOriginPolicyMock = vi.fn<() => MockPolicy>(() => ({
+  action: 'scan',
+  reason: 'default_scan',
+  matchedRule: null,
+}));
+vi.mock('@/policy/origin-policy.js', () => ({
+  resolveOriginPolicy: () => resolveOriginPolicyMock(),
+}));
+vi.mock('@/policy/origin-storage.js', () => ({
+  getOverrides: async () => ({}),
+}));
+vi.mock('@/shared/install-secret.js', () => ({
+  ensureInstallSecret: async () => new Uint8Array(32),
+}));
+vi.mock('./stamp.js', () => ({
+  generateStamp: async () => null,
+}));
+
+import { analyzeSnapshot } from './orchestrator.js';
+import { loadRegistryOnce, __resetRegistryForTests } from '@/registry/lookup.js';
+
+const SAMPLE_HTML = `<!doctype html>
+<html lang="en">
+  <body>
+    <header><a href="/">Acme</a></header>
+    <nav><ul><li><a href="/x">X</a></li></ul></nav>
+    <article><p>varies</p></article>
+    <footer><p>© 2026 Acme</p></footer>
+  </body>
+</html>`;
+
+const FRAME_SELECTORS = ['header', 'nav', 'footer'] as const;
+
+let signerPrivHex: string;
+let signerPubHex: string;
+let bundle: SignedRegistryBundle;
+let entry: RegistryEntry;
+
+beforeAll(async () => {
+  const priv = ed.utils.randomPrivateKey();
+  signerPrivHex = bytesToHex(priv);
+  signerPubHex = bytesToHex(await ed.getPublicKeyAsync(priv));
+
+  const zones = extractZones(SAMPLE_HTML, [...FRAME_SELECTORS], []);
+  const registryZones: RegistryZone[] = await Promise.all(
+    zones.map(async (z) => ({
+      zoneId: z.zoneId,
+      selector: z.zoneId.split('#')[0]!,
+      fingerprint: await fingerprintZone(z),
+    })),
+  );
+  entry = {
+    origin: 'acme.test',
+    capturedAt: 1_700_000_000_000,
+    schemaVersion: 1,
+    zones: registryZones,
+    excludedSelectors: [],
+  };
+  bundle = await signRegistry({
+    entries: [entry],
+    privateKeyHex: signerPrivHex,
+    now: () => 1_700_000_000_999,
+  });
+});
+
+function buildChunk(index: number, text: string): Chunk {
+  const hex = (index + 1).toString(16).padStart(64, '0');
+  return { text, start: index * 100, end: index * 100 + text.length, contentHash: hex };
+}
+
+function snapshotFixture(opts: { origin?: string; pageHtml?: string } = {}): PageSnapshot {
+  return {
+    visibleText: 'visible content',
+    hiddenText: '',
+    scriptFingerprints: [],
+    metadata: {
+      title: 'Test',
+      url: `https://${opts.origin ?? 'acme.test'}/page`,
+      origin: opts.origin ?? 'acme.test',
+      description: '',
+      ogTags: new Map<string, string>(),
+      cspMeta: null,
+      lang: 'en',
+    },
+    extractedAt: 1_700_000_000_000,
+    charCount: 15,
+    pageHtml: opts.pageHtml ?? SAMPLE_HTML,
+  };
+}
+
+interface ChromeContext {
+  runProbesCalls: { msg: { type: string; chunkIndex: number; tabId: number } }[];
+  fetchMock: ReturnType<typeof vi.fn>;
+  setBundleResponse(b: unknown | null, status?: number): void;
+}
+
+function setupChrome(): ChromeContext {
+  const calls: ChromeContext['runProbesCalls'] = [];
+  let listener: ((m: unknown) => void) | null = null;
+  const sendMessage = vi.fn((msg: { type: string; tabId: number; chunkIndex: number }) => {
+    if (msg.type === 'RUN_PROBES') {
+      calls.push({ msg });
+      Promise.resolve().then(() => {
+        listener?.({
+          type: 'PROBE_RESULTS',
+          tabId: msg.tabId,
+          chunkIndex: msg.chunkIndex,
+          results: [],
+          canaryId: 'gemma-2-2b-mlc',
+          webgpuAdapterMode: 'core',
+        });
+      });
+    }
+  });
+  const addListener = vi.fn((l: (m: unknown) => void) => { listener = l; });
+  const removeListener = vi.fn(() => { listener = null; });
+
+  let nextResp: { ok: boolean; status: number; body: unknown | null } = {
+    ok: false, status: 404, body: null,
+  };
+  const fetchMock = vi.fn(async (_url: string) => ({
+    ok: nextResp.ok,
+    status: nextResp.status,
+    json: async () => nextResp.body,
+  }));
+
+  vi.stubGlobal('fetch', fetchMock);
+  vi.stubGlobal('chrome', {
+    runtime: {
+      onMessage: { addListener, removeListener },
+      sendMessage,
+      getURL: (path: string) => `chrome-extension://test/${path}`,
+    },
+    storage: {
+      local: {
+        get: vi.fn(async () => ({})),
+        set: vi.fn(async () => undefined),
+      },
+    },
+  });
+
+  return {
+    runProbesCalls: calls,
+    fetchMock,
+    setBundleResponse(b, status = 200) {
+      nextResp = b === null
+        ? { ok: false, status, body: null }
+        : { ok: true, status: 200, body: b };
+    },
+  };
+}
+
+describe('analyzeSnapshot registry short-circuit (SR-F / registry-#51)', () => {
+  beforeEach(() => {
+    runHuntersMock.mockReset();
+    chunkTextMock.mockReset();
+    detectLanguageMock.mockReset();
+    detectLanguageMock.mockResolvedValue({ lang: 'und', confidence: 0, source: 'chrome-api' });
+    resolveOriginPolicyMock.mockReset();
+    resolveOriginPolicyMock.mockReturnValue({
+      action: 'scan',
+      reason: 'default_scan',
+      matchedRule: null,
+    });
+    chunkTextMock.mockResolvedValue([buildChunk(0, 'visible content')]);
+    runHuntersMock.mockResolvedValue({
+      results: [],
+      totalScore: 0,
+      maxConfidence: 0,
+      shouldSkipProbes: false,
+      flags: [],
+      aggregateError: null,
+    });
+    __resetRegistryForTests();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('on registry hit, returns CLEAN verdict and never invokes the chunk-probes pipeline', async () => {
+    const ctx = setupChrome();
+    ctx.setBundleResponse(bundle);
+    await loadRegistryOnce({ trustedPublicKeyHex: signerPubHex });
+
+    const verdict = await analyzeSnapshot(501, snapshotFixture({ origin: 'acme.test' }));
+
+    expect(verdict.status).toBe('CLEAN');
+    expect(verdict.analysisError).toMatch(/^registry_match: /);
+    expect(verdict.probeResults).toEqual([]);
+    expect(ctx.runProbesCalls.length).toBe(0);
+    expect(runHuntersMock).not.toHaveBeenCalled();
+    expect(chunkTextMock).not.toHaveBeenCalled();
+  });
+
+  it('on registry miss (origin not in bundle), falls through to the existing chunk pipeline', async () => {
+    const ctx = setupChrome();
+    ctx.setBundleResponse(bundle);
+    await loadRegistryOnce({ trustedPublicKeyHex: signerPubHex });
+
+    const verdict = await analyzeSnapshot(
+      502,
+      snapshotFixture({ origin: 'unknown.test', pageHtml: SAMPLE_HTML }),
+    );
+
+    expect(verdict.status).toBe('CLEAN');
+    expect(verdict.analysisError).toBeNull();
+    expect(chunkTextMock).toHaveBeenCalled();
+    expect(runHuntersMock).toHaveBeenCalled();
+    expect(ctx.runProbesCalls.length).toBe(0);
+  });
+
+  it('when the registry bundle is missing (404), behaves identically to the pre-SR-F pipeline (Phase 2 fail-safe)', async () => {
+    const ctx = setupChrome();
+    ctx.setBundleResponse(null, 404);
+    await loadRegistryOnce({ trustedPublicKeyHex: signerPubHex });
+
+    const verdict = await analyzeSnapshot(503, snapshotFixture({ origin: 'acme.test' }));
+
+    expect(verdict.status).toBe('CLEAN');
+    expect(verdict.analysisError).toBeNull();
+    expect(chunkTextMock).toHaveBeenCalled();
+    expect(runHuntersMock).toHaveBeenCalled();
+    expect(ctx.runProbesCalls.length).toBe(0);
+  });
+
+  it('when verifyRegistry rejects the bundle (wrong trust root), all origins fall through (fail-safe)', async () => {
+    const ctx = setupChrome();
+    ctx.setBundleResponse(bundle);
+    const wrongPriv = ed.utils.randomPrivateKey();
+    const wrongPub = bytesToHex(await ed.getPublicKeyAsync(wrongPriv));
+    await loadRegistryOnce({ trustedPublicKeyHex: wrongPub });
+
+    const verdict = await analyzeSnapshot(504, snapshotFixture({ origin: 'acme.test' }));
+
+    expect(verdict.analysisError).toBeNull();
+    expect(chunkTextMock).toHaveBeenCalled();
+  });
+
+  it('on snapshot.pageHtml absent, registry misses and full pipeline runs (preserves Phase 2 byte-locked baseline contract)', async () => {
+    const ctx = setupChrome();
+    ctx.setBundleResponse(bundle);
+    await loadRegistryOnce({ trustedPublicKeyHex: signerPubHex });
+
+    const noHtmlSnapshot: PageSnapshot = {
+      ...snapshotFixture({ origin: 'acme.test' }),
+      pageHtml: undefined,
+    };
+    const verdict = await analyzeSnapshot(505, noHtmlSnapshot);
+
+    expect(verdict.analysisError).toBeNull();
+    expect(chunkTextMock).toHaveBeenCalled();
+    expect(ctx.runProbesCalls.length).toBe(0);
+  });
+
+  it('registry hit short-circuits BEFORE the #20 origin-policy check (registry runs even on opted-out origins per RFC §Q7)', async () => {
+    const ctx = setupChrome();
+    ctx.setBundleResponse(bundle);
+    await loadRegistryOnce({ trustedPublicKeyHex: signerPubHex });
+    resolveOriginPolicyMock.mockReturnValue({
+      action: 'skip',
+      reason: 'user_override_skip',
+      matchedRule: null,
+    });
+
+    const verdict = await analyzeSnapshot(506, snapshotFixture({ origin: 'acme.test' }));
+
+    expect(verdict.status).toBe('CLEAN');
+    expect(verdict.analysisError).toMatch(/^registry_match: /);
+    expect(ctx.runProbesCalls.length).toBe(0);
+  });
+
+  it('registry hit names the matched zoneIds in analysisError so SR-G telemetry can attribute hits per-zone', async () => {
+    setupChrome();
+    const ctx = setupChrome();
+    ctx.setBundleResponse(bundle);
+    await loadRegistryOnce({ trustedPublicKeyHex: signerPubHex });
+
+    const verdict = await analyzeSnapshot(507, snapshotFixture({ origin: 'acme.test' }));
+
+    expect(verdict.analysisError).not.toBeNull();
+    for (const z of entry.zones) {
+      expect(verdict.analysisError).toContain(z.zoneId);
+    }
+  });
+
+  it('registry hit returns confidence=100 and totalScore=0 (CLEAN with no probe activity)', async () => {
+    const ctx = setupChrome();
+    ctx.setBundleResponse(bundle);
+    await loadRegistryOnce({ trustedPublicKeyHex: signerPubHex });
+
+    const verdict = await analyzeSnapshot(508, snapshotFixture({ origin: 'acme.test' }));
+
+    expect(verdict.confidence).toBe(100);
+    expect(verdict.totalScore).toBe(0);
+    expect(verdict.probeResults).toEqual([]);
+    expect(verdict.perChunkAnalysis).toBeNull();
+    expect(verdict.entitySummary).toBeNull();
+    expect(verdict.stamp).toBeNull();
+    void ctx;
+  });
+});

--- a/src/service-worker/orchestrator.ts
+++ b/src/service-worker/orchestrator.ts
@@ -42,6 +42,7 @@ import { mergeNerIntoPackets } from '@/hunters/ner/merge-ner.js';
 import type { EvidencePacket } from '@/probes/base-probe.js';
 import type { Entity } from '@/hunters/ner/types.js';
 import { rollupEntities } from '@/hunters/ner/rollup.js';
+import { lookupRegistry } from '@/registry/lookup.js';
 
 const log = createLogger('Orchestrator');
 
@@ -158,6 +159,48 @@ export function buildOriginSkippedVerdict(
 }
 
 /**
+ * Build the synthetic "registry-match" verdict (SR-F / registry-#51).
+ * The signed site-structure registry confirmed the snapshot's static
+ * frame zones (header / nav / footer etc.) byte-match the committed
+ * fingerprints for this origin — meaning the page chrome is the
+ * known-clean baseline and no probe pipeline needs to run. The CLEAN
+ * verdict carries `analysisError: 'registry_match: <zoneIds>'` as a
+ * metadata channel so the popup + SR-G telemetry can attribute hits
+ * per-zone. Stamp is null for the same reason as origin-skip:
+ * we did not actually probe the page; the attestation contract on
+ * stamps is "we scanned this URL", which a registry-skip does not
+ * satisfy.
+ */
+export function buildRegistryMatchVerdict(
+  snapshot: PageSnapshot,
+  matchedZoneIds: readonly string[],
+): SecurityVerdict {
+  return {
+    status: 'CLEAN',
+    confidence: 100,
+    totalScore: 0,
+    probeResults: [],
+    behavioralFlags: {
+      roleDrift: false,
+      exfiltrationIntent: false,
+      instructionFollowing: false,
+      hiddenContentAwareness: false,
+    },
+    mitigationsApplied: [],
+    timestamp: Date.now(),
+    url: snapshot.metadata.url,
+    analysisError: `registry_match: ${matchedZoneIds.join(',')}`,
+    canaryId: null,
+    webgpuAdapterMode: null,
+    stamp: null,
+    perChunkAnalysis: null,
+    entitySummary: null,
+    responseVerdict: null,
+    thinkingVerdict: null,
+  };
+}
+
+/**
  * Build the synthetic "skipped because page language is outside the
  * probe stack's supported set" verdict (issue #48). Mirrors
  * buildOriginSkippedVerdict so popup/storage/icon paths render the
@@ -234,6 +277,28 @@ export async function analyzeSnapshot(
   tabId: number,
   snapshot: PageSnapshot,
 ): Promise<SecurityVerdict> {
+  // SR-F (registry-#51) — content-blind static-frame registry skip. Per
+  // RFC §Q7 + §Q8, the registry runs FIRST: ahead of #20 origin-policy
+  // (so opted-out origins still get a CLEAN registry-match when their
+  // chrome is unmodified) and ahead of the #127 page-scan cache (so a
+  // registry hit avoids the IndexedDB lookup entirely). lookupRegistry
+  // returns matched=false on every failure mode (registry not loaded,
+  // origin missing, fingerprint drift, partial-zone match, empty
+  // pageHtml) so the orchestrator falls through to the existing
+  // pipeline — RFC §Q5 fail-safe.
+  const registryHit = await lookupRegistry(
+    snapshot.metadata.origin,
+    snapshot.pageHtml ?? '',
+  ).catch(() => null);
+  if (registryHit !== null && registryHit.matched) {
+    log.info(
+      `Registry match for ${snapshot.metadata.url}: zones=${registryHit.zoneIds.join(',')} — skipping analysis`,
+    );
+    const verdict = buildRegistryMatchVerdict(snapshot, registryHit.zoneIds);
+    await persistVerdict(verdict);
+    return verdict;
+  }
+
   // Issue #20 — short-circuit before any ingestion or offscreen work if the
   // origin is on the deny-list or explicitly skipped by the user. Persisting
   // the synthetic verdict means the popup + toolbar icon still have a signal

--- a/src/types/snapshot.ts
+++ b/src/types/snapshot.ts
@@ -22,4 +22,12 @@ export interface PageSnapshot {
   readonly metadata: PageMetadata;
   readonly extractedAt: number;
   readonly charCount: number;
+  // SR-F (registry-#51) — raw `document.documentElement.outerHTML` from the
+  // page context, captured by the content-script extractor so the SW
+  // registry-lookup can run `extractZones` + `fingerprintZone` against the
+  // committed RegistryEntry.zones for the snapshot's origin. Optional:
+  // pre-SR-F snapshots (and synthetic test fixtures) may omit it; the
+  // registry lookup misses on absent / empty HTML by design (RFC §Q5
+  // fail-safe — no HTML means full analysis runs).
+  readonly pageHtml?: string;
 }


### PR DESCRIPTION
## Summary

SR-F (Stage 7 of item 13) wires the signed site-structure registry into the SW orchestrator's hot path. The orchestrator now short-circuits to a CLEAN \`registry_match\` verdict when a snapshot's static-frame zones (header / nav / footer etc.) byte-match the committed fingerprints for the origin — saving the chunk pipeline + Hunter pass + LLM probes on known-clean origins.

- New \`src/registry/lookup.ts\`:
  - \`loadRegistryOnce()\` — idempotent cached-promise SW startup hook. Fetches \`dist/registry/signed-registry.json\` via \`chrome.runtime.getURL\` (no static import → tsc rootDir constraint preserved; no \`web_accessible_resources\` entry needed for SW-internal \`chrome-extension://\` fetches). Verifies via \`verifyRegistry\` (default trust root). Every failure mode (404, parse error, verify false) leaves the cached bundle null and the registry MISSes for the rest of the SW lifetime — RFC §Q5 fail-safe.
  - \`lookupRegistry(origin, snapshotHtml)\` — host-normalised origin match (\`https://acme.test\` and \`acme.test\` both resolve to host \`acme.test\`); \`extractZones\` against the entry's deduplicated frame selectors + the entry's excluded selectors; per-zone \`fingerprintZone\` comparison. Returns \`{matched: false, zoneIds: []}\` on partial-zone match, fingerprint drift, empty / absent \`snapshotHtml\`, unloaded bundle, or origin not in registry.
- \`src/service-worker/orchestrator.ts\`:
  - New \`buildRegistryMatchVerdict\` — CLEAN / confidence 100 / totalScore 0 / \`analysisError: 'registry_match: <zoneIds>'\` (metadata channel for SR-G telemetry attribution) / \`stamp: null\` (the stamp attests "we scanned this URL"; a registry-skip does not satisfy that contract).
  - Short-circuit at the very start of \`analyzeSnapshot\`, before the #20 origin-policy check and the #127 cache lookup, per RFC §Q7 (registry runs even on opted-out origins — registry skip is content-blind) and §Q8 (sequence: registry → #6 cache → full analyse, disjoint cache keys).
- \`PageSnapshot\` gains optional \`pageHtml\` populated by the content-script extractor as \`document.documentElement.outerHTML\`. Pre-SR-F snapshots and synthetic test fixtures may omit it; the registry lookup misses by design on absent / empty HTML.
- \`src/service-worker/index.ts\` adds \`bootstrapRegistry\` mirroring \`bootstrapInstallSecret\`; called from both \`chrome.runtime.onStartup\` and \`onInstalled\` so the verify cost is amortised over the SW lifetime instead of paid on the first \`PAGE_SNAPSHOT\`.

## TDD

18 new tests (1190 → 1208):

- \`src/registry/__tests__/lookup.test.ts\` (10 cases): bundle fetch+verify+cache idempotency / 404 graceful skip / wrong-trust-root rejects / origin hit / origin miss / fingerprint drift on one zone / partial-zone match → MISS / unloaded bundle → MISS / empty snapshotHtml → MISS / URL-shaped origin host normalisation.
- \`src/service-worker/orchestrator.registry.test.ts\` (8 cases): registry hit returns CLEAN + skips chunk pipeline / registry miss falls through / 404 fail-safe preserves Phase 2 baseline / wrong trust root falls through / absent \`pageHtml\` falls through / registry hit short-circuits BEFORE #20 opt-out / zoneIds named in \`analysisError\` for SR-G attribution / verdict shape (confidence=100, perChunkAnalysis=null, stamp=null).

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 1208/1208 passing across 105 files
- [x] \`npm run build\` — clean (the missing-bundle warning is the documented SR-E ramp-up state per \`scripts/build-assets.ts\`)
- [x] \`npm audit\` — 0 vulnerabilities
- [x] Pre-commit secret grep — clean

Refs #51 (registry stays open until SR-H ships adversarial regression suite + first production release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)