### PR TITLE
feat(registry-#51): SR-H adversarial regression suite + first production release

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -79,14 +79,24 @@ async function main() {
     });
   }
 
+  // SR-H — `HONEYLLM_BUILD_RELEASE=1` enables the production-release gate
+  // in copyBuildAssets: a missing `registry/signed-registry.json` aborts
+  // the build instead of warning. Default builds keep SR-E ramp-up
+  // semantics so dev / CI / unrelated work stays green pre-signing.
+  const releaseMode = process.env.HONEYLLM_BUILD_RELEASE === '1';
   copyBuildAssets(BUILD_ASSETS, {
     projectRoot: __dirname,
+    releaseMode,
     onSkip: (src) => {
       console.warn(
-        `[build] asset missing, skipping copy: ${src} (this is expected for registry/signed-registry.json before SR-E maintainer signing has produced the first bundle)`,
+        `[build] asset missing, skipping copy: ${src} (this is expected for registry/signed-registry.json before SR-E maintainer signing has produced the first bundle; set HONEYLLM_BUILD_RELEASE=1 to fail the build instead)`,
       );
     },
   });
+
+  if (releaseMode) {
+    console.log('[build] release mode active — registry hard-gate enforced.');
+  }
 
   console.log('Build complete.');
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "vite build --watch",
     "build": "tsc --noEmit && npx tsx build.ts",
+    "build:release": "tsc --noEmit && HONEYLLM_BUILD_RELEASE=1 npx tsx build.ts",
     "build:simple": "tsc --noEmit && vite build",
     "sign:registry": "tsx scripts/sign-registry.ts --input registry/sites --output registry/signed-registry.json",
     "typecheck": "tsc --noEmit",

--- a/registry/signed-registry.json
+++ b/registry/signed-registry.json
@@ -1,0 +1,227 @@
+{
+  "schemaVersion": 1,
+  "publicKeyHex": "e2fbe502cd8508283fd5369279d5bd04d89171b859a24fbf990c9268a38d0de3",
+  "signedAt": 1777553709164,
+  "entries": [
+    {
+      "origin": "claude.ai",
+      "capturedAt": 1777542094727,
+      "schemaVersion": 1,
+      "zones": [
+        {
+          "zoneId": "nav#0",
+          "selector": "nav",
+          "fingerprint": {
+            "structural": "3e2c90640f08fd1286991b47d3b0fd5e118c2190cf3999ba5c3050cd77907fe2",
+            "tokens": "d690f76f5283bf9da7a10bb1a455eb01327805968707139d793aff5687c7ec02"
+          }
+        },
+        {
+          "zoneId": "footer[data-theme=\"claude\"]#0",
+          "selector": "footer[data-theme=\"claude\"]",
+          "fingerprint": {
+            "structural": "dfd4621f526c4188f1501cfcdc0a1f6c540d390765978d951850180dade1d487",
+            "tokens": "35bdb2d4d45452d2c9679331fa01b67739ec3ab1d89833b4f0ac94d1c2dec715"
+          }
+        }
+      ],
+      "excludedSelectors": [
+        "[aria-hidden=\"true\"]"
+      ]
+    },
+    {
+      "origin": "docs.google.com",
+      "capturedAt": 1777542087840,
+      "schemaVersion": 1,
+      "zones": [
+        {
+          "zoneId": "header.TemplateHeader_header#0",
+          "selector": "header.TemplateHeader_header",
+          "fingerprint": {
+            "structural": "29ea1f0cbd6dbb1666bbca0b9e4c1248749fa0adec10c0ed986cd2d0936a435a",
+            "tokens": "96a450cf59294848e1c7dfec5cb86d500b90e647eda20e794a6358f404355521"
+          }
+        },
+        {
+          "zoneId": "nav.TemplateHeader_headerNav#0",
+          "selector": "nav.TemplateHeader_headerNav",
+          "fingerprint": {
+            "structural": "d499343e1f5f7f45524d8f4818b1ced0c7cbb8d155f38bfcb402513067894398",
+            "tokens": "992d97cd13834367c1b6d100182176bd2248c3bd0aec63b4172aec5d9719bfa8"
+          }
+        },
+        {
+          "zoneId": "footer#0",
+          "selector": "footer",
+          "fingerprint": {
+            "structural": "af85abc11bce7dd9d4c0d00ae741104decf35f68f806811acf440cd278a00dc3",
+            "tokens": "e7b976b8bddc3ea70b8152f983770b9bce1de84d1cef010a25f9cfe4b13ceb25"
+          }
+        }
+      ],
+      "excludedSelectors": [
+        "nav.dropdown-menu",
+        "[aria-hidden=\"true\"]",
+        "[data-user-name]"
+      ]
+    },
+    {
+      "origin": "github.com",
+      "capturedAt": 1777542094122,
+      "schemaVersion": 1,
+      "zones": [
+        {
+          "zoneId": "header[role=\"banner\"]#0",
+          "selector": "header[role=\"banner\"]",
+          "fingerprint": {
+            "structural": "2f0e3d0467ac4322454f516a3624ee985ec0ed43892f577859896e4818903195",
+            "tokens": "396a6c23d365d522ca10d9a29e1ffb88c323e81ba27785832d714f3ba0f2b1d7"
+          }
+        },
+        {
+          "zoneId": "footer[role=\"contentinfo\"]#0",
+          "selector": "footer[role=\"contentinfo\"]",
+          "fingerprint": {
+            "structural": "f9acffb0726a32445987f71af25485e0abec980ccd237b36ba5cf799d3de57ef",
+            "tokens": "7306734b0449b3415037eab698aacdcb493b0a8ac3d540cac2968d4dae3e450c"
+          }
+        }
+      ],
+      "excludedSelectors": [
+        "[aria-hidden=\"true\"]"
+      ]
+    },
+    {
+      "origin": "gmail.com",
+      "capturedAt": 1777529370554,
+      "schemaVersion": 1,
+      "zones": [
+        {
+          "zoneId": "header.TemplateHeader_header#0",
+          "selector": "header.TemplateHeader_header",
+          "fingerprint": {
+            "structural": "4a9cd9d7496358e29716c268d2cf631f042bbf88126e482910566a9021bef920",
+            "tokens": "f4e27a3ba6cfed5bc17306e1ae66e7192d2b961e0360a3126baf13e9b9e6ce1d"
+          }
+        },
+        {
+          "zoneId": "nav.TemplateHeader_headerNav#0",
+          "selector": "nav.TemplateHeader_headerNav",
+          "fingerprint": {
+            "structural": "4ff9916ad9a220a0ba8278ce5f988e9d49458603c37e73f382feb65b6b935a67",
+            "tokens": "c887f134c26ea8310e1fb4bd6fbab7b640393bd1b556e62691c7a442be92ec2a"
+          }
+        },
+        {
+          "zoneId": "footer#0",
+          "selector": "footer",
+          "fingerprint": {
+            "structural": "65d8df46a8c508719b6597ae3203db1005ae07e85f8fc68fe42946ce02130ad0",
+            "tokens": "bcd448fa7683119786df488394a22ce8c35b5392c8d8d02feebb12e2d60a42fc"
+          }
+        }
+      ],
+      "excludedSelectors": [
+        "nav.dropdown-menu",
+        "[aria-hidden=\"true\"]",
+        "[data-user-name]"
+      ]
+    },
+    {
+      "origin": "linkedin.com",
+      "capturedAt": 1777542093972,
+      "schemaVersion": 1,
+      "zones": [
+        {
+          "zoneId": "nav.nav#0",
+          "selector": "nav.nav",
+          "fingerprint": {
+            "structural": "4765ddfd9f9d72610bca6cbfae58ffbadf2f4166f11e6275c9b8d2c02249526e",
+            "tokens": "e66ac3333ec3f60e35b04d9665c365b8ebd3f888f9963c51bc8d1ac2c6096689"
+          }
+        },
+        {
+          "zoneId": "footer.li-footer#0",
+          "selector": "footer.li-footer",
+          "fingerprint": {
+            "structural": "99985091b6d376491af8b9f0ae481f03101fcb6bc21299365448f57dcd9cfcbd",
+            "tokens": "1048fb5a4fbb29c17a6b8bbfdfa3778b3a2259c30344308c997f0778bed4b8bf"
+          }
+        }
+      ],
+      "excludedSelectors": [
+        "[aria-hidden=\"true\"]"
+      ]
+    },
+    {
+      "origin": "notion.com",
+      "capturedAt": 1777542093477,
+      "schemaVersion": 1,
+      "zones": [
+        {
+          "zoneId": "nav[aria-label=\"Main\"]#0",
+          "selector": "nav[aria-label=\"Main\"]",
+          "fingerprint": {
+            "structural": "7078c383cd697ad172fcbf8c76671729f0af0f072e05fbba88f034c5b139987f",
+            "tokens": "eda1f45668d9e7808c5afc72118ba4104f62da1bf491ad6992b80e863b549be3"
+          }
+        },
+        {
+          "zoneId": "nav[aria-label=\"Footer\"]#0",
+          "selector": "nav[aria-label=\"Footer\"]",
+          "fingerprint": {
+            "structural": "20e27b877031e4c0df7501b4a07116493ca0d04cba3647e97b26b8b2c1731cc8",
+            "tokens": "d1468de6b3d9cf2babf42890189441a44c30d432154698dfa7ff28031932cfc0"
+          }
+        },
+        {
+          "zoneId": "footer[data-analytics-name=\"footer\"]#0",
+          "selector": "footer[data-analytics-name=\"footer\"]",
+          "fingerprint": {
+            "structural": "1ebc5c5408f211bc3e5ed8359716fbed3451bea461f32ff0151c7daeede82916",
+            "tokens": "d1468de6b3d9cf2babf42890189441a44c30d432154698dfa7ff28031932cfc0"
+          }
+        }
+      ],
+      "excludedSelectors": [
+        "[aria-hidden=\"true\"]"
+      ]
+    },
+    {
+      "origin": "slack.com",
+      "capturedAt": 1777542092384,
+      "schemaVersion": 1,
+      "zones": [
+        {
+          "zoneId": "header[role=\"banner\"]#0",
+          "selector": "header[role=\"banner\"]",
+          "fingerprint": {
+            "structural": "badc24119ddee19af8b2ce2564792f8c1a6eb6f989cc79981a1edf80fb28cf84",
+            "tokens": "57b99c8e8b5a50a920da8f0c4a1443870a0731681fca56d12073a6a0ba26b4d1"
+          }
+        },
+        {
+          "zoneId": "nav.c-nav--primary--expanded#0",
+          "selector": "nav.c-nav--primary--expanded",
+          "fingerprint": {
+            "structural": "4e05599f78757623b339ed348764f6b65511c9221955b9ab79123b62baeb1a28",
+            "tokens": "20ea64a0d8ff0651de947541d5dbfb2c6df5b6a824b4b5ef5009adca7baa0a8d"
+          }
+        },
+        {
+          "zoneId": "footer.c-nav--expanded-footer#0",
+          "selector": "footer.c-nav--expanded-footer",
+          "fingerprint": {
+            "structural": "1fc3c88cbf7f7a32e149b8c8c97bc095f9fef19a59e77076b2ee3c87d22b9c5b",
+            "tokens": "8051b2a8d122618a89a280500c3ffddbc2a7e8d021774f8c6c1035e879ce3320"
+          }
+        }
+      ],
+      "excludedSelectors": [
+        "[aria-hidden=\"true\"]",
+        "nav.c-nav__mobile"
+      ]
+    }
+  ],
+  "signature": "120e37a3431653e7ea2993f0a95eb2ef473b4e091d66560d71c0c9258e3db28859c174ceb361e95ab5e8ece6746dab6493ba62a122d1290e5c81dcd745366f08"
+}

--- a/scripts/__tests__/build-assets.test.ts
+++ b/scripts/__tests__/build-assets.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, beforeAll, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
 import { existsSync } from 'node:fs';
 import { mkdtemp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -7,7 +7,11 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join, resolve } from 'node:path';
 import * as ed from '@noble/ed25519';
 
-import { BUILD_ASSETS, copyBuildAssets } from '../build-assets.js';
+import {
+  BUILD_ASSETS,
+  RELEASE_REQUIRED_SOURCES,
+  copyBuildAssets,
+} from '../build-assets.js';
 import { signRegistryFromDir } from '../sign-registry.js';
 import { bytesToHex } from '@/registry/canonical-bundle.js';
 import { verifyRegistry } from '@/registry/verify.js';
@@ -52,6 +56,92 @@ describe('copyBuildAssets', () => {
       copyBuildAssets([['missing/file.txt', 'dist/missing/file.txt']], { projectRoot: tmp }),
     ).not.toThrow();
     expect(existsSync(join(tmp, 'dist/missing/file.txt'))).toBe(false);
+  });
+});
+
+describe('SR-H committed bundle ↔ embedded trust root', () => {
+  // Strong regression-safety assertion: the v1.0-pre signed bundle MUST
+  // verify against `REGISTRY_PUBLIC_KEY_HEX` in `src/registry/keys.ts`. If
+  // a maintainer rotates keys.ts but forgets to re-sign (or vice versa),
+  // the SW would silently MISS the registry on every page load. This test
+  // fires before the silence ever reaches production.
+  it('registry/signed-registry.json verifies under the embedded REGISTRY_PUBLIC_KEY_HEX', async () => {
+    const bundlePath = resolve(REPO_ROOT, 'registry/signed-registry.json');
+    const raw = await readFile(bundlePath, 'utf8');
+    const bundle = JSON.parse(raw);
+    expect(await verifyRegistry(bundle)).toBe(true);
+  });
+
+  it('the committed bundle covers every JSON in registry/sites/ (fail-loud if a site was added without re-signing)', async () => {
+    const bundlePath = resolve(REPO_ROOT, 'registry/signed-registry.json');
+    const sitesDir = resolve(REPO_ROOT, 'registry/sites');
+    const bundle = JSON.parse(await readFile(bundlePath, 'utf8'));
+    const committedJsons = (await readdir(sitesDir)).filter(
+      (n) => n.endsWith('.json') && n !== 'manifest.json',
+    );
+    expect(bundle.entries.length).toBe(committedJsons.length);
+  });
+});
+
+describe('SR-H release-mode hard-gate', () => {
+  let tmp: string;
+
+  beforeEach(async () => {
+    tmp = await mkdtemp(join(tmpdir(), 'sr-h-release-'));
+  });
+  afterEach(async () => {
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  it('declares `registry/signed-registry.json` as a release-required source', () => {
+    expect(RELEASE_REQUIRED_SOURCES).toContain('registry/signed-registry.json');
+  });
+
+  it('release mode + missing registry source → throws (production builds must ship the signed bundle)', () => {
+    const onSkip = vi.fn();
+    expect(() =>
+      copyBuildAssets(
+        [['registry/signed-registry.json', 'dist/registry/signed-registry.json']],
+        { projectRoot: tmp, releaseMode: true, onSkip },
+      ),
+    ).toThrow(/release mode.*registry\/signed-registry\.json/i);
+    expect(onSkip).not.toHaveBeenCalled();
+  });
+
+  it('release mode + present registry source → copies and does not throw', async () => {
+    await mkdir(join(tmp, 'registry'), { recursive: true });
+    await writeFile(join(tmp, 'registry/signed-registry.json'), '{"schemaVersion":1}', 'utf8');
+
+    expect(() =>
+      copyBuildAssets(
+        [['registry/signed-registry.json', 'dist/registry/signed-registry.json']],
+        { projectRoot: tmp, releaseMode: true },
+      ),
+    ).not.toThrow();
+    const written = await readFile(join(tmp, 'dist/registry/signed-registry.json'), 'utf8');
+    expect(written).toBe('{"schemaVersion":1}');
+  });
+
+  it('release mode + missing non-required source → still skips (only release-required sources are gated)', () => {
+    const onSkip = vi.fn();
+    expect(() =>
+      copyBuildAssets(
+        [['some/other/asset.txt', 'dist/some/other/asset.txt']],
+        { projectRoot: tmp, releaseMode: true, onSkip },
+      ),
+    ).not.toThrow();
+    expect(onSkip).toHaveBeenCalledWith('some/other/asset.txt');
+  });
+
+  it('default (releaseMode=false) + missing registry source → still skips (preserves SR-E ramp-up behaviour)', () => {
+    const onSkip = vi.fn();
+    expect(() =>
+      copyBuildAssets(
+        [['registry/signed-registry.json', 'dist/registry/signed-registry.json']],
+        { projectRoot: tmp, onSkip },
+      ),
+    ).not.toThrow();
+    expect(onSkip).toHaveBeenCalledWith('registry/signed-registry.json');
   });
 });
 

--- a/scripts/build-assets.ts
+++ b/scripts/build-assets.ts
@@ -33,9 +33,20 @@ export const BUILD_ASSETS: readonly AssetPair[] = [
   ['registry/signed-registry.json', 'dist/registry/signed-registry.json'],
 ];
 
+// SR-H — sources whose absence aborts the build under `releaseMode: true`.
+// The signed registry bundle is the trust root that production users rely
+// on; shipping a release without it would silently disable the §Q5
+// fail-safe in the field. Other assets (HTML shells, prebuilt vendor
+// bundles) keep skip-with-warning semantics because their absence is loud
+// at runtime — only the registry pair is silently security-relevant.
+export const RELEASE_REQUIRED_SOURCES: readonly string[] = [
+  'registry/signed-registry.json',
+];
+
 export interface CopyBuildAssetsOptions {
   readonly projectRoot?: string;
   readonly onSkip?: (src: string) => void;
+  readonly releaseMode?: boolean;
 }
 
 export function copyBuildAssets(
@@ -47,12 +58,20 @@ export function copyBuildAssets(
     const absSrc = resolve(root, src);
     const absDest = resolve(root, dest);
     if (!existsSync(absSrc)) {
+      if (opts.releaseMode === true && RELEASE_REQUIRED_SOURCES.includes(src)) {
+        // SR-H production-release gate: a missing release-required source
+        // is a hard error. Closes the SR-E ramp-up window for production
+        // builds — the registry must be signed before tagging a release.
+        throw new Error(
+          `copyBuildAssets: required asset missing in release mode: ${src} (run \`npm run sign:registry\` with the maintainer private key, or trigger the registry-crawl workflow with HONEYLLM_REGISTRY_SIGNING_KEY set)`,
+        );
+      }
       // SR-E ramp-up: `registry/signed-registry.json` may not exist on the
       // first build after merging this PR (the maintainer signs locally or
       // the registry-crawl Action signs in CI; both produce the file as a
       // follow-up commit). Skip-with-warning instead of failing so the
       // wider build pipeline stays green during the rollout. SR-H gates
-      // this hard at production-release time.
+      // this hard at production-release time via `releaseMode: true`.
       opts.onSkip?.(src);
       continue;
     }

--- a/src/popup/popup-registry.adversarial.test.ts
+++ b/src/popup/popup-registry.adversarial.test.ts
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+//
+// SR-H adversarial popup-render assertions — drives `renderRegistryStats`
+// directly (per SR-G drift carry-forward (e)+(g): it's a pure function;
+// reuse it for adversarial UI cases instead of driving the full popup
+// lifecycle). Sibling to `popup-registry.test.ts` (functional render);
+// this file covers the union states a tampered or stale registry would
+// surface to the user — what the popup looks like when verifyFailures is
+// non-zero, when the bundle is past the staleness threshold, and when
+// both signals fire at once.
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderRegistryStats } from './registry-stats.js';
+import type { RegistryStats } from '@/registry/telemetry.js';
+import { REGISTRY_STALE_BUNDLE_THRESHOLD_MS } from '@/shared/constants.js';
+
+function freshStats(overrides: Partial<RegistryStats> = {}): RegistryStats {
+  return {
+    hits: 0,
+    misses: 0,
+    verifyFailures: 0,
+    hitRate: null,
+    bundleSignedAt: null,
+    bundleLoadedAt: null,
+    bundleAgeMs: null,
+    staleBundle: false,
+    perOrigin: {},
+    lastResetAt: 0,
+    ...overrides,
+  };
+}
+
+let container: HTMLElement;
+
+beforeEach(() => {
+  document.body.replaceChildren();
+  container = document.createElement('div');
+  container.id = 'root';
+  document.body.appendChild(container);
+});
+
+describe('SR-H — adversarial popup render states', () => {
+  it('high verifyFailures (signature-tamper run) renders the literal count, not a clamped or rounded value', () => {
+    renderRegistryStats(container, freshStats({ verifyFailures: 99 }));
+    const verifyLine = Array.from(container.querySelectorAll('div')).find((d) =>
+      (d.textContent ?? '').toLowerCase().includes('verify failure'),
+    );
+    expect(verifyLine).toBeDefined();
+    expect(verifyLine!.textContent).toContain('99');
+    // Adversary should not be able to "hide" via a high count: the renderer
+    // must surface the unclamped integer.
+    expect(verifyLine!.textContent).not.toMatch(/\b9\+\b/);
+  });
+
+  it('stale bundle + non-zero verifyFailures: both warnings render simultaneously', () => {
+    renderRegistryStats(
+      container,
+      freshStats({
+        verifyFailures: 3,
+        bundleSignedAt: 1_000,
+        bundleLoadedAt: 1_000 + REGISTRY_STALE_BUNDLE_THRESHOLD_MS + 1,
+        bundleAgeMs: REGISTRY_STALE_BUNDLE_THRESHOLD_MS + 1,
+        staleBundle: true,
+      }),
+    );
+    expect(container.querySelector('.registry-stale-warning')).not.toBeNull();
+    const text = (container.textContent ?? '').toLowerCase();
+    expect(text).toContain('verify failure');
+    expect(text).toContain('stale');
+  });
+
+  it('stale bundle with successful lookups: stale warning AND hit-rate render (no contradiction)', () => {
+    renderRegistryStats(
+      container,
+      freshStats({
+        hits: 10,
+        misses: 0,
+        hitRate: 1,
+        verifyFailures: 0,
+        bundleSignedAt: 1_000,
+        bundleLoadedAt: 1_000 + REGISTRY_STALE_BUNDLE_THRESHOLD_MS + 1,
+        bundleAgeMs: REGISTRY_STALE_BUNDLE_THRESHOLD_MS + 1,
+        staleBundle: true,
+      }),
+    );
+    const text = container.textContent ?? '';
+    expect(text).toContain('100.0%');
+    expect(container.querySelector('.registry-stale-warning')).not.toBeNull();
+    // verifyFailures === 0 → that warning line is omitted
+    expect(text.toLowerCase()).not.toContain('verify failure');
+  });
+
+  it('verifyFailures with zero lookups: shows the failure count without lying about hit-rate', () => {
+    // Adversarial state: bundle was rejected at startup, so no hits or
+    // misses ever recorded; the popup must not invent a hit-rate.
+    renderRegistryStats(container, freshStats({ verifyFailures: 1 }));
+    const text = container.textContent ?? '';
+    expect(text.toLowerCase()).toContain('verify failure');
+    expect(text.toLowerCase()).toContain('no lookups yet');
+  });
+
+  it('per-origin section truncates to top-3 even in adversarial multi-origin loads', () => {
+    // Defensive: an adversary cannot push perOrigin past the LRU cap (the
+    // module enforces REGISTRY_MAX_ORIGINS_TRACKED), but the render layer
+    // must independently cap to top 3 by hits regardless of input size.
+    const perOrigin: Record<string, { hits: number; misses: number; lastSeenAt: number }> = {};
+    for (let i = 0; i < 20; i += 1) {
+      perOrigin[`site${i}.test`] = { hits: 20 - i, misses: 0, lastSeenAt: i };
+    }
+    renderRegistryStats(
+      container,
+      freshStats({ hits: 210, misses: 0, hitRate: 1, perOrigin }),
+    );
+    const rows = container.querySelectorAll('.registry-origin-row');
+    expect(rows.length).toBe(3);
+    expect(rows[0]!.textContent).toContain('site0.test');
+    expect(rows[1]!.textContent).toContain('site1.test');
+    expect(rows[2]!.textContent).toContain('site2.test');
+  });
+});

--- a/src/registry/__tests__/lookup.adversarial.test.ts
+++ b/src/registry/__tests__/lookup.adversarial.test.ts
@@ -1,0 +1,384 @@
+// @vitest-environment jsdom
+//
+// SR-H adversarial regression suite — RFC §Q9 properties exercised
+// end-to-end through `loadRegistryOnce` + `lookupRegistry` against
+// deliberately mutated `SignedRegistryBundle` payloads. Sibling to
+// `lookup.test.ts` (functional) and `lookup.telemetry.test.ts` (counter
+// wiring); this file is the "an attacker mutated the bundle on disk"
+// surface area.
+//
+// Each case follows the same shape:
+//   1. sign a clean bundle with a fresh keypair
+//   2. mutate ONE field (signature byte / entries / signedAt / pubKey)
+//   3. confirm `verifyRegistry` rejects via `loadRegistryOnce`
+//   4. confirm `verifyFailures` increments (or stays at 0 for fetch-404
+//      paths where no bundle was presented for verification)
+//   5. confirm every subsequent `lookupRegistry` is MISS for the SW
+//      lifetime (the §Q5 fail-safe)
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as ed from '@noble/ed25519';
+
+import { signRegistry } from '../sign.js';
+import { extractZones } from '../extract-zones.js';
+import { fingerprintZone } from '../fingerprint.js';
+import { bytesToHex, type SignedRegistryBundle } from '../canonical-bundle.js';
+import type { RegistryEntry, RegistryZone } from '@/types/registry.js';
+
+import {
+  loadRegistryOnce,
+  lookupRegistry,
+  __resetRegistryForTests,
+} from '../lookup.js';
+import { getRegistryStats, resetRegistryTelemetry } from '../telemetry.js';
+
+const SAMPLE_HTML = `<!doctype html>
+<html lang="en">
+  <body>
+    <header><a href="/">Acme</a></header>
+    <nav><ul><li><a href="/x">X</a></li></ul></nav>
+    <article><p>varies</p></article>
+    <footer><p>© 2026 Acme</p></footer>
+  </body>
+</html>`;
+
+const FRAME_SELECTORS = ['header', 'nav', 'footer'] as const;
+const FIXED_SIGNED_AT = 1_700_000_000_999;
+
+async function buildEntryFromHtml(origin: string, html: string): Promise<RegistryEntry> {
+  const zones = extractZones(html, [...FRAME_SELECTORS], []);
+  const registryZones: RegistryZone[] = await Promise.all(
+    zones.map(async (z) => ({
+      zoneId: z.zoneId,
+      selector: z.zoneId.split('#')[0]!,
+      fingerprint: await fingerprintZone(z),
+    })),
+  );
+  return {
+    origin,
+    capturedAt: 1_700_000_000_000,
+    schemaVersion: 1,
+    zones: registryZones,
+    excludedSelectors: [],
+  };
+}
+
+interface ChromeStub {
+  fetchMock: ReturnType<typeof vi.fn>;
+  setBundleResponse(bundle: unknown | null, status?: number): void;
+  setStorageBehaviour(opts: { getThrows?: boolean; setThrows?: boolean }): void;
+}
+
+function setupChrome(): ChromeStub {
+  let nextResponse: { ok: boolean; status: number; body: unknown | null } = {
+    ok: false,
+    status: 404,
+    body: null,
+  };
+  let getThrows = false;
+  let setThrows = false;
+
+  const fetchMock = vi.fn(async (_url: string) => ({
+    ok: nextResponse.ok,
+    status: nextResponse.status,
+    json: async () => nextResponse.body,
+  }));
+
+  const store = new Map<string, unknown>();
+
+  vi.stubGlobal('fetch', fetchMock);
+  vi.stubGlobal('chrome', {
+    runtime: {
+      getURL: (path: string) => `chrome-extension://test/${path}`,
+    },
+    storage: {
+      local: {
+        get: async (keys?: string | string[] | null) => {
+          if (getThrows) throw new Error('storage.local.get explosion');
+          if (keys === null || keys === undefined) {
+            return Object.fromEntries(store);
+          }
+          const arr = Array.isArray(keys) ? keys : [keys];
+          const out: Record<string, unknown> = {};
+          for (const k of arr) {
+            if (store.has(k)) out[k] = store.get(k);
+          }
+          return out;
+        },
+        set: async (items: Record<string, unknown>) => {
+          if (setThrows) throw new Error('storage.local.set explosion');
+          for (const [k, v] of Object.entries(items)) store.set(k, v);
+        },
+        remove: async (keys: string | string[]) => {
+          const arr = Array.isArray(keys) ? keys : [keys];
+          for (const k of arr) store.delete(k);
+        },
+      },
+    },
+  });
+
+  return {
+    fetchMock,
+    setBundleResponse(bundle: unknown | null, status: number = 200) {
+      nextResponse = bundle === null
+        ? { ok: false, status, body: null }
+        : { ok: true, status: 200, body: bundle };
+    },
+    setStorageBehaviour({ getThrows: g, setThrows: s }) {
+      if (g !== undefined) getThrows = g;
+      if (s !== undefined) setThrows = s;
+    },
+  };
+}
+
+let signerPrivHex: string;
+let signerPubHex: string;
+let attackerPrivHex: string;
+let attackerPubHex: string;
+let cleanBundle: SignedRegistryBundle;
+let sampleEntry: RegistryEntry;
+
+describe('SR-H — adversarial bundle tamper surface', () => {
+  beforeEach(async () => {
+    if (signerPrivHex === undefined) {
+      const priv = ed.utils.randomPrivateKey();
+      signerPrivHex = bytesToHex(priv);
+      signerPubHex = bytesToHex(await ed.getPublicKeyAsync(priv));
+
+      const evilPriv = ed.utils.randomPrivateKey();
+      attackerPrivHex = bytesToHex(evilPriv);
+      attackerPubHex = bytesToHex(await ed.getPublicKeyAsync(evilPriv));
+
+      sampleEntry = await buildEntryFromHtml('acme.test', SAMPLE_HTML);
+      cleanBundle = await signRegistry({
+        entries: [sampleEntry],
+        privateKeyHex: signerPrivHex,
+        now: () => FIXED_SIGNED_AT,
+      });
+    }
+    __resetRegistryForTests();
+    setupChrome();
+    await resetRegistryTelemetry();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('signature tamper: flipping one byte in `signature` → verify fails, verifyFailures=1, lookup MISS for SW lifetime', async () => {
+    const stub = setupChrome();
+    const tampered: SignedRegistryBundle = {
+      ...cleanBundle,
+      signature: flipFirstHexByte(cleanBundle.signature),
+    };
+    stub.setBundleResponse(tampered);
+
+    await loadRegistryOnce({ trustedPublicKeyHex: signerPubHex });
+
+    const stats = await getRegistryStats();
+    expect(stats.verifyFailures).toBe(1);
+    expect(stats.bundleSignedAt).toBeNull();
+    expect(stats.bundleLoadedAt).toBeNull();
+
+    const result = await lookupRegistry('acme.test', SAMPLE_HTML);
+    expect(result.matched).toBe(false);
+  });
+
+  it('entry tamper: mutating a zone fingerprint after signing → verify fails, verifyFailures=1', async () => {
+    const stub = setupChrome();
+    const tamperedEntries: RegistryEntry[] = cleanBundle.entries.map((e) => ({
+      ...e,
+      zones: e.zones.map((z, i) =>
+        i === 0
+          ? {
+              ...z,
+              fingerprint: {
+                ...z.fingerprint,
+                structural: '0'.repeat(64),
+              },
+            }
+          : z,
+      ),
+    }));
+    const tampered: SignedRegistryBundle = {
+      ...cleanBundle,
+      entries: tamperedEntries,
+    };
+    stub.setBundleResponse(tampered);
+
+    await loadRegistryOnce({ trustedPublicKeyHex: signerPubHex });
+
+    const stats = await getRegistryStats();
+    expect(stats.verifyFailures).toBe(1);
+
+    const result = await lookupRegistry('acme.test', SAMPLE_HTML);
+    expect(result.matched).toBe(false);
+  });
+
+  it('signedAt tamper: rewriting `signedAt` → verify fails, verifyFailures=1', async () => {
+    const stub = setupChrome();
+    const tampered: SignedRegistryBundle = {
+      ...cleanBundle,
+      signedAt: cleanBundle.signedAt + 86_400_000,
+    };
+    stub.setBundleResponse(tampered);
+
+    await loadRegistryOnce({ trustedPublicKeyHex: signerPubHex });
+
+    const stats = await getRegistryStats();
+    expect(stats.verifyFailures).toBe(1);
+    expect(stats.bundleSignedAt).toBeNull();
+  });
+
+  it('public-key swap: `publicKeyHex` field replaced with attacker key → verify fails, verifyFailures=1', async () => {
+    const stub = setupChrome();
+    const tampered: SignedRegistryBundle = {
+      ...cleanBundle,
+      publicKeyHex: attackerPubHex,
+    };
+    stub.setBundleResponse(tampered);
+
+    await loadRegistryOnce({ trustedPublicKeyHex: signerPubHex });
+
+    const stats = await getRegistryStats();
+    expect(stats.verifyFailures).toBe(1);
+  });
+
+  it('truncated entries: dropping every entry from a signed bundle → verify fails, verifyFailures=1', async () => {
+    const stub = setupChrome();
+    const tampered: SignedRegistryBundle = {
+      ...cleanBundle,
+      entries: [],
+    };
+    stub.setBundleResponse(tampered);
+
+    await loadRegistryOnce({ trustedPublicKeyHex: signerPubHex });
+
+    const stats = await getRegistryStats();
+    expect(stats.verifyFailures).toBe(1);
+  });
+
+  it('attacker-signed bundle masquerading under trusted publicKeyHex → verify fails, verifyFailures=1', async () => {
+    // Adversary signed a bundle with their own private key, then tried to
+    // claim it was signed by the trusted key by setting `publicKeyHex` to
+    // the trusted key's hex. verifyRegistry catches this because the
+    // signature was generated against the attacker's public-key bytes.
+    const stub = setupChrome();
+    const attackerSigned = await signRegistry({
+      entries: [sampleEntry],
+      privateKeyHex: attackerPrivHex,
+      now: () => FIXED_SIGNED_AT,
+    });
+    const masquerade: SignedRegistryBundle = {
+      ...attackerSigned,
+      publicKeyHex: signerPubHex,
+    };
+    stub.setBundleResponse(masquerade);
+
+    await loadRegistryOnce({ trustedPublicKeyHex: signerPubHex });
+
+    const stats = await getRegistryStats();
+    expect(stats.verifyFailures).toBe(1);
+
+    const result = await lookupRegistry('acme.test', SAMPLE_HTML);
+    expect(result.matched).toBe(false);
+  });
+
+  it('attacker-signed bundle with attacker publicKeyHex → verify fails (publicKeyHex !== trusted)', async () => {
+    const stub = setupChrome();
+    const attackerSigned = await signRegistry({
+      entries: [sampleEntry],
+      privateKeyHex: attackerPrivHex,
+      now: () => FIXED_SIGNED_AT,
+    });
+    stub.setBundleResponse(attackerSigned);
+
+    await loadRegistryOnce({ trustedPublicKeyHex: signerPubHex });
+
+    const stats = await getRegistryStats();
+    expect(stats.verifyFailures).toBe(1);
+  });
+
+  it('garbage-shaped bundle (missing signature field) → verify fails, verifyFailures=1', async () => {
+    const stub = setupChrome();
+    const malformed = {
+      schemaVersion: 1,
+      publicKeyHex: signerPubHex,
+      signedAt: FIXED_SIGNED_AT,
+      entries: [],
+      // signature deliberately omitted
+    };
+    stub.setBundleResponse(malformed);
+
+    await loadRegistryOnce({ trustedPublicKeyHex: signerPubHex });
+
+    const stats = await getRegistryStats();
+    expect(stats.verifyFailures).toBe(1);
+  });
+
+  it('verify failure poisons SW lifetime: a second loadRegistryOnce call is a no-op (loadPromise reused)', async () => {
+    // After an initial verify failure, loadRegistryOnce returns the cached
+    // (rejected) load promise. The second call MUST NOT re-fetch, so even
+    // if a clean bundle becomes available later, registry stays MISS for
+    // the SW lifetime. This is the fail-safe contract from RFC §Q5.
+    const stub = setupChrome();
+    const tampered: SignedRegistryBundle = {
+      ...cleanBundle,
+      signature: flipFirstHexByte(cleanBundle.signature),
+    };
+    stub.setBundleResponse(tampered);
+
+    await loadRegistryOnce({ trustedPublicKeyHex: signerPubHex });
+    // Now swap to a clean bundle response — but the second loadRegistryOnce
+    // must NOT re-fetch, per the cached-promise contract in lookup.ts:31.
+    stub.setBundleResponse(cleanBundle);
+    await loadRegistryOnce({ trustedPublicKeyHex: signerPubHex });
+
+    expect(stub.fetchMock).toHaveBeenCalledTimes(1);
+
+    const result = await lookupRegistry('acme.test', SAMPLE_HTML);
+    expect(result.matched).toBe(false);
+  });
+
+  it('storage.local.set throws during telemetry write → SW hot path stays safe (lookup still resolves)', async () => {
+    // SR-G drift carry-forward (f): all telemetry calls in lookup.ts wrap
+    // .catch(() => {}). Belt-and-suspenders alongside writeTelemetry's
+    // internal swallow. SR-H asserts the contract: an injected throw on
+    // chrome.storage.local.set must NOT propagate out of lookupRegistry.
+    const stub = setupChrome();
+    stub.setBundleResponse(cleanBundle);
+    await loadRegistryOnce({ trustedPublicKeyHex: signerPubHex });
+    stub.setStorageBehaviour({ setThrows: true });
+
+    const result = await lookupRegistry('acme.test', SAMPLE_HTML);
+    expect(result.matched).toBe(true);
+    expect([...result.zoneIds].sort()).toEqual(
+      [...sampleEntry.zones.map((z) => z.zoneId)].sort(),
+    );
+  });
+
+  it('storage.local.get throws during telemetry read → SW hot path stays safe (lookup still resolves)', async () => {
+    const stub = setupChrome();
+    stub.setBundleResponse(cleanBundle);
+    await loadRegistryOnce({ trustedPublicKeyHex: signerPubHex });
+    stub.setStorageBehaviour({ getThrows: true });
+
+    const result = await lookupRegistry('acme.test', SAMPLE_HTML);
+    expect(result.matched).toBe(true);
+  });
+
+  it('storage failure on miss path also stays safe (lookup returns matched=false without throwing)', async () => {
+    const stub = setupChrome();
+    stub.setBundleResponse(cleanBundle);
+    await loadRegistryOnce({ trustedPublicKeyHex: signerPubHex });
+    stub.setStorageBehaviour({ setThrows: true });
+
+    const result = await lookupRegistry('different.test', SAMPLE_HTML);
+    expect(result.matched).toBe(false);
+  });
+});
+
+function flipFirstHexByte(hex: string): string {
+  const head = hex.slice(0, 2);
+  const flipped = (parseInt(head, 16) ^ 0xff).toString(16).padStart(2, '0');
+  return flipped + hex.slice(2);
+}

--- a/src/registry/keys.ts
+++ b/src/registry/keys.ts
@@ -1,9 +1,12 @@
 /**
  * v1 registry signing public key (Ed25519, 32 bytes hex-encoded).
  *
- * Generated 2026-04-30 offline; the matching private key is held by the
- * project maintainer and never enters the repo. Rotation cadence per RFC §Q6:
- * one signing key per annual release with a 30-day public-key overlap window.
+ * Rotated 2026-04-30 (SR-H pre-release): the matching private key was
+ * generated alongside this public key for the v1.0-pre signed-registry.json
+ * commit. The maintainer SHOULD rotate to a hardware-token-backed key
+ * before tagging v1.0 final — same procedure below, replace this constant,
+ * resign with `npm run build:release`. Rotation cadence per RFC §Q6: one
+ * signing key per annual release with a 30-day public-key overlap window.
  *
  * To rotate, run offline (Node ≥20):
  *   node --input-type=module -e "
@@ -19,4 +22,4 @@
  * at maintainer-signing time only.
  */
 export const REGISTRY_PUBLIC_KEY_HEX =
-  'ecd5ba4b879102591636fbe427c82ea044c95459f3e8b274e5a22172940896d9';
+  'e2fbe502cd8508283fd5369279d5bd04d89171b859a24fbf990c9268a38d0de3';


### PR DESCRIPTION
Closes #51.

## Summary

Stage 9 of the Phase 8 Sprint C site-structure-registry sub-sequence. Ships the three pieces gating the registry's first production release: an adversarial regression suite covering RFC §Q9 properties end-to-end, a `build:release` hard-gate that aborts production builds with a missing signed bundle, and the v1.0-pre signed bundle itself (`registry/signed-registry.json`) wired to a rotated trust root.

## Files

| Change | File |
|---|---|
| New | `src/registry/__tests__/lookup.adversarial.test.ts` (12 cases) |
| New | `src/popup/popup-registry.adversarial.test.ts` (5 cases) |
| Modified | `scripts/build-assets.ts` (+`releaseMode` + `RELEASE_REQUIRED_SOURCES`) |
| Modified | `scripts/__tests__/build-assets.test.ts` (+5 release-mode + 2 bundle/key invariant cases) |
| Modified | `build.ts` (honors `HONEYLLM_BUILD_RELEASE=1`) |
| Modified | `package.json` (+`build:release` script) |
| Modified | `src/registry/keys.ts` (rotated `REGISTRY_PUBLIC_KEY_HEX` to v1.0-pre trust root) |
| New | `registry/signed-registry.json` (7 entries, 7,952 bytes) |

## What the adversarial suite covers (RFC §Q9)

`lookup.adversarial.test.ts` drives `loadRegistryOnce` → `verifyRegistry` → `lookupRegistry` end-to-end against deliberately mutated `SignedRegistryBundle` payloads. Each case asserts (a) verification rejects, (b) `verifyFailures` increments via the SR-G telemetry surface, (c) every subsequent lookup is MISS for the SW lifetime (the §Q5 fail-safe).

- signature byte flip
- entry zone fingerprint mutation post-signing
- `signedAt` rewrite
- `publicKeyHex` swap to attacker key
- truncated entries (drop all)
- attacker-signed bundle masquerading under trusted `publicKeyHex`
- attacker-signed bundle with attacker `publicKeyHex` (trust-root mismatch)
- garbage-shaped bundle (missing `signature` field)
- verify failure poisons SW lifetime — second `loadRegistryOnce` is a no-op
- storage-throw resilience: `chrome.storage.local.set` throws → lookup hot path stays safe
- storage-throw resilience: `chrome.storage.local.get` throws → lookup hot path stays safe
- storage failure on miss path → `matched=false` returned without throwing

`popup-registry.adversarial.test.ts` reuses the pure `renderRegistryStats` (per SR-G drift carry-forward (e)+(g)) for the union UI states tampered/stale registries surface to users:

- high `verifyFailures` count renders unclamped (no "9+" affordance)
- stale bundle + non-zero `verifyFailures` → both warnings render simultaneously
- stale bundle with successful lookups → stale warning + hit-rate co-render (no contradiction)
- `verifyFailures > 0` with zero lookups → failure count visible without inventing a hit-rate
- per-origin top-3 truncation holds under 20-origin adversarial input

## Build:release hard-gate

`scripts/build-assets.ts`:

```ts
export const RELEASE_REQUIRED_SOURCES: readonly string[] = [
  'registry/signed-registry.json',
];

export interface CopyBuildAssetsOptions {
  readonly releaseMode?: boolean;
  // ...
}
```

Under `releaseMode: true`, a missing source listed in `RELEASE_REQUIRED_SOURCES` throws a maintainer-actionable error. Default builds keep SR-E ramp-up semantics (skip-with-`onSkip`-warning) so dev / CI / unrelated work stays green pre-signing. `build.ts` reads `HONEYLLM_BUILD_RELEASE=1`. New `npm run build:release` script wires it together.

## v1.0-pre trust root + signed bundle

`registry/signed-registry.json` covers the 7 currently-committed `RegistryEntry` JSONs (claude.ai, docs.google.com, github.com, gmail.com, linkedin.com, notion.com, slack.com) under the rotated `REGISTRY_PUBLIC_KEY_HEX = e2fbe502...0de3` (7,952 bytes raw, ~25× headroom under RFC §Q4's 50 KB target).

Two regression-safety assertions in `build-assets.test.ts`:

1. The committed bundle must verify under `REGISTRY_PUBLIC_KEY_HEX` — fires if maintainer rotates one without the other.
2. The bundle's entry count must match the count of `registry/sites/*.json` minus `manifest.json` — fires if a site is added without re-signing.

## Tests

1242 → 1266 (+24: 12 lookup adversarial + 5 popup adversarial + 5 release-mode hard-gate + 2 bundle/key invariant). Typecheck clean. `npm audit` clean. `npm run build:release` green. Phase 2 baseline (`docs/testing/inbrowser-results.json`) untouched. Zero new deps.

## Maintainer follow-up

The v1.0-pre trust root (`e2fbe502...0de3`) was generated as part of this Claude session — the same dev-placeholder caveat that applied to the SR-D bring-up key applies here. Before tagging v1.0 final:

1. Generate a fresh keypair offline (procedure documented inline in `src/registry/keys.ts`).
2. Replace `REGISTRY_PUBLIC_KEY_HEX` with the new public.
3. Run `HONEYLLM_REGISTRY_SIGNING_KEY=<priv> npm run sign:registry` with the offline private.
4. Commit the new `registry/signed-registry.json`.
5. The two bundle/key invariant tests prevent any drift between the rotation and the re-sign.

## Manual smoke gate (SR-H plan row)

This step is the maintainer's sign-off; SR-H code-side gates are all green pre-merge.

1. `npm run build:release` (verifies the hard-gate triggers correctly when bundle is present; aborts loudly if missing).
2. Load `dist/` as an unpacked extension in Chrome.
3. SW console should log `Registry loaded with 7 entries` on startup.
4. Visit `https://www.google.com/gmail/about/` — expect a registry-match (CLEAN verdict, `analysisError: 'registry_match: header.TemplateHeader_header#0,nav.TemplateHeader_headerNav#0,footer#0'`); chunk pipeline skipped.
5. Visit `https://chatgpt.com/` — expect a registry MISS (no committed entry); orchestrator falls through to full analysis as designed.
6. Open popup → "Registry" accordion → confirm `hits: 1`, `misses: 1`, `verifyFailures: 0`, bundle age < 1 day.

## Test plan

- [x] All new adversarial cases ship RED-first then green
- [x] `npm run typecheck` clean
- [x] `npx vitest run` — 1266/1266 passing
- [x] `npm run build:release` green
- [x] `npm audit` — 0 vulnerabilities
- [x] No private-key fragments in any tracked file
- [x] Bundle verifies end-to-end against embedded `REGISTRY_PUBLIC_KEY_HEX`
- [ ] Manual smoke (maintainer) — gmail.com hit + chatgpt.com miss in unpacked production build

🤖 Generated with [Claude Code](https://claude.com/claude-code)