### PR TITLE
feat(registry-#51): SR-G privacy telemetry counters

### DIFF
--- a/src/popup/popup-accordion.test.ts
+++ b/src/popup/popup-accordion.test.ts
@@ -30,6 +30,8 @@ describe('popup.html accordion structure (issue #114)', () => {
       'accordion-mitigations',
       'accordion-engine',
       'accordion-policy',
+      // SR-G (registry-#51) — site-structure registry telemetry surface.
+      'accordion-registry',
     ];
     for (const id of ids) {
       const el = doc.getElementById(id);
@@ -37,6 +39,13 @@ describe('popup.html accordion structure (issue #114)', () => {
       expect(el!.tagName).toBe('DETAILS');
       expect(el!.hasAttribute('open')).toBe(false);
     }
+  });
+
+  it('places registry-body inside the Site-structure registry accordion (SR-G / registry-#51)', () => {
+    const doc = loadPopupDocument();
+    const body = doc.getElementById('registry-body');
+    expect(body).not.toBeNull();
+    expect(body!.closest('#accordion-registry')).not.toBeNull();
   });
 
   it('places response-analysis-body inside the Response analysis accordion (issue #126)', () => {

--- a/src/popup/popup-registry.test.ts
+++ b/src/popup/popup-registry.test.ts
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderRegistryStats } from './registry-stats.js';
+import type { RegistryStats } from '@/registry/telemetry.js';
+import { REGISTRY_STALE_BUNDLE_THRESHOLD_MS } from '@/shared/constants.js';
+
+function freshStats(overrides: Partial<RegistryStats> = {}): RegistryStats {
+  return {
+    hits: 0,
+    misses: 0,
+    verifyFailures: 0,
+    hitRate: null,
+    bundleSignedAt: null,
+    bundleLoadedAt: null,
+    bundleAgeMs: null,
+    staleBundle: false,
+    perOrigin: {},
+    lastResetAt: 0,
+    ...overrides,
+  };
+}
+
+let container: HTMLElement;
+
+beforeEach(() => {
+  document.body.replaceChildren();
+  container = document.createElement('div');
+  container.id = 'root';
+  document.body.appendChild(container);
+});
+
+describe('popup registry-stats render', () => {
+  it('empty state: shows "no lookups yet" and "bundle not loaded"', () => {
+    renderRegistryStats(container, freshStats());
+    const text = container.textContent ?? '';
+    expect(text).toContain('no lookups yet');
+    expect(text).toContain('not loaded');
+  });
+
+  it('with hits and misses: shows hit rate as percent and absolute counts', () => {
+    renderRegistryStats(
+      container,
+      freshStats({ hits: 7, misses: 3, hitRate: 0.7 }),
+    );
+    const text = container.textContent ?? '';
+    expect(text).toContain('70.0%');
+    expect(text).toContain('7 hit');
+    expect(text).toContain('3 miss');
+  });
+
+  it('with verifyFailures > 0: surfaces a verify-failures line', () => {
+    renderRegistryStats(container, freshStats({ verifyFailures: 4 }));
+    const text = container.textContent ?? '';
+    expect(text.toLowerCase()).toContain('verify failure');
+    expect(text).toContain('4');
+  });
+
+  it('with verifyFailures === 0: does NOT render a verify-failures line', () => {
+    renderRegistryStats(container, freshStats({ hits: 1, misses: 1, hitRate: 0.5 }));
+    const text = container.textContent ?? '';
+    expect(text.toLowerCase()).not.toContain('verify failure');
+  });
+
+  it('fresh bundle: renders age in days, no stale warning', () => {
+    const oneDay = 24 * 60 * 60 * 1000;
+    renderRegistryStats(
+      container,
+      freshStats({
+        bundleSignedAt: 1_700_000_000_000,
+        bundleLoadedAt: 1_700_000_000_000 + oneDay,
+        bundleAgeMs: 5 * oneDay,
+        staleBundle: false,
+      }),
+    );
+    const text = container.textContent ?? '';
+    expect(text).toContain('5');
+    expect(text.toLowerCase()).toContain('day');
+    const warning = container.querySelector('.registry-stale-warning');
+    expect(warning).toBeNull();
+  });
+
+  it('stale bundle: renders amber warning element with the staleness threshold context', () => {
+    renderRegistryStats(
+      container,
+      freshStats({
+        bundleSignedAt: 1_700_000_000_000,
+        bundleLoadedAt: 1_700_000_000_000 + REGISTRY_STALE_BUNDLE_THRESHOLD_MS + 1,
+        bundleAgeMs: REGISTRY_STALE_BUNDLE_THRESHOLD_MS + 1,
+        staleBundle: true,
+      }),
+    );
+    const warning = container.querySelector('.registry-stale-warning');
+    expect(warning).not.toBeNull();
+    expect((warning!.textContent ?? '').toLowerCase()).toContain('stale');
+  });
+
+  it('per-origin section: lists the top 3 origins by hit count, descending', () => {
+    renderRegistryStats(
+      container,
+      freshStats({
+        hits: 12,
+        misses: 0,
+        hitRate: 1,
+        perOrigin: {
+          'gmail.com': { hits: 5, misses: 0, lastSeenAt: 100 },
+          'github.com': { hits: 4, misses: 1, lastSeenAt: 200 },
+          'slack.com': { hits: 2, misses: 0, lastSeenAt: 300 },
+          'notion.com': { hits: 1, misses: 0, lastSeenAt: 400 },
+        },
+      }),
+    );
+    const rows = container.querySelectorAll('.registry-origin-row');
+    expect(rows.length).toBe(3);
+    expect(rows[0]!.textContent).toContain('gmail.com');
+    expect(rows[1]!.textContent).toContain('github.com');
+    expect(rows[2]!.textContent).toContain('slack.com');
+  });
+
+  it('per-origin section: omitted entirely when no origins recorded', () => {
+    renderRegistryStats(container, freshStats());
+    const rows = container.querySelectorAll('.registry-origin-row');
+    expect(rows.length).toBe(0);
+  });
+
+  it('replaces existing children rather than appending (idempotent re-render)', () => {
+    container.appendChild(document.createElement('span'));
+    renderRegistryStats(container, freshStats({ hits: 1, misses: 1, hitRate: 0.5 }));
+    const childCountFirst = container.children.length;
+
+    renderRegistryStats(container, freshStats({ hits: 1, misses: 1, hitRate: 0.5 }));
+    const childCountSecond = container.children.length;
+    expect(childCountSecond).toBe(childCountFirst);
+  });
+});

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -524,6 +524,13 @@
         </div>
       </details>
 
+      <details class="accordion" id="accordion-registry">
+        <summary>Site-structure registry</summary>
+        <div class="card">
+          <div class="placeholder" id="registry-body">Loading registry stats…</div>
+        </div>
+      </details>
+
       <details class="accordion" id="accordion-policy">
         <summary>Per-origin policy</summary>
         <div class="card" id="policy-body">

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -28,6 +28,8 @@ import { renderResponseVerdict } from './response-analysis.js';
 import { renderThinkingVerdict } from './thinking-analysis.js';
 import type { ResponseVerdict, ThinkingVerdict } from '@/types/portal-response.js';
 import { getCacheStats, clearCache } from '@/service-worker/scan-cache.js';
+import { getRegistryStats, resetRegistryTelemetry } from '@/registry/telemetry.js';
+import { renderRegistryStats } from './registry-stats.js';
 import { initPendingInterceptPanel } from './pending-intercept.js';
 
 interface StoredVerdict {
@@ -580,6 +582,59 @@ async function initCacheAccordion(): Promise<void> {
   await refresh();
 }
 
+/**
+ * SR-G (registry-#51) — render the site-structure registry's hit/miss/
+ * stale telemetry. Reads counters lazily on popup open via
+ * `getRegistryStats`; no live refresh while the panel is mounted (per
+ * SR-G drift carry-forward — telemetry is read-on-open). Includes a
+ * "Reset counters" button that zeros the hit/miss/perOrigin maps but
+ * preserves bundle metadata so the stale-bundle warning isn't lost.
+ */
+async function initRegistryAccordion(): Promise<void> {
+  const bodyEl = document.getElementById('registry-body');
+  if (bodyEl === null) return;
+  const body: HTMLElement = bodyEl;
+
+  async function refresh(): Promise<void> {
+    try {
+      const stats = await getRegistryStats();
+      const wrapper = document.createElement('div');
+      const statsContainer = document.createElement('div');
+      renderRegistryStats(statsContainer, stats);
+      wrapper.appendChild(statsContainer);
+
+      const btnRow = document.createElement('div');
+      btnRow.style.marginTop = '8px';
+      const btn = document.createElement('button');
+      btn.textContent = 'Reset counters';
+      btn.className = 'quick-link';
+      btn.addEventListener('click', async () => {
+        btn.disabled = true;
+        btn.textContent = 'Resetting…';
+        try {
+          await resetRegistryTelemetry();
+          showToast('Registry counters reset');
+          await refresh();
+        } catch (err) {
+          console.error('resetRegistryTelemetry failed', err);
+          showToast('Could not reset registry counters');
+          btn.disabled = false;
+          btn.textContent = 'Reset counters';
+        }
+      });
+      btnRow.appendChild(btn);
+      wrapper.appendChild(btnRow);
+
+      body.replaceChildren(wrapper);
+    } catch (err) {
+      console.error('registry stats render failed', err);
+      body.textContent = 'Registry stats unavailable.';
+    }
+  }
+
+  await refresh();
+}
+
 void (async () => {
   try {
     await initSiteCard();
@@ -626,6 +681,11 @@ void (async () => {
     await initCacheAccordion();
   } catch (err) {
     console.error('cache accordion init failed', err);
+  }
+  try {
+    await initRegistryAccordion();
+  } catch (err) {
+    console.error('registry accordion init failed', err);
   }
   try {
     // Issue #130 (N7b) — pending-intercept panel. Renders only when

--- a/src/popup/registry-stats.ts
+++ b/src/popup/registry-stats.ts
@@ -1,0 +1,99 @@
+import type { RegistryStats } from '@/registry/telemetry.js';
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+const TOP_ORIGINS_LIMIT = 3;
+
+function formatBundleAge(ageMs: number): string {
+  const days = Math.round(ageMs / ONE_DAY_MS);
+  if (days <= 0) return 'less than a day';
+  if (days === 1) return '1 day';
+  return `${days} days`;
+}
+
+function pickTopOrigins(
+  perOrigin: RegistryStats['perOrigin'],
+  limit: number,
+): ReadonlyArray<readonly [string, RegistryStats['perOrigin'][string]]> {
+  return Object.entries(perOrigin)
+    .sort(([aOrigin, a], [bOrigin, b]) => {
+      if (b.hits !== a.hits) return b.hits - a.hits;
+      // Deterministic tiebreak: newer lastSeenAt first, then origin lexicographic
+      if (b.lastSeenAt !== a.lastSeenAt) return b.lastSeenAt - a.lastSeenAt;
+      return aOrigin.localeCompare(bOrigin);
+    })
+    .slice(0, limit);
+}
+
+/**
+ * SR-G — render the SR-F registry's hit / miss / stale counters into the
+ * given container. Pure DOM construction; idempotent re-render via
+ * `replaceChildren`. Renders nothing network-bound — counters and
+ * bundle metadata are read from chrome.storage.local by the caller and
+ * passed in as a `RegistryStats` value.
+ */
+export function renderRegistryStats(container: HTMLElement, stats: RegistryStats): void {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'meta';
+  wrapper.style.lineHeight = '1.6';
+
+  const hitRateLine = document.createElement('div');
+  if (stats.hitRate === null) {
+    hitRateLine.textContent = 'Hit rate: — (no lookups yet)';
+  } else {
+    const pct = (stats.hitRate * 100).toFixed(1);
+    hitRateLine.textContent = `Hit rate: ${pct}% (${stats.hits} hit / ${stats.misses} miss)`;
+  }
+  wrapper.appendChild(hitRateLine);
+
+  const bundleLine = document.createElement('div');
+  if (stats.bundleSignedAt === null || stats.bundleAgeMs === null) {
+    bundleLine.textContent = 'Bundle: not loaded';
+  } else {
+    bundleLine.textContent = `Bundle age: ${formatBundleAge(stats.bundleAgeMs)}`;
+  }
+  wrapper.appendChild(bundleLine);
+
+  if (stats.staleBundle) {
+    const warning = document.createElement('div');
+    warning.className = 'registry-stale-warning';
+    warning.style.color = '#facc15';
+    warning.style.marginTop = '4px';
+    warning.textContent = 'Bundle is stale (older than the freshness threshold) — site coverage may have drifted.';
+    wrapper.appendChild(warning);
+  }
+
+  if (stats.verifyFailures > 0) {
+    const verifyLine = document.createElement('div');
+    verifyLine.style.color = '#f87171';
+    verifyLine.style.marginTop = '4px';
+    verifyLine.textContent = `Verify failures: ${stats.verifyFailures}`;
+    wrapper.appendChild(verifyLine);
+  }
+
+  const top = pickTopOrigins(stats.perOrigin, TOP_ORIGINS_LIMIT);
+  if (top.length > 0) {
+    const heading = document.createElement('div');
+    heading.style.marginTop = '8px';
+    heading.style.color = '#888';
+    heading.textContent = 'Top origins by hits';
+    wrapper.appendChild(heading);
+
+    for (const [origin, counts] of top) {
+      const row = document.createElement('div');
+      row.className = 'registry-origin-row';
+      row.style.display = 'flex';
+      row.style.justifyContent = 'space-between';
+      row.style.fontSize = '11px';
+      const left = document.createElement('span');
+      left.textContent = origin;
+      const right = document.createElement('span');
+      right.style.fontVariantNumeric = 'tabular-nums';
+      right.textContent = `${counts.hits} hit / ${counts.misses} miss`;
+      row.appendChild(left);
+      row.appendChild(right);
+      wrapper.appendChild(row);
+    }
+  }
+
+  container.replaceChildren(wrapper);
+}

--- a/src/registry/__tests__/lookup.telemetry.test.ts
+++ b/src/registry/__tests__/lookup.telemetry.test.ts
@@ -1,0 +1,272 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as ed from '@noble/ed25519';
+
+import { signRegistry } from '../sign.js';
+import { extractZones } from '../extract-zones.js';
+import { fingerprintZone } from '../fingerprint.js';
+import { bytesToHex, type SignedRegistryBundle } from '../canonical-bundle.js';
+import type { RegistryEntry, RegistryZone } from '@/types/registry.js';
+
+import {
+  loadRegistryOnce,
+  lookupRegistry,
+  __resetRegistryForTests,
+} from '../lookup.js';
+import { getRegistryStats, resetRegistryTelemetry } from '../telemetry.js';
+
+const SAMPLE_HTML = `<!doctype html>
+<html lang="en">
+  <body>
+    <header><a href="/">Acme</a></header>
+    <nav><ul><li><a href="/x">X</a></li></ul></nav>
+    <article><p>varies</p></article>
+    <footer><p>© 2026 Acme</p></footer>
+  </body>
+</html>`;
+
+const FRAME_SELECTORS = ['header', 'nav', 'footer'] as const;
+const FIXED_SIGNED_AT = 1_700_000_000_999;
+
+async function buildEntryFromHtml(origin: string, html: string): Promise<RegistryEntry> {
+  const zones = extractZones(html, [...FRAME_SELECTORS], []);
+  const registryZones: RegistryZone[] = await Promise.all(
+    zones.map(async (z) => ({
+      zoneId: z.zoneId,
+      selector: z.zoneId.split('#')[0]!,
+      fingerprint: await fingerprintZone(z),
+    })),
+  );
+  return {
+    origin,
+    capturedAt: 1_700_000_000_000,
+    schemaVersion: 1,
+    zones: registryZones,
+    excludedSelectors: [],
+  };
+}
+
+interface ChromeStub {
+  fetchMock: ReturnType<typeof vi.fn>;
+  setBundleResponse(bundle: unknown | null, status?: number): void;
+}
+
+function setupChrome(): ChromeStub {
+  let nextResponse: { ok: boolean; status: number; body: unknown | null } = {
+    ok: false,
+    status: 404,
+    body: null,
+  };
+
+  const fetchMock = vi.fn(async (_url: string) => ({
+    ok: nextResponse.ok,
+    status: nextResponse.status,
+    json: async () => nextResponse.body,
+  }));
+
+  const store = new Map<string, unknown>();
+
+  vi.stubGlobal('fetch', fetchMock);
+  vi.stubGlobal('chrome', {
+    runtime: {
+      getURL: (path: string) => `chrome-extension://test/${path}`,
+    },
+    storage: {
+      local: {
+        get: async (keys?: string | string[] | null) => {
+          if (keys === null || keys === undefined) {
+            return Object.fromEntries(store);
+          }
+          const arr = Array.isArray(keys) ? keys : [keys];
+          const out: Record<string, unknown> = {};
+          for (const k of arr) {
+            if (store.has(k)) out[k] = store.get(k);
+          }
+          return out;
+        },
+        set: async (items: Record<string, unknown>) => {
+          for (const [k, v] of Object.entries(items)) store.set(k, v);
+        },
+        remove: async (keys: string | string[]) => {
+          const arr = Array.isArray(keys) ? keys : [keys];
+          for (const k of arr) store.delete(k);
+        },
+      },
+    },
+  });
+
+  return {
+    fetchMock,
+    setBundleResponse(bundle: unknown | null, status: number = 200) {
+      nextResponse = bundle === null
+        ? { ok: false, status, body: null }
+        : { ok: true, status: 200, body: bundle };
+    },
+  };
+}
+
+let signerPrivHex: string;
+let signerPubHex: string;
+let sampleBundle: SignedRegistryBundle;
+let sampleEntry: RegistryEntry;
+
+describe('registry lookup → telemetry wiring (SR-G)', () => {
+  beforeEach(async () => {
+    if (signerPrivHex === undefined) {
+      const priv = ed.utils.randomPrivateKey();
+      signerPrivHex = bytesToHex(priv);
+      signerPubHex = bytesToHex(await ed.getPublicKeyAsync(priv));
+      sampleEntry = await buildEntryFromHtml('acme.test', SAMPLE_HTML);
+      sampleBundle = await signRegistry({
+        entries: [sampleEntry],
+        privateKeyHex: signerPrivHex,
+        now: () => FIXED_SIGNED_AT,
+      });
+    }
+    __resetRegistryForTests();
+    setupChrome();
+    await resetRegistryTelemetry();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('on successful bundle load, records bundleSignedAt and bundleLoadedAt', async () => {
+    const stub = setupChrome();
+    stub.setBundleResponse(sampleBundle);
+
+    await loadRegistryOnce({ trustedPublicKeyHex: signerPubHex });
+
+    const stats = await getRegistryStats();
+    expect(stats.bundleSignedAt).toBe(FIXED_SIGNED_AT);
+    expect(stats.bundleLoadedAt).not.toBeNull();
+    expect(stats.verifyFailures).toBe(0);
+  });
+
+  it('on verify failure (wrong trust root), increments verifyFailures and skips bundle metadata write', async () => {
+    const stub = setupChrome();
+    stub.setBundleResponse(sampleBundle);
+
+    const wrongPriv = ed.utils.randomPrivateKey();
+    const wrongPub = bytesToHex(await ed.getPublicKeyAsync(wrongPriv));
+
+    await loadRegistryOnce({ trustedPublicKeyHex: wrongPub });
+
+    const stats = await getRegistryStats();
+    expect(stats.verifyFailures).toBe(1);
+    expect(stats.bundleSignedAt).toBeNull();
+    expect(stats.bundleLoadedAt).toBeNull();
+  });
+
+  it('on fetch 404, does NOT increment verifyFailures (no bundle to verify) and leaves bundle metadata null', async () => {
+    const stub = setupChrome();
+    stub.setBundleResponse(null, 404);
+
+    await loadRegistryOnce({ trustedPublicKeyHex: signerPubHex });
+
+    const stats = await getRegistryStats();
+    expect(stats.verifyFailures).toBe(0);
+    expect(stats.bundleSignedAt).toBeNull();
+  });
+
+  it('on full registry hit, records hit against the normalised origin', async () => {
+    const stub = setupChrome();
+    stub.setBundleResponse(sampleBundle);
+
+    await loadRegistryOnce({ trustedPublicKeyHex: signerPubHex });
+    const result = await lookupRegistry('acme.test', SAMPLE_HTML);
+    expect(result.matched).toBe(true);
+
+    const stats = await getRegistryStats();
+    expect(stats.hits).toBe(1);
+    expect(stats.misses).toBe(0);
+    expect(stats.perOrigin['acme.test']!.hits).toBe(1);
+  });
+
+  it('records the hit against the host-normalised origin even when called with a URL-shaped origin', async () => {
+    const stub = setupChrome();
+    stub.setBundleResponse(sampleBundle);
+
+    await loadRegistryOnce({ trustedPublicKeyHex: signerPubHex });
+    await lookupRegistry('https://acme.test', SAMPLE_HTML);
+
+    const stats = await getRegistryStats();
+    expect(stats.perOrigin['acme.test']).toBeDefined();
+    expect(stats.perOrigin['https://acme.test']).toBeUndefined();
+  });
+
+  it('on origin not in registry, records miss against the normalised origin', async () => {
+    const stub = setupChrome();
+    stub.setBundleResponse(sampleBundle);
+
+    await loadRegistryOnce({ trustedPublicKeyHex: signerPubHex });
+    await lookupRegistry('different.test', SAMPLE_HTML);
+
+    const stats = await getRegistryStats();
+    expect(stats.misses).toBe(1);
+    expect(stats.hits).toBe(0);
+    expect(stats.perOrigin['different.test']!.misses).toBe(1);
+  });
+
+  it('on fingerprint drift (origin in registry, content changed), records miss against the origin', async () => {
+    const stub = setupChrome();
+    stub.setBundleResponse(sampleBundle);
+
+    await loadRegistryOnce({ trustedPublicKeyHex: signerPubHex });
+
+    const drifted = SAMPLE_HTML.replace(
+      '<footer><p>© 2026 Acme</p></footer>',
+      '<footer><p>© 2026 Acme</p><p>injected</p></footer>',
+    );
+    await lookupRegistry('acme.test', drifted);
+
+    const stats = await getRegistryStats();
+    expect(stats.misses).toBe(1);
+    expect(stats.perOrigin['acme.test']!.misses).toBe(1);
+    expect(stats.perOrigin['acme.test']!.hits).toBe(0);
+  });
+
+  it('does NOT record telemetry when the registry is unloaded (cachedBundle still null)', async () => {
+    setupChrome();
+    // No loadRegistryOnce call.
+    await lookupRegistry('acme.test', SAMPLE_HTML);
+
+    const stats = await getRegistryStats();
+    expect(stats.hits).toBe(0);
+    expect(stats.misses).toBe(0);
+  });
+
+  it('does NOT record telemetry when snapshotHtml is empty (synthetic / pre-SR-F state)', async () => {
+    const stub = setupChrome();
+    stub.setBundleResponse(sampleBundle);
+
+    await loadRegistryOnce({ trustedPublicKeyHex: signerPubHex });
+    await lookupRegistry('acme.test', '');
+
+    const stats = await getRegistryStats();
+    expect(stats.hits).toBe(0);
+    expect(stats.misses).toBe(0);
+  });
+
+  it('a hit followed by a miss against the same origin produces hit=1 / miss=1 / hitRate=0.5', async () => {
+    const stub = setupChrome();
+    stub.setBundleResponse(sampleBundle);
+
+    await loadRegistryOnce({ trustedPublicKeyHex: signerPubHex });
+
+    await lookupRegistry('acme.test', SAMPLE_HTML);
+    const drifted = SAMPLE_HTML.replace(
+      '<footer><p>© 2026 Acme</p></footer>',
+      '<footer><p>© 2026 Acme</p><p>injected</p></footer>',
+    );
+    await lookupRegistry('acme.test', drifted);
+
+    const stats = await getRegistryStats();
+    expect(stats.hits).toBe(1);
+    expect(stats.misses).toBe(1);
+    expect(stats.hitRate).toBeCloseTo(0.5, 6);
+    expect(stats.perOrigin['acme.test']!.hits).toBe(1);
+    expect(stats.perOrigin['acme.test']!.misses).toBe(1);
+  });
+});

--- a/src/registry/__tests__/telemetry.test.ts
+++ b/src/registry/__tests__/telemetry.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+import {
+  recordRegistryHit,
+  recordRegistryMiss,
+  recordRegistryVerifyFailure,
+  recordRegistryBundleLoaded,
+  resetRegistryTelemetry,
+  getRegistryStats,
+} from '../telemetry.js';
+import {
+  STORAGE_KEY_REGISTRY_TELEMETRY,
+  REGISTRY_MAX_ORIGINS_TRACKED,
+  REGISTRY_STALE_BUNDLE_THRESHOLD_MS,
+} from '@/shared/constants.js';
+
+function installChromeStub(): Map<string, unknown> {
+  const store = new Map<string, unknown>();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).chrome = {
+    storage: {
+      local: {
+        get: async (keys?: string | string[] | null) => {
+          if (keys === null || keys === undefined) {
+            return Object.fromEntries(store);
+          }
+          const arr = Array.isArray(keys) ? keys : [keys];
+          const out: Record<string, unknown> = {};
+          for (const k of arr) {
+            if (store.has(k)) out[k] = store.get(k);
+          }
+          return out;
+        },
+        set: async (items: Record<string, unknown>) => {
+          for (const [k, v] of Object.entries(items)) store.set(k, v);
+        },
+        remove: async (keys: string | string[]) => {
+          const arr = Array.isArray(keys) ? keys : [keys];
+          for (const k of arr) store.delete(k);
+        },
+      },
+    },
+  };
+  return store;
+}
+
+beforeEach(async () => {
+  installChromeStub();
+  vi.useRealTimers();
+  await resetRegistryTelemetry();
+});
+
+describe('registry telemetry: fresh state', () => {
+  it('returns zero counters and null bundle metadata before any activity', async () => {
+    const stats = await getRegistryStats();
+    expect(stats.hits).toBe(0);
+    expect(stats.misses).toBe(0);
+    expect(stats.verifyFailures).toBe(0);
+    expect(stats.hitRate).toBeNull();
+    expect(stats.bundleSignedAt).toBeNull();
+    expect(stats.bundleLoadedAt).toBeNull();
+    expect(stats.bundleAgeMs).toBeNull();
+    expect(stats.staleBundle).toBe(false);
+    expect(Object.keys(stats.perOrigin)).toEqual([]);
+  });
+});
+
+describe('registry telemetry: counter mutations', () => {
+  it('recordRegistryHit increments global hits and bumps per-origin hits + lastSeenAt', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-30T10:00:00Z'));
+    await recordRegistryHit('gmail.com');
+    await recordRegistryHit('gmail.com');
+
+    const stats = await getRegistryStats();
+    expect(stats.hits).toBe(2);
+    expect(stats.misses).toBe(0);
+    expect(stats.perOrigin['gmail.com']).toBeDefined();
+    expect(stats.perOrigin['gmail.com']!.hits).toBe(2);
+    expect(stats.perOrigin['gmail.com']!.misses).toBe(0);
+    expect(stats.perOrigin['gmail.com']!.lastSeenAt).toBe(
+      new Date('2026-04-30T10:00:00Z').getTime(),
+    );
+  });
+
+  it('recordRegistryMiss increments global misses and bumps per-origin misses', async () => {
+    await recordRegistryMiss('unknown.test');
+    await recordRegistryMiss('unknown.test');
+    await recordRegistryMiss('other.test');
+
+    const stats = await getRegistryStats();
+    expect(stats.misses).toBe(3);
+    expect(stats.hits).toBe(0);
+    expect(stats.perOrigin['unknown.test']!.misses).toBe(2);
+    expect(stats.perOrigin['other.test']!.misses).toBe(1);
+  });
+
+  it('recordRegistryVerifyFailure increments global verifyFailures only (no per-origin)', async () => {
+    await recordRegistryVerifyFailure();
+    await recordRegistryVerifyFailure();
+
+    const stats = await getRegistryStats();
+    expect(stats.verifyFailures).toBe(2);
+    expect(stats.hits).toBe(0);
+    expect(stats.misses).toBe(0);
+    expect(Object.keys(stats.perOrigin)).toEqual([]);
+  });
+
+  it('hitRate is hits / (hits + misses); 0/0 collapses to null', async () => {
+    await recordRegistryHit('gmail.com');
+    await recordRegistryHit('gmail.com');
+    await recordRegistryHit('gmail.com');
+    await recordRegistryMiss('unknown.test');
+
+    const stats = await getRegistryStats();
+    expect(stats.hitRate).toBeCloseTo(0.75, 6);
+  });
+});
+
+describe('registry telemetry: bundle metadata + staleness', () => {
+  it('recordRegistryBundleLoaded persists signedAt + loadedAt; getRegistryStats derives bundleAgeMs from now', async () => {
+    vi.useFakeTimers();
+    const signedAtTs = new Date('2026-04-15T00:00:00Z').getTime();
+    const loadAtTs = new Date('2026-04-30T00:00:00Z').getTime();
+    vi.setSystemTime(loadAtTs);
+
+    await recordRegistryBundleLoaded(signedAtTs);
+    const stats = await getRegistryStats();
+
+    expect(stats.bundleSignedAt).toBe(signedAtTs);
+    expect(stats.bundleLoadedAt).toBe(loadAtTs);
+    expect(stats.bundleAgeMs).toBe(loadAtTs - signedAtTs);
+    expect(stats.staleBundle).toBe(false);
+  });
+
+  it('staleBundle becomes true when bundleAgeMs exceeds REGISTRY_STALE_BUNDLE_THRESHOLD_MS', async () => {
+    vi.useFakeTimers();
+    const now = new Date('2026-04-30T00:00:00Z').getTime();
+    const ancientSignedAt = now - REGISTRY_STALE_BUNDLE_THRESHOLD_MS - 1;
+    vi.setSystemTime(now);
+
+    await recordRegistryBundleLoaded(ancientSignedAt);
+    const stats = await getRegistryStats();
+
+    expect(stats.staleBundle).toBe(true);
+    expect(stats.bundleAgeMs).toBeGreaterThan(REGISTRY_STALE_BUNDLE_THRESHOLD_MS);
+  });
+
+  it('bundleAgeMs is computed against now() at read time, not stored', async () => {
+    vi.useFakeTimers();
+    const signedAt = new Date('2026-04-15T00:00:00Z').getTime();
+    vi.setSystemTime(new Date('2026-04-15T00:00:01Z'));
+    await recordRegistryBundleLoaded(signedAt);
+
+    vi.setSystemTime(new Date('2026-05-15T00:00:00Z'));
+    const stats = await getRegistryStats();
+
+    const expected = new Date('2026-05-15T00:00:00Z').getTime() - signedAt;
+    expect(stats.bundleAgeMs).toBe(expected);
+  });
+});
+
+describe('registry telemetry: reset semantics', () => {
+  it('resetRegistryTelemetry zeros counters + perOrigin + verifyFailures and sets lastResetAt', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-29T00:00:00Z'));
+    await recordRegistryHit('gmail.com');
+    await recordRegistryMiss('other.test');
+    await recordRegistryVerifyFailure();
+
+    vi.setSystemTime(new Date('2026-04-30T00:00:00Z'));
+    await resetRegistryTelemetry();
+
+    const stats = await getRegistryStats();
+    expect(stats.hits).toBe(0);
+    expect(stats.misses).toBe(0);
+    expect(stats.verifyFailures).toBe(0);
+    expect(Object.keys(stats.perOrigin)).toEqual([]);
+    expect(stats.lastResetAt).toBe(new Date('2026-04-30T00:00:00Z').getTime());
+  });
+
+  it('resetRegistryTelemetry preserves bundleSignedAt + bundleLoadedAt (bundle metadata is independent of counter lifetime)', async () => {
+    vi.useFakeTimers();
+    const signedAt = new Date('2026-04-15T00:00:00Z').getTime();
+    const loadedAt = new Date('2026-04-29T00:00:00Z').getTime();
+    vi.setSystemTime(loadedAt);
+    await recordRegistryBundleLoaded(signedAt);
+    await recordRegistryHit('gmail.com');
+
+    vi.setSystemTime(new Date('2026-04-30T00:00:00Z'));
+    await resetRegistryTelemetry();
+
+    const stats = await getRegistryStats();
+    expect(stats.bundleSignedAt).toBe(signedAt);
+    expect(stats.bundleLoadedAt).toBe(loadedAt);
+  });
+});
+
+describe('registry telemetry: per-origin LRU eviction', () => {
+  it('caps perOrigin at REGISTRY_MAX_ORIGINS_TRACKED, evicting the oldest lastSeenAt entry first', async () => {
+    vi.useFakeTimers();
+    // Fill the table at consecutive timestamps so the LRU order is deterministic.
+    for (let i = 0; i < REGISTRY_MAX_ORIGINS_TRACKED; i += 1) {
+      vi.setSystemTime(new Date('2026-04-30T00:00:00Z').getTime() + i);
+      await recordRegistryHit(`origin-${i}.test`);
+    }
+
+    // Confirm we filled to the cap.
+    let stats = await getRegistryStats();
+    expect(Object.keys(stats.perOrigin)).toHaveLength(REGISTRY_MAX_ORIGINS_TRACKED);
+    expect(stats.perOrigin['origin-0.test']).toBeDefined();
+
+    // Now add one more — origin-0.test should be evicted (oldest lastSeenAt).
+    vi.setSystemTime(
+      new Date('2026-04-30T00:00:00Z').getTime() + REGISTRY_MAX_ORIGINS_TRACKED,
+    );
+    await recordRegistryHit('newcomer.test');
+
+    stats = await getRegistryStats();
+    expect(Object.keys(stats.perOrigin)).toHaveLength(REGISTRY_MAX_ORIGINS_TRACKED);
+    expect(stats.perOrigin['origin-0.test']).toBeUndefined();
+    expect(stats.perOrigin['newcomer.test']).toBeDefined();
+    expect(stats.perOrigin['origin-1.test']).toBeDefined();
+  });
+
+  it('re-touching an existing origin updates lastSeenAt without evicting any entry', async () => {
+    vi.useFakeTimers();
+    for (let i = 0; i < REGISTRY_MAX_ORIGINS_TRACKED; i += 1) {
+      vi.setSystemTime(new Date('2026-04-30T00:00:00Z').getTime() + i);
+      await recordRegistryHit(`origin-${i}.test`);
+    }
+
+    // Re-touch origin-0.test, making it the newest.
+    vi.setSystemTime(
+      new Date('2026-04-30T00:00:00Z').getTime() + REGISTRY_MAX_ORIGINS_TRACKED + 100,
+    );
+    await recordRegistryHit('origin-0.test');
+
+    // Now add a newcomer — origin-1.test should be evicted (now the oldest).
+    vi.setSystemTime(
+      new Date('2026-04-30T00:00:00Z').getTime() + REGISTRY_MAX_ORIGINS_TRACKED + 200,
+    );
+    await recordRegistryHit('newcomer.test');
+
+    const stats = await getRegistryStats();
+    expect(Object.keys(stats.perOrigin)).toHaveLength(REGISTRY_MAX_ORIGINS_TRACKED);
+    expect(stats.perOrigin['origin-0.test']).toBeDefined();
+    expect(stats.perOrigin['origin-1.test']).toBeUndefined();
+    expect(stats.perOrigin['newcomer.test']).toBeDefined();
+  });
+});
+
+describe('registry telemetry: persistence across reads', () => {
+  it('counters survive a fresh module read by reading from chrome.storage.local on every call (no in-memory cache)', async () => {
+    await recordRegistryHit('gmail.com');
+    await recordRegistryMiss('other.test');
+
+    // Simulate SW restart by re-reading raw storage; the persisted shape
+    // must be a structured-clonable object suitable for chrome.storage.local.
+    const raw = await (globalThis as { chrome: typeof chrome }).chrome.storage.local.get(
+      STORAGE_KEY_REGISTRY_TELEMETRY,
+    );
+    const persisted = raw[STORAGE_KEY_REGISTRY_TELEMETRY] as {
+      hits: number;
+      misses: number;
+      perOrigin: Record<string, { hits: number; misses: number; lastSeenAt: number }>;
+    };
+    expect(persisted.hits).toBe(1);
+    expect(persisted.misses).toBe(1);
+    expect(persisted.perOrigin['gmail.com']!.hits).toBe(1);
+    expect(persisted.perOrigin['other.test']!.misses).toBe(1);
+  });
+
+  it('recovers gracefully when stored telemetry is malformed (returns fresh state)', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (globalThis as any).chrome.storage.local.set({
+      [STORAGE_KEY_REGISTRY_TELEMETRY]: { junk: 'not a real telemetry object' },
+    });
+
+    const stats = await getRegistryStats();
+    expect(stats.hits).toBe(0);
+    expect(stats.misses).toBe(0);
+    expect(stats.verifyFailures).toBe(0);
+  });
+});

--- a/src/registry/lookup.ts
+++ b/src/registry/lookup.ts
@@ -4,6 +4,12 @@ import { fingerprintZone } from './fingerprint.js';
 import { verifyRegistry } from './verify.js';
 import type { SignedRegistryBundle } from './canonical-bundle.js';
 import type { RegistryEntry } from '@/types/registry.js';
+import {
+  recordRegistryBundleLoaded,
+  recordRegistryHit,
+  recordRegistryMiss,
+  recordRegistryVerifyFailure,
+} from './telemetry.js';
 
 const log = createLogger('RegistryLookup');
 
@@ -43,10 +49,16 @@ async function doLoad(opts: LoadRegistryOptions): Promise<void> {
     const ok = await verifyRegistry(parsed, verifyOpts);
     if (!ok) {
       log.warn('Registry bundle verification failed (registry MISS for SW lifetime)');
+      // SR-G — verifyFailure attributable: bundle was fetched + parsed, the
+      // signature did not check out. 404 / parse-error paths skip this
+      // counter (no bundle was presented for verification).
+      await recordRegistryVerifyFailure().catch(() => {});
       return;
     }
     cachedBundle = parsed as SignedRegistryBundle;
     log.info(`Registry loaded with ${cachedBundle.entries.length} entries`);
+    // SR-G — capture bundle metadata for the popup's stale-bundle warning.
+    await recordRegistryBundleLoaded(cachedBundle.signedAt).catch(() => {});
   } catch (err) {
     log.warn('Registry load threw; treating as MISS for SW lifetime', err);
   }
@@ -56,12 +68,21 @@ export async function lookupRegistry(
   origin: string,
   snapshotHtml: string,
 ): Promise<LookupResult> {
+  // Synthetic / pre-load states — do NOT record telemetry. Per the SR-G
+  // hit-rate contract these are not user-attributable lookups (the
+  // registry hasn't bootstrapped yet, or the snapshot omitted pageHtml
+  // for a fixture / pre-SR-F caller). Counting them as misses would
+  // skew the popup's hit-rate downward without surfacing anything the
+  // user can act on.
   if (cachedBundle === null) return EMPTY_RESULT;
   if (snapshotHtml.length === 0) return EMPTY_RESULT;
 
   const normalised = normaliseOrigin(origin);
   const entry = findEntry(cachedBundle.entries, normalised);
-  if (entry === null) return EMPTY_RESULT;
+  if (entry === null) {
+    await recordRegistryMiss(normalised).catch(() => {});
+    return EMPTY_RESULT;
+  }
 
   const frameSelectors = uniqueSelectors(entry.zones);
   const extracted = extractZones(snapshotHtml, frameSelectors, entry.excludedSelectors);
@@ -69,17 +90,22 @@ export async function lookupRegistry(
   const matchedIds: string[] = [];
   for (const entryZone of entry.zones) {
     const ext = extracted.find((z) => z.zoneId === entryZone.zoneId);
-    if (ext === undefined) return EMPTY_RESULT;
+    if (ext === undefined) {
+      await recordRegistryMiss(normalised).catch(() => {});
+      return EMPTY_RESULT;
+    }
     const fp = await fingerprintZone(ext);
     if (
       fp.structural !== entryZone.fingerprint.structural ||
       fp.tokens !== entryZone.fingerprint.tokens
     ) {
+      await recordRegistryMiss(normalised).catch(() => {});
       return EMPTY_RESULT;
     }
     matchedIds.push(entryZone.zoneId);
   }
 
+  await recordRegistryHit(normalised).catch(() => {});
   return { matched: true, zoneIds: matchedIds };
 }
 

--- a/src/registry/telemetry.ts
+++ b/src/registry/telemetry.ts
@@ -1,0 +1,203 @@
+import {
+  STORAGE_KEY_REGISTRY_TELEMETRY,
+  REGISTRY_MAX_ORIGINS_TRACKED,
+  REGISTRY_STALE_BUNDLE_THRESHOLD_MS,
+} from '@/shared/constants.js';
+import { createLogger } from '@/shared/logger.js';
+
+const log = createLogger('RegistryTelemetry');
+
+interface PerOriginCounters {
+  readonly hits: number;
+  readonly misses: number;
+  readonly lastSeenAt: number;
+}
+
+interface RegistryTelemetry {
+  readonly hits: number;
+  readonly misses: number;
+  readonly verifyFailures: number;
+  readonly bundleSignedAt: number | null;
+  readonly bundleLoadedAt: number | null;
+  readonly perOrigin: Record<string, PerOriginCounters>;
+  readonly lastResetAt: number;
+}
+
+export interface RegistryStats {
+  readonly hits: number;
+  readonly misses: number;
+  readonly verifyFailures: number;
+  readonly hitRate: number | null;
+  readonly bundleSignedAt: number | null;
+  readonly bundleLoadedAt: number | null;
+  readonly bundleAgeMs: number | null;
+  readonly staleBundle: boolean;
+  readonly perOrigin: Record<string, PerOriginCounters>;
+  readonly lastResetAt: number;
+}
+
+function freshTelemetry(): RegistryTelemetry {
+  return {
+    hits: 0,
+    misses: 0,
+    verifyFailures: 0,
+    bundleSignedAt: null,
+    bundleLoadedAt: null,
+    perOrigin: {},
+    lastResetAt: Date.now(),
+  };
+}
+
+function isPerOrigin(value: unknown): value is PerOriginCounters {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.hits === 'number' &&
+    typeof v.misses === 'number' &&
+    typeof v.lastSeenAt === 'number'
+  );
+}
+
+function isTelemetry(value: unknown): value is RegistryTelemetry {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  if (
+    typeof v.hits !== 'number' ||
+    typeof v.misses !== 'number' ||
+    typeof v.verifyFailures !== 'number' ||
+    typeof v.lastResetAt !== 'number'
+  ) {
+    return false;
+  }
+  if (v.bundleSignedAt !== null && typeof v.bundleSignedAt !== 'number') return false;
+  if (v.bundleLoadedAt !== null && typeof v.bundleLoadedAt !== 'number') return false;
+  if (typeof v.perOrigin !== 'object' || v.perOrigin === null) return false;
+  for (const entry of Object.values(v.perOrigin as Record<string, unknown>)) {
+    if (!isPerOrigin(entry)) return false;
+  }
+  return true;
+}
+
+async function readTelemetry(): Promise<RegistryTelemetry> {
+  try {
+    const result = await chrome.storage.local.get(STORAGE_KEY_REGISTRY_TELEMETRY);
+    const value = result[STORAGE_KEY_REGISTRY_TELEMETRY];
+    if (isTelemetry(value)) return value;
+  } catch (err) {
+    log.warn('readTelemetry failed', err);
+  }
+  return freshTelemetry();
+}
+
+async function writeTelemetry(t: RegistryTelemetry): Promise<void> {
+  try {
+    await chrome.storage.local.set({ [STORAGE_KEY_REGISTRY_TELEMETRY]: t });
+  } catch (err) {
+    log.warn('writeTelemetry failed', err);
+  }
+}
+
+/**
+ * Insert/update a per-origin bucket and enforce the LRU cap. Returns a
+ * fresh `perOrigin` record; never mutates the input. When the bump would
+ * push the table past REGISTRY_MAX_ORIGINS_TRACKED, drop the entry with
+ * the smallest `lastSeenAt` (deterministic — ties resolve to insertion
+ * order, which matters only in tests with collapsed timestamps).
+ */
+function bumpOrigin(
+  perOrigin: Record<string, PerOriginCounters>,
+  origin: string,
+  delta: { hits?: number; misses?: number },
+  now: number,
+): Record<string, PerOriginCounters> {
+  const existing = perOrigin[origin];
+  const next: Record<string, PerOriginCounters> = { ...perOrigin };
+  next[origin] = {
+    hits: (existing?.hits ?? 0) + (delta.hits ?? 0),
+    misses: (existing?.misses ?? 0) + (delta.misses ?? 0),
+    lastSeenAt: now,
+  };
+
+  if (Object.keys(next).length <= REGISTRY_MAX_ORIGINS_TRACKED) return next;
+
+  let evictKey: string | null = null;
+  let evictAt = Infinity;
+  for (const [k, v] of Object.entries(next)) {
+    if (k === origin) continue;
+    if (v.lastSeenAt < evictAt) {
+      evictAt = v.lastSeenAt;
+      evictKey = k;
+    }
+  }
+  if (evictKey !== null) delete next[evictKey];
+  return next;
+}
+
+export async function recordRegistryHit(origin: string): Promise<void> {
+  const now = Date.now();
+  const t = await readTelemetry();
+  await writeTelemetry({
+    ...t,
+    hits: t.hits + 1,
+    perOrigin: bumpOrigin(t.perOrigin, origin, { hits: 1 }, now),
+  });
+}
+
+export async function recordRegistryMiss(origin: string): Promise<void> {
+  const now = Date.now();
+  const t = await readTelemetry();
+  await writeTelemetry({
+    ...t,
+    misses: t.misses + 1,
+    perOrigin: bumpOrigin(t.perOrigin, origin, { misses: 1 }, now),
+  });
+}
+
+export async function recordRegistryVerifyFailure(): Promise<void> {
+  const t = await readTelemetry();
+  await writeTelemetry({ ...t, verifyFailures: t.verifyFailures + 1 });
+}
+
+export async function recordRegistryBundleLoaded(signedAt: number): Promise<void> {
+  const t = await readTelemetry();
+  await writeTelemetry({
+    ...t,
+    bundleSignedAt: signedAt,
+    bundleLoadedAt: Date.now(),
+  });
+}
+
+export async function resetRegistryTelemetry(): Promise<void> {
+  const t = await readTelemetry();
+  await writeTelemetry({
+    hits: 0,
+    misses: 0,
+    verifyFailures: 0,
+    bundleSignedAt: t.bundleSignedAt,
+    bundleLoadedAt: t.bundleLoadedAt,
+    perOrigin: {},
+    lastResetAt: Date.now(),
+  });
+}
+
+export async function getRegistryStats(): Promise<RegistryStats> {
+  const t = await readTelemetry();
+  const totalLookups = t.hits + t.misses;
+  const hitRate = totalLookups === 0 ? null : t.hits / totalLookups;
+  const now = Date.now();
+  const bundleAgeMs = t.bundleSignedAt === null ? null : now - t.bundleSignedAt;
+  const staleBundle =
+    bundleAgeMs !== null && bundleAgeMs > REGISTRY_STALE_BUNDLE_THRESHOLD_MS;
+  return {
+    hits: t.hits,
+    misses: t.misses,
+    verifyFailures: t.verifyFailures,
+    hitRate,
+    bundleSignedAt: t.bundleSignedAt,
+    bundleLoadedAt: t.bundleLoadedAt,
+    bundleAgeMs,
+    staleBundle,
+    perOrigin: t.perOrigin,
+    lastResetAt: t.lastResetAt,
+  };
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -520,6 +520,49 @@ export const THINKING_CHUNK_INDEX_OFFSET = 3_000_000;
 export const MAX_THINKING_TEXT_CHARS = 80_000;
 
 /**
+ * SR-G (registry-#51) — privacy telemetry for site-structure registry
+ * lookups. Persisted in chrome.storage.local so the popup can render
+ * registry hit/miss/stale metadata without a message round-trip to the SW
+ * and so counters survive SW termination. Distinct namespace from
+ * STORAGE_KEY_CACHE_TELEMETRY; the registry sits in front of the cache in
+ * `analyzeSnapshot` and the two surfaces have independent reset semantics.
+ *
+ * Shape: `{
+ *   hits: number;
+ *   misses: number;
+ *   verifyFailures: number;
+ *   bundleSignedAt: number | null;
+ *   bundleLoadedAt: number | null;
+ *   perOrigin: Record<origin, { hits: number; misses: number; lastSeenAt: number }>;
+ *   lastResetAt: number;
+ * }`.
+ *
+ * `verifyFailures` is global (the load happens before any origin is in
+ * play). `perOrigin` is bucketed for the popup so the user can see which
+ * origins contributed to the hit-rate; bounded by REGISTRY_MAX_ORIGINS_TRACKED
+ * with LRU eviction by `lastSeenAt` so a long-tail of one-off origins can't
+ * dominate the storage payload.
+ */
+export const STORAGE_KEY_REGISTRY_TELEMETRY = 'honeyllm:registry-telemetry';
+
+/**
+ * SR-G (registry-#51) — LRU cap on per-origin registry telemetry buckets.
+ * 50 covers the realistic top-N most-visited origins for any one user
+ * without unbounded growth from one-off visits. Eviction picks the entry
+ * with the oldest `lastSeenAt` when a new origin would overflow the cap.
+ */
+export const REGISTRY_MAX_ORIGINS_TRACKED = 50;
+
+/**
+ * SR-G (registry-#51) — staleness threshold for the bundled registry's
+ * `signedAt` timestamp. The popup renders an amber warning when
+ * `now() - bundleSignedAt > REGISTRY_STALE_BUNDLE_THRESHOLD_MS`. 60 days
+ * is a soft signal ahead of SR-H's hard signing-cadence gate; the
+ * warning is informational, not blocking.
+ */
+export const REGISTRY_STALE_BUNDLE_THRESHOLD_MS = 60 * 24 * 60 * 60 * 1000;
+
+/**
  * Issue #48 — set of page languages where the LLM probe stack is known to
  * produce signal. The orchestrator pre-flight calls detectLanguage() and
  * short-circuits with a synthetic `unsupported_language: <lang>` verdict


### PR DESCRIPTION
## Summary

SR-G (Stage 8 of item 13) wires hit / miss / verifyFailure / per-origin counters and a bundle-staleness signal onto the SR-F registry lookup, then surfaces them in the popup. All telemetry is local — counters live in `chrome.storage.local`; **zero network egress**.

- New `STORAGE_KEY_REGISTRY_TELEMETRY` (`'honeyllm:registry-telemetry'`) — distinct namespace from `STORAGE_KEY_CACHE_TELEMETRY`. Shape: `{hits, misses, verifyFailures, bundleSignedAt, bundleLoadedAt, perOrigin: Record<origin,{hits,misses,lastSeenAt}>, lastResetAt}`.
- New `REGISTRY_MAX_ORIGINS_TRACKED=50` LRU cap on `perOrigin`; eviction picks the entry with the oldest `lastSeenAt` so a long tail of one-off origins can't dominate the storage payload.
- New `REGISTRY_STALE_BUNDLE_THRESHOLD_MS=60d` informational warning threshold (SR-H will hard-gate signing cadence).

`src/registry/telemetry.ts` (new):
- `recordRegistryHit(origin)` / `recordRegistryMiss(origin)` — bumps global + per-origin counter, refreshes `lastSeenAt`, runs the LRU evictor.
- `recordRegistryVerifyFailure()` — global only (no origin in scope at load time).
- `recordRegistryBundleLoaded(signedAt)` — captures bundle metadata for `bundleAgeMs` derivation.
- `resetRegistryTelemetry()` — zeros counters / `perOrigin` / `verifyFailures`, sets `lastResetAt`; deliberately preserves `bundleSignedAt` + `bundleLoadedAt` (bundle metadata is independent of the counter lifetime).
- `getRegistryStats()` — derives `hitRate` (`hits / (hits + misses)`; `0/0 → null`), `bundleAgeMs` (against `now()` at read time, not stored), and `staleBundle`. Read lazily from `chrome.storage.local` on every call so SW restarts don't lose counters.

`src/registry/lookup.ts`:
- `doLoad`: on `verifyRegistry === false` → `recordRegistryVerifyFailure`; on success → `recordRegistryBundleLoaded(parsed.signedAt)`. 404 / parse-error paths skip both counters (no bundle was presented for verification).
- `lookupRegistry`: full match → `recordRegistryHit(normalisedOrigin)`; origin-not-in-registry / fingerprint drift / partial-zone match → `recordRegistryMiss(normalisedOrigin)`. Pre-load (`cachedBundle === null`) and empty `snapshotHtml` deliberately do NOT record telemetry — they're synthetic / pre-SR-F snapshots and counting them would skew hit-rate downward without surfacing anything actionable.
- All telemetry calls wrapped in `.catch(() => {})` defensively (belt-and-suspenders alongside `writeTelemetry`'s internal swallow).

`src/popup/registry-stats.ts` (new):
- Pure `renderRegistryStats(container, stats)` — easily unit-tested without driving the full popup lifecycle.
- Renders hit-rate as percent + absolute counts, "no lookups yet" fallback for the 0/0 universe.
- Bundle line: `Bundle: not loaded` / `Bundle age: N days`; amber `.registry-stale-warning` element when `staleBundle === true`.
- Verify-failures line surfaced only when count > 0.
- Top-3 perOrigin rows by hits (descending), deterministic tiebreak by `lastSeenAt` then origin lexicographic.
- Idempotent re-render via `replaceChildren`.

`src/popup/popup.html` + `src/popup/popup.ts`:
- New `<details id="accordion-registry">` after `accordion-cache` with `<div id="registry-body">`.
- New `initRegistryAccordion()` mirrors `initCacheAccordion`: lazy read on popup open, "Reset counters" button calls `resetRegistryTelemetry` then re-renders. No live refresh while panel is mounted.

## TDD

1208 → 1242 (+34 across 4 files):

- `src/registry/__tests__/telemetry.test.ts` (14 cases): fresh state / hit + per-origin bump / miss + per-origin bump / `verifyFailures` global only / `hitRate` math / bundle metadata round-trip / `staleBundle` threshold / `bundleAgeMs` computed at read time / reset zeros counters + `lastResetAt` / reset preserves bundle metadata / LRU evicts oldest `lastSeenAt` at the cap / re-touching an existing origin updates `lastSeenAt` without eviction / persistence via `chrome.storage.local` roundtrip / malformed stored telemetry → fresh state.
- `src/registry/__tests__/lookup.telemetry.test.ts` (10 cases): `bundleSignedAt` / `bundleLoadedAt` recorded on success / `verifyFailures` incremented on wrong trust root / 404 does not increment `verifyFailures` / hit recorded against normalised origin / URL-shaped origin normalised to host before bucketing / origin-not-in-registry recorded as miss / fingerprint drift recorded as miss / pre-load lookup does NOT record / empty `snapshotHtml` does NOT record / hit + miss against same origin → `hits=1 misses=1 hitRate=0.5`.
- `src/popup/popup-registry.test.ts` (9 cases): empty state / hit-rate format / `verifyFailures > 0` line / hidden when 0 / fresh bundle age in days / stale bundle amber warning / top-3 perOrigin / perOrigin section omitted when empty / idempotent re-render.
- `src/popup/popup-accordion.test.ts` (+1 case): `accordion-registry` exists / `registry-body` inside it.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 1242/1242 passing across 108 files
- [x] `npm run build` — clean (the missing-bundle warning is the documented SR-E ramp-up state per `scripts/build-assets.ts`)
- [x] `npm audit` — 0 vulnerabilities
- [x] Pre-commit AIza secret grep — clean

Refs #51 (registry stays open until SR-H ships adversarial regression suite + first production release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)