### PR TITLE
feat(agent-sdk-#125): Stage 3 — LangGraph tool-call middleware

### DIFF
--- a/packages/agent-sdk-langchain/README.md
+++ b/packages/agent-sdk-langchain/README.md
@@ -4,7 +4,7 @@ LangChain wrapper for the HoneyLLM Agent SDK. Wraps a LangChain web tool so its
 output is screened by the [HoneyLLM Browse MCP server](../../mcp-server/) before
 reaching the LLM.
 
-Status: **Stage 2 — LangChain per-tool wrappers + StructuredTool support + subprocess smoke** (issue
+Status: **Stage 3 — LangGraph tool-call middleware** (issue
 [#125](https://github.com/JimmyCapps/zentropy/issues/125)).
 
 ## What it does
@@ -166,7 +166,58 @@ const safeRunnable = wrapAsRunnable(fetcher, { analyzer: conn.analyzer });
 const chain = safeRunnable.pipe(myDownstreamRunnable);
 ```
 
-## Stage 2 surface (this release)
+## LangGraph tool-call middleware (Stage 3)
+
+The per-tool wrappers above run analysis at every wrapped tool's boundary. If
+you'd rather screen all tool outputs at one place in the graph — for example,
+right after a `ToolNode` and before the model sees the results — use
+`createHoneyLLMMiddleware`. It returns a LangChain `Runnable` that screens
+every `ToolMessage` in the latest tool-call batch and replaces its content
+with the analyzer-sanitised string (or throws `HoneyLLMBlockedError`).
+
+```ts
+import { ChatOpenAI } from '@langchain/openai';
+import { ToolNode } from '@langchain/langgraph/prebuilt';
+import { StateGraph, MessagesAnnotation } from '@langchain/langgraph';
+import {
+  connectStdioMcpServer,
+  createHoneyLLMMiddleware,
+} from '@honeyllm/agent-sdk-langchain';
+
+const conn = await connectStdioMcpServer({ command: 'npx', args: ['honeyllm-mcp'] });
+
+const tools = [/* your raw tools — no per-tool wrapping needed */];
+const toolNode = new ToolNode(tools);
+const honeyllmGuard = createHoneyLLMMiddleware({
+  analyzer: conn.analyzer,
+  policy: 'block-on-compromised',
+  toolNames: ['web_fetch', 'browse'], // optional: only screen these tools
+});
+
+const graph = new StateGraph(MessagesAnnotation)
+  .addNode('tools', toolNode)
+  .addNode('honeyllm', honeyllmGuard)
+  .addNode('model', model)
+  .addEdge('tools', 'honeyllm')
+  .addEdge('honeyllm', 'model');
+```
+
+The middleware accepts either `BaseMessage[]` or `{ messages: BaseMessage[] }`
+and returns the same shape — drop it into a `MessagesAnnotation` graph
+directly, or `.pipe()` it after a Runnable that emits messages. URL hints are
+correlated automatically: each `ToolMessage` is matched against the
+preceding `AIMessage`'s `tool_calls` by `tool_call_id`, then the default URL
+extractor walks the call's `args` (`url`/`href`/`webPath`/`uri` precedence).
+
+If you only need the pure transform (e.g. to test a graph node without running
+it through `Runnable.invoke`), `screenToolMessages(messages, opts)` is
+exported as a plain async function with the same options.
+
+`ToolMessages` with `status === 'error'` and non-string content (multimodal
+arrays) are passed through unchanged — only successful string outputs from
+the latest tool batch are screened.
+
+## Stage 3 surface (this release)
 
 - `wrapWebTool(tool, opts)` — framework-neutral primitive (Stage 1)
 - `wrapAsLangChainTool(tool, opts)` — LangChain `DynamicTool` adapter (Stage 1)
@@ -176,6 +227,10 @@ const chain = safeRunnable.pipe(myDownstreamRunnable);
   Document-loader adapters (Stage 2)
 - `wrapRequestsGetTool(tool, opts)` — typed alias for `RequestsGetTool` (Stage 2)
 - `wrapAsRunnable(tool, opts)` — LangChain `Runnable` for graph-level use (Stage 2)
+- `createHoneyLLMMiddleware(opts)` — LangGraph node `Runnable` that screens
+  `ToolMessage`s in the latest tool-call batch at the graph boundary (Stage 3)
+- `screenToolMessages(messages, opts)` — pure async function under the
+  middleware, exposed for direct testing / custom graph wiring (Stage 3)
 - `screenContent` / `screenContentOrThrow` — direct content screening (Stage 1)
 - `createMcpAnalyzer({ client })` — analyzer over an `McpClientLike` shim (Stage 1)
 - `connectStdioMcpServer({ command, args })` — spawns `honeyllm-mcp` over
@@ -186,7 +241,6 @@ const chain = safeRunnable.pipe(myDownstreamRunnable);
 ## Out of scope (later stages)
 
 - HTTP-streamable transport to a hosted MCP server
-- LangGraph tool-call middleware on the tool node (Stage 3)
 - Other frameworks: CrewAI, AutoGen, Mastra, Vercel AI SDK (Stages 4–7)
 - Python sister-package (`honeyllm-agent-sdk`) (Stage 8)
 
@@ -195,7 +249,7 @@ These are tracked under #125; each will land in its own follow-up stage.
 ## Testing
 
 ```bash
-npm test          # 105 unit + integration tests (Stage 2)
+npm test          # 125 unit + integration tests (Stage 3)
 npm run typecheck # tsc --noEmit
 npm run build     # tsc -p tsconfig.build.json → dist/
 ```

--- a/packages/agent-sdk-langchain/package.json
+++ b/packages/agent-sdk-langchain/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "license": "Apache-2.0",
-  "description": "HoneyLLM Agent SDK — LangChain wrapper. Per-tool wrappers (WebBaseLoader / PlaywrightURLLoader / RequestsGetTool / StructuredTool) plus a Runnable adapter; output is screened by the HoneyLLM Browse MCP server before reaching the LLM (issue #125, Stage 2).",
+  "description": "HoneyLLM Agent SDK — LangChain wrapper. Per-tool wrappers (WebBaseLoader / PlaywrightURLLoader / RequestsGetTool / StructuredTool) plus a Runnable adapter and a LangGraph tool-call middleware; output is screened by the HoneyLLM Browse MCP server before reaching the LLM (issue #125, Stage 3).",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/agent-sdk-langchain/src/__tests__/middleware-runnable.test.ts
+++ b/packages/agent-sdk-langchain/src/__tests__/middleware-runnable.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Runnable, RunnableLambda } from '@langchain/core/runnables';
+import { AIMessage, ToolMessage } from '@langchain/core/messages';
+import type { Analyzer, AnalyzerResult, SecurityVerdict } from '../types.js';
+import { HoneyLLMBlockedError } from '../types.js';
+import { createHoneyLLMMiddleware } from '../middleware.js';
+
+function makeVerdict(status: SecurityVerdict['status']): SecurityVerdict {
+  return {
+    status,
+    confidence: 100,
+    totalScore: status === 'COMPROMISED' ? 80 : 0,
+    url: 'https://example.com/',
+    timestamp: 1_700_000_000_000,
+    analysisError: null,
+  };
+}
+
+const cleanResult: AnalyzerResult = {
+  content: 'sanitised',
+  verdict: makeVerdict('CLEAN'),
+  mitigationsApplied: [],
+};
+
+const compromisedResult: AnalyzerResult = {
+  content: 'tainted',
+  verdict: makeVerdict('COMPROMISED'),
+  mitigationsApplied: [],
+};
+
+function makeAnalyzer(result: AnalyzerResult): Analyzer {
+  return { analyzeHtml: vi.fn(async () => result) };
+}
+
+function singleToolBatch() {
+  const ai = new AIMessage({
+    content: '',
+    tool_calls: [{ name: 'web_fetch', args: { url: 'https://example.com/' }, id: 't1' }],
+  });
+  const tm = new ToolMessage({
+    content: '<html>raw</html>',
+    tool_call_id: 't1',
+    name: 'web_fetch',
+  });
+  return [ai, tm];
+}
+
+describe('createHoneyLLMMiddleware', () => {
+  it('returns a LangChain Runnable instance', () => {
+    const mw = createHoneyLLMMiddleware({ analyzer: makeAnalyzer(cleanResult) });
+    expect(mw).toBeInstanceOf(Runnable);
+  });
+
+  it('accepts a BaseMessage[] input and returns the screened array', async () => {
+    const mw = createHoneyLLMMiddleware({ analyzer: makeAnalyzer(cleanResult) });
+    const out = await mw.invoke(singleToolBatch());
+    expect(Array.isArray(out)).toBe(true);
+    expect((out as readonly ToolMessage[])[1]?.content).toBe('sanitised');
+  });
+
+  it('accepts a {messages: BaseMessage[]} state input and returns {messages}', async () => {
+    const mw = createHoneyLLMMiddleware({ analyzer: makeAnalyzer(cleanResult) });
+    const out = await mw.invoke({ messages: singleToolBatch() });
+    expect(out).toHaveProperty('messages');
+    expect((out as { messages: readonly ToolMessage[] }).messages[1]?.content).toBe(
+      'sanitised',
+    );
+  });
+
+  it('throws HoneyLLMBlockedError on COMPROMISED via the Runnable', async () => {
+    const mw = createHoneyLLMMiddleware({ analyzer: makeAnalyzer(compromisedResult) });
+    await expect(mw.invoke(singleToolBatch())).rejects.toBeInstanceOf(HoneyLLMBlockedError);
+  });
+
+  it('composes with .pipe() — graph-level use', async () => {
+    const mw = createHoneyLLMMiddleware({ analyzer: makeAnalyzer(cleanResult) });
+    const tail = RunnableLambda.from((msgs: readonly ToolMessage[]) => {
+      const last = msgs[msgs.length - 1];
+      return last && typeof last.content === 'string' ? last.content.toUpperCase() : '';
+    });
+    const chain = mw.pipe(tail);
+    const out = await chain.invoke(singleToolBatch());
+    expect(out).toBe('SANITISED');
+  });
+
+  it('honours flag-only policy on COMPROMISED through the Runnable boundary', async () => {
+    const mw = createHoneyLLMMiddleware({
+      analyzer: makeAnalyzer(compromisedResult),
+      policy: 'flag-only',
+    });
+    const out = await mw.invoke(singleToolBatch());
+    expect((out as readonly ToolMessage[])[1]?.content).toBe('tainted');
+  });
+});

--- a/packages/agent-sdk-langchain/src/__tests__/middleware.test.ts
+++ b/packages/agent-sdk-langchain/src/__tests__/middleware.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
+import type { BaseMessage } from '@langchain/core/messages';
+import type { Analyzer, AnalyzerResult, SecurityVerdict } from '../types.js';
+import { HoneyLLMBlockedError } from '../types.js';
+import { screenToolMessages } from '../middleware.js';
+
+function makeVerdict(status: SecurityVerdict['status']): SecurityVerdict {
+  return {
+    status,
+    confidence: 100,
+    totalScore: status === 'COMPROMISED' ? 80 : status === 'SUSPICIOUS' ? 20 : 0,
+    url: 'https://example.com/',
+    timestamp: 1_700_000_000_000,
+    analysisError: null,
+  };
+}
+
+function clean(content: string): AnalyzerResult {
+  return {
+    content,
+    verdict: makeVerdict('CLEAN'),
+    mitigationsApplied: [],
+  };
+}
+
+function compromised(content: string): AnalyzerResult {
+  return {
+    content,
+    verdict: makeVerdict('COMPROMISED'),
+    mitigationsApplied: [],
+  };
+}
+
+function makeAnalyzer(...results: AnalyzerResult[]): Analyzer {
+  if (results.length === 0) throw new Error('makeAnalyzer requires at least one result');
+  let i = 0;
+  return {
+    analyzeHtml: vi.fn(async () => {
+      const r = results[i] ?? results[results.length - 1];
+      i += 1;
+      return r as AnalyzerResult;
+    }),
+  };
+}
+
+describe('screenToolMessages', () => {
+  it('returns the input untouched when there are no messages', async () => {
+    const out = await screenToolMessages([], { analyzer: makeAnalyzer(clean('x')) });
+    expect(out).toEqual([]);
+  });
+
+  it('returns the input untouched when there are no ToolMessages at the tail', async () => {
+    const msgs: BaseMessage[] = [new HumanMessage('hi'), new AIMessage('hello')];
+    const analyzer = makeAnalyzer(clean('x'));
+    const out = await screenToolMessages(msgs, { analyzer });
+    expect(out).toEqual(msgs);
+    expect(analyzer.analyzeHtml).not.toHaveBeenCalled();
+  });
+
+  it('replaces a tail ToolMessage content with the screened (sanitised) string on CLEAN', async () => {
+    const ai = new AIMessage({
+      content: '',
+      tool_calls: [{ name: 'web_fetch', args: { url: 'https://example.com/' }, id: 't1' }],
+    });
+    const tm = new ToolMessage({
+      content: '<html>raw</html>',
+      tool_call_id: 't1',
+      name: 'web_fetch',
+    });
+    const out = await screenToolMessages([ai, tm], {
+      analyzer: makeAnalyzer(clean('sanitised')),
+    });
+    expect(out).toHaveLength(2);
+    const replaced = out[1] as ToolMessage;
+    expect(replaced).toBeInstanceOf(ToolMessage);
+    expect(replaced.content).toBe('sanitised');
+    expect(replaced.tool_call_id).toBe('t1');
+    expect(replaced.name).toBe('web_fetch');
+  });
+
+  it('throws HoneyLLMBlockedError on COMPROMISED under default policy', async () => {
+    const ai = new AIMessage({
+      content: '',
+      tool_calls: [{ name: 'web_fetch', args: { url: 'https://example.com/' }, id: 't1' }],
+    });
+    const tm = new ToolMessage({
+      content: '<html>tainted</html>',
+      tool_call_id: 't1',
+      name: 'web_fetch',
+    });
+    await expect(
+      screenToolMessages([ai, tm], { analyzer: makeAnalyzer(compromised('tainted')) }),
+    ).rejects.toBeInstanceOf(HoneyLLMBlockedError);
+  });
+
+  it('does not throw on COMPROMISED under flag-only policy and passes content through', async () => {
+    const ai = new AIMessage({
+      content: '',
+      tool_calls: [{ name: 'web_fetch', args: { url: 'https://example.com/' }, id: 't1' }],
+    });
+    const tm = new ToolMessage({
+      content: '<html>tainted</html>',
+      tool_call_id: 't1',
+      name: 'web_fetch',
+    });
+    const out = await screenToolMessages([ai, tm], {
+      analyzer: makeAnalyzer(compromised('tainted')),
+      policy: 'flag-only',
+    });
+    expect((out[1] as ToolMessage).content).toBe('tainted');
+  });
+
+  it('screens every ToolMessage in the tail batch (parallel tool calls)', async () => {
+    const ai = new AIMessage({
+      content: '',
+      tool_calls: [
+        { name: 'web_fetch', args: { url: 'https://a.example/' }, id: 't1' },
+        { name: 'web_fetch', args: { url: 'https://b.example/' }, id: 't2' },
+      ],
+    });
+    const tm1 = new ToolMessage({ content: '<a/>', tool_call_id: 't1', name: 'web_fetch' });
+    const tm2 = new ToolMessage({ content: '<b/>', tool_call_id: 't2', name: 'web_fetch' });
+    const analyzer = makeAnalyzer(clean('A'), clean('B'));
+    const out = await screenToolMessages([ai, tm1, tm2], { analyzer });
+    expect((out[1] as ToolMessage).content).toBe('A');
+    expect((out[2] as ToolMessage).content).toBe('B');
+    expect(analyzer.analyzeHtml).toHaveBeenCalledTimes(2);
+  });
+
+  it('passes the URL hint by correlating ToolMessage.tool_call_id with the prior AIMessage tool_calls', async () => {
+    const ai = new AIMessage({
+      content: '',
+      tool_calls: [{ name: 'web_fetch', args: { url: 'https://target.example/x' }, id: 't1' }],
+    });
+    const tm = new ToolMessage({ content: '<h/>', tool_call_id: 't1', name: 'web_fetch' });
+    const analyzer = makeAnalyzer(clean('ok'));
+    await screenToolMessages([ai, tm], { analyzer });
+    expect(analyzer.analyzeHtml).toHaveBeenCalledWith({
+      html: '<h/>',
+      url: 'https://target.example/x',
+    });
+  });
+
+  it('omits url when no AIMessage tool_call matches and no extractor finds one', async () => {
+    const tm = new ToolMessage({ content: '<h/>', tool_call_id: 'orphan', name: 'web_fetch' });
+    const analyzer = makeAnalyzer(clean('ok'));
+    await screenToolMessages([tm], { analyzer });
+    expect(analyzer.analyzeHtml).toHaveBeenCalledWith({ html: '<h/>' });
+  });
+
+  it('skips ToolMessages whose name is not in toolNames filter', async () => {
+    const ai = new AIMessage({
+      content: '',
+      tool_calls: [
+        { name: 'web_fetch', args: { url: 'https://a.example/' }, id: 't1' },
+        { name: 'calculator', args: { x: 2 }, id: 't2' },
+      ],
+    });
+    const tm1 = new ToolMessage({ content: '<a/>', tool_call_id: 't1', name: 'web_fetch' });
+    const tm2 = new ToolMessage({ content: '4', tool_call_id: 't2', name: 'calculator' });
+    const analyzer = makeAnalyzer(clean('A'));
+    const out = await screenToolMessages([ai, tm1, tm2], {
+      analyzer,
+      toolNames: ['web_fetch'],
+    });
+    expect((out[1] as ToolMessage).content).toBe('A');
+    expect((out[2] as ToolMessage).content).toBe('4');
+    expect(analyzer.analyzeHtml).toHaveBeenCalledTimes(1);
+  });
+
+  it('honours a custom extractUrl over the default precedence walk', async () => {
+    const ai = new AIMessage({
+      content: '',
+      tool_calls: [{ name: 'fetch', args: { target: 'https://other.example/' }, id: 't1' }],
+    });
+    const tm = new ToolMessage({ content: '<h/>', tool_call_id: 't1', name: 'fetch' });
+    const analyzer = makeAnalyzer(clean('ok'));
+    await screenToolMessages([ai, tm], {
+      analyzer,
+      extractUrl: (args) => (args as { target: string }).target,
+    });
+    expect(analyzer.analyzeHtml).toHaveBeenCalledWith({
+      html: '<h/>',
+      url: 'https://other.example/',
+    });
+  });
+
+  it('passes through ToolMessages with status=error without screening', async () => {
+    const ai = new AIMessage({
+      content: '',
+      tool_calls: [{ name: 'web_fetch', args: { url: 'https://example.com/' }, id: 't1' }],
+    });
+    const tm = new ToolMessage({
+      content: 'fetch failed: ECONNREFUSED',
+      tool_call_id: 't1',
+      name: 'web_fetch',
+      status: 'error',
+    });
+    const analyzer = makeAnalyzer(clean('x'));
+    const out = await screenToolMessages([ai, tm], { analyzer });
+    expect(out[1]).toBe(tm);
+    expect(analyzer.analyzeHtml).not.toHaveBeenCalled();
+  });
+
+  it('passes through ToolMessages with non-string (multimodal array) content unchanged', async () => {
+    const ai = new AIMessage({
+      content: '',
+      tool_calls: [{ name: 'web_fetch', args: { url: 'https://example.com/' }, id: 't1' }],
+    });
+    const tm = new ToolMessage({
+      content: [{ type: 'text', text: 'hello' }],
+      tool_call_id: 't1',
+      name: 'web_fetch',
+    });
+    const analyzer = makeAnalyzer(clean('x'));
+    const out = await screenToolMessages([ai, tm], { analyzer });
+    expect(out[1]).toBe(tm);
+    expect(analyzer.analyzeHtml).not.toHaveBeenCalled();
+  });
+
+  it('only screens the tail batch — earlier ToolMessages from prior turns are left alone', async () => {
+    const ai1 = new AIMessage({
+      content: '',
+      tool_calls: [{ name: 'web_fetch', args: { url: 'https://old.example/' }, id: 't0' }],
+    });
+    const oldTm = new ToolMessage({ content: '<old/>', tool_call_id: 't0', name: 'web_fetch' });
+    const aiText = new AIMessage('intermediate');
+    const ai2 = new AIMessage({
+      content: '',
+      tool_calls: [{ name: 'web_fetch', args: { url: 'https://new.example/' }, id: 't1' }],
+    });
+    const newTm = new ToolMessage({ content: '<new/>', tool_call_id: 't1', name: 'web_fetch' });
+    const analyzer = makeAnalyzer(clean('NEW'));
+    const out = await screenToolMessages([ai1, oldTm, aiText, ai2, newTm], { analyzer });
+    expect(out[1]).toBe(oldTm);
+    expect((out[4] as ToolMessage).content).toBe('NEW');
+    expect(analyzer.analyzeHtml).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves ToolMessage tool_call_id, name, status, and additional_kwargs on replacement', async () => {
+    const ai = new AIMessage({
+      content: '',
+      tool_calls: [{ name: 'web_fetch', args: { url: 'https://example.com/' }, id: 't1' }],
+    });
+    const tm = new ToolMessage({
+      content: '<h/>',
+      tool_call_id: 't1',
+      name: 'web_fetch',
+      status: 'success',
+      additional_kwargs: { custom: 'meta' },
+    });
+    const analyzer = makeAnalyzer(clean('san'));
+    const out = await screenToolMessages([ai, tm], { analyzer });
+    const replaced = out[1] as ToolMessage;
+    expect(replaced.tool_call_id).toBe('t1');
+    expect(replaced.name).toBe('web_fetch');
+    expect(replaced.status).toBe('success');
+    expect(replaced.additional_kwargs).toEqual({ custom: 'meta' });
+  });
+});

--- a/packages/agent-sdk-langchain/src/index.ts
+++ b/packages/agent-sdk-langchain/src/index.ts
@@ -38,6 +38,12 @@ export type {
 } from './loaders.js';
 export { wrapAsRunnable } from './runnable.js';
 export type { InvokableLike, WrapAsRunnableOptions } from './runnable.js';
+export { createHoneyLLMMiddleware, screenToolMessages } from './middleware.js';
+export type {
+  HoneyLLMMiddlewareOptions,
+  MiddlewareInput,
+  MiddlewareOutput,
+} from './middleware.js';
 export { createMcpAnalyzer } from './stdio-analyzer.js';
 export type {
   CreateMcpAnalyzerOptions,

--- a/packages/agent-sdk-langchain/src/middleware.ts
+++ b/packages/agent-sdk-langchain/src/middleware.ts
@@ -1,0 +1,116 @@
+import { AIMessage, ToolMessage } from '@langchain/core/messages';
+import type { BaseMessage } from '@langchain/core/messages';
+import { type Runnable, RunnableLambda } from '@langchain/core/runnables';
+import { defaultExtractUrl, type ExtractUrl } from './extract-url.js';
+import { screenContentOrThrow } from './screen.js';
+import type { Analyzer, WrapPolicy } from './types.js';
+
+export interface HoneyLLMMiddlewareOptions {
+  readonly analyzer: Analyzer;
+  readonly policy?: WrapPolicy;
+  readonly toolNames?: readonly string[];
+  readonly extractUrl?: ExtractUrl<unknown>;
+}
+
+function isAIMessage(m: BaseMessage): m is AIMessage {
+  return m._getType() === 'ai';
+}
+
+function findTailToolBatchStart(messages: readonly BaseMessage[]): number {
+  let i = messages.length - 1;
+  while (i >= 0 && messages[i] instanceof ToolMessage) {
+    i -= 1;
+  }
+  return i + 1;
+}
+
+function findToolCallArgs(
+  messages: readonly BaseMessage[],
+  batchStart: number,
+  toolCallId: string,
+): unknown {
+  for (let j = batchStart - 1; j >= 0; j -= 1) {
+    const m = messages[j];
+    if (!m || !isAIMessage(m)) continue;
+    const calls = m.tool_calls ?? [];
+    const match = calls.find((c) => c.id === toolCallId);
+    if (match) return match.args;
+    return undefined;
+  }
+  return undefined;
+}
+
+function rebuildToolMessage(original: ToolMessage, content: string): ToolMessage {
+  return new ToolMessage({
+    content,
+    tool_call_id: original.tool_call_id,
+    ...(original.name !== undefined ? { name: original.name } : {}),
+    ...(original.status !== undefined ? { status: original.status } : {}),
+    ...(original.additional_kwargs !== undefined
+      ? { additional_kwargs: original.additional_kwargs }
+      : {}),
+    ...(original.response_metadata !== undefined
+      ? { response_metadata: original.response_metadata }
+      : {}),
+    ...(original.id !== undefined ? { id: original.id } : {}),
+    ...(original.artifact !== undefined ? { artifact: original.artifact } : {}),
+  });
+}
+
+export async function screenToolMessages(
+  messages: readonly BaseMessage[],
+  opts: HoneyLLMMiddlewareOptions,
+): Promise<readonly BaseMessage[]> {
+  if (messages.length === 0) return messages;
+  const batchStart = findTailToolBatchStart(messages);
+  if (batchStart === messages.length) return messages;
+
+  const extractUrl = opts.extractUrl ?? ((args: unknown) => defaultExtractUrl(args));
+  const allowed = opts.toolNames ? new Set(opts.toolNames) : null;
+
+  const out: BaseMessage[] = messages.slice();
+  for (let k = batchStart; k < messages.length; k += 1) {
+    const tm = messages[k] as ToolMessage;
+    if (allowed && (tm.name === undefined || !allowed.has(tm.name))) continue;
+    if (tm.status === 'error') continue;
+    if (typeof tm.content !== 'string') continue;
+
+    const args = findToolCallArgs(messages, batchStart, tm.tool_call_id);
+    const url = args !== undefined ? extractUrl(args) : undefined;
+
+    const screened = await screenContentOrThrow({
+      html: tm.content,
+      analyzer: opts.analyzer,
+      ...(url !== undefined ? { url } : {}),
+      ...(opts.policy !== undefined ? { policy: opts.policy } : {}),
+    });
+    out[k] = rebuildToolMessage(tm, screened.content);
+  }
+  return out;
+}
+
+export type MiddlewareInput =
+  | readonly BaseMessage[]
+  | { readonly messages: readonly BaseMessage[] };
+
+export type MiddlewareOutput =
+  | readonly BaseMessage[]
+  | { readonly messages: readonly BaseMessage[] };
+
+function isStateShape(
+  input: MiddlewareInput,
+): input is { readonly messages: readonly BaseMessage[] } {
+  return !Array.isArray(input) && typeof input === 'object' && input !== null && 'messages' in input;
+}
+
+export function createHoneyLLMMiddleware(
+  opts: HoneyLLMMiddlewareOptions,
+): Runnable<MiddlewareInput, MiddlewareOutput> {
+  return RunnableLambda.from(async (input: MiddlewareInput): Promise<MiddlewareOutput> => {
+    if (isStateShape(input)) {
+      const screened = await screenToolMessages(input.messages, opts);
+      return { messages: screened };
+    }
+    return await screenToolMessages(input, opts);
+  });
+}


### PR DESCRIPTION
## Summary

Stage 3 of #125 (HoneyLLM Agent SDK). Drops a HoneyLLM screen step into a LangGraph graph as a `Runnable` node so the analyzer runs at the **graph boundary** rather than per-tool wrapper.

- **`screenToolMessages(messages, opts)`** — pure async function. Identifies the tail batch of `ToolMessage`s, correlates each with the prior `AIMessage`'s `tool_calls` by `tool_call_id` to derive a URL hint, and screens each string-content message via the shared `screenContentOrThrow` seam. Tail-only scan keeps prior turns untouched. Skips `status === 'error'` and non-string (multimodal array) content. Optional `toolNames` filter, optional custom `extractUrl` (else `defaultExtractUrl` walks `url`/`href`/`webPath`/`uri`).
- **`createHoneyLLMMiddleware(opts)`** — `RunnableLambda` wrapping the pure function. Accepts either `BaseMessage[]` or `{ messages: BaseMessage[] }` and returns the same shape, so it drops directly into a `MessagesAnnotation` graph or composes with `.pipe()` after any Runnable emitting messages.

Reuses the Stage 1/2 seams:
- `Analyzer` interface — middleware does NOT spawn its own MCP client; consumer passes `conn.analyzer` from `connectStdioMcpServer` (unchanged transport seam).
- `defaultExtractUrl` (Stage 2 carry-forward).
- `screenContentOrThrow` (policy enforcement).

Default policy `block-on-compromised`; `flag-only` and `block-on-suspicious` honoured at the boundary.

## Tests

agent-sdk-langchain: **105 → 125** (+20 across 2 new files).

- `middleware.test.ts` — 14 cases driving the pure function end-to-end through a fake `Analyzer`: empty messages, no-tool-tail passthrough, single CLEAN replacement, COMPROMISED throws, flag-only passthrough, parallel tool-call batch (multi-message), URL hint correlation by `tool_call_id`, orphan tool_call_id (no AIMessage match) → no URL hint, `toolNames` filter skipping non-matching, custom `extractUrl`, `status === 'error'` passthrough, multimodal array content passthrough, prior-turn tail isolation, additional_kwargs/status preservation on rebuild.
- `middleware-runnable.test.ts` — 6 cases on the Runnable boundary: `Runnable` instance check, `BaseMessage[]` shape, `{ messages }` state-shape input, `HoneyLLMBlockedError` propagation, `.pipe()` composition, `flag-only` policy through the boundary.

Parent repo unchanged at **1291**; mcp-server unchanged at **135**.

## Test plan

- [x] `npm test` in `packages/agent-sdk-langchain/` (125 pass)
- [x] `npm run typecheck` clean
- [x] `npm run build` (tsc -p tsconfig.build.json) clean
- [x] Parent `npm test` (1291) and `npm run typecheck` clean
- [x] mcp-server `npm test` (135) clean
- [x] `npm audit --audit-level=high` — only the 3 moderate `uuid<14` advisories carrying forward from Stage 2 (langsmith transitive devDep). No new vulns introduced.
- [x] Secret grep clean

Refs #125