### PR TITLE
feat(embeddings-#129): Stage 4 — SW↔offscreen EMBED_TEXT bridge + wired hunter

### DIFF
--- a/src/offscreen/index.ts
+++ b/src/offscreen/index.ts
@@ -1,5 +1,6 @@
 import type {
   HoneyLLMMessage,
+  EmbedResultMessage,
   LanguageResultMessage,
   NerResultMessage,
   ParseHtmlResultMessage,
@@ -13,6 +14,7 @@ import { runProbes } from './probe-runner.js';
 import { runDirectProbe, type DirectProbeDeps } from './direct-probe.js';
 import { handleDetectLanguage } from './lang-detect-engine.js';
 import { handleRunNer } from './ner-engine.js';
+import { embedText } from './embedding-engine.js';
 import { parseHtmlToSnapshot } from './parse-html.js';
 
 const log = createLogger('Offscreen');
@@ -152,6 +154,36 @@ chrome.runtime.onMessage.addListener((message: HoneyLLMMessage, _sender, sendRes
     return false; // synchronous reply
   }
 
+  // Issue #129 Stage 4 — sentence-embedding RPC. SW-side
+  // `embed-router.ts` invokes this; `embedText` is total (returns null on
+  // empty input / model load failure / inference exception). We serialise
+  // the Float32Array to `number[]` because chrome.runtime messages are
+  // JSON-cloneable; the SW router rehydrates back to Float32Array. The
+  // single RPC dispatch shape mirrors RUN_NER so the offscreen-doc has a
+  // single consistent contract for the orchestrator's chunk loop.
+  if (message.type === 'EMBED_TEXT') {
+    const start = performance.now();
+    embedText(message.text, message.mode === undefined ? undefined : { mode: message.mode })
+      .then((vec) => {
+        const reply: EmbedResultMessage = {
+          type: 'EMBED_RESULT',
+          embedding: vec === null ? null : Array.from(vec),
+          inferenceMs: performance.now() - start,
+        };
+        sendResponse(reply);
+      })
+      .catch((err: unknown) => {
+        log.error('embedText rejected unexpectedly', err);
+        const reply: EmbedResultMessage = {
+          type: 'EMBED_RESULT',
+          embedding: null,
+          inferenceMs: performance.now() - start,
+        };
+        sendResponse(reply);
+      });
+    return true; // keep channel open for async sendResponse
+  }
+
   if (message.type === 'RUN_NER') {
     const start = performance.now();
     handleRunNer(message.text, message.deadlineMs ?? 250, message.chunkOffset)
@@ -244,4 +276,14 @@ initEngine().catch((err) => {
 // bounds the cold-load wait without blocking the offscreen doc.
 handleRunNer('warmup', 30_000).catch((err: unknown) => {
   log.warn('NER pre-warm failed; first scan will load on demand', err);
+});
+
+// Issue #129 Stage 4 — pre-warm the embedding engine at offscreen-doc
+// creation. Same rationale as the NER pre-warm: the first
+// `intfloat/multilingual-e5-small` load fetches ~50 MB from the HF CDN
+// and runs ONNX session init. `embedText` is total (returns null on
+// every failure path); pre-warming amortises the cold load over SW
+// startup so the orchestrator's first embed RPC sees a warm model.
+embedText('warmup').catch((err: unknown) => {
+  log.warn('Embedding pre-warm failed; first scan will load on demand', err);
 });

--- a/src/service-worker/embed-router.test.ts
+++ b/src/service-worker/embed-router.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { embedTextForChunk, _resetForTesting, MIN_EMBED_CHARS } from './embed-router.js';
+import type { EmbedResultMessage } from '@/types/messages.js';
+
+interface FakeDeps {
+  readonly send: (text: string) => Promise<EmbedResultMessage>;
+}
+
+function fakeReply(embedding: readonly number[] | null): EmbedResultMessage {
+  return {
+    type: 'EMBED_RESULT',
+    embedding,
+    inferenceMs: 7,
+  };
+}
+
+function unitArray(seed: number, dim = 384): readonly number[] {
+  const out: number[] = [];
+  let sumSq = 0;
+  for (let i = 0; i < dim; i++) {
+    const x = Math.sin(seed * 7919 + i * 31);
+    out.push(x);
+    sumSq += x * x;
+  }
+  const norm = Math.sqrt(sumSq);
+  return out.map((x) => x / norm);
+}
+
+describe('embedTextForChunk (issue #129 Stage 4)', () => {
+  beforeEach(() => _resetForTesting());
+
+  it('cache hit — same text → one RPC across multiple calls', async () => {
+    const vec = unitArray(1);
+    let sendCalls = 0;
+    const deps: FakeDeps = {
+      send: async () => {
+        sendCalls++;
+        return fakeReply(vec);
+      },
+    };
+
+    const r1 = await embedTextForChunk('repeated chunk text content longer than threshold', deps);
+    const r2 = await embedTextForChunk('repeated chunk text content longer than threshold', deps);
+    const r3 = await embedTextForChunk('repeated chunk text content longer than threshold', deps);
+
+    expect(sendCalls).toBe(1);
+    expect(r1).not.toBeNull();
+    expect(r2).not.toBeNull();
+    expect(r3).not.toBeNull();
+    expect(Array.from(r1!)).toEqual(Array.from(r2!));
+    expect(Array.from(r2!)).toEqual(Array.from(r3!));
+  });
+
+  it('different text → separate RPCs', async () => {
+    let sendCalls = 0;
+    const deps: FakeDeps = {
+      send: async () => {
+        sendCalls++;
+        return fakeReply(unitArray(sendCalls));
+      },
+    };
+
+    await embedTextForChunk('chunk A content longer than threshold', deps);
+    await embedTextForChunk('chunk B content longer than threshold', deps);
+    expect(sendCalls).toBe(2);
+  });
+
+  it('single-flight: concurrent calls for same text trigger one RPC', async () => {
+    let sendCalls = 0;
+    let resolve: ((reply: EmbedResultMessage) => void) | undefined;
+    const deps: FakeDeps = {
+      send: async () => {
+        sendCalls++;
+        return new Promise<EmbedResultMessage>((r) => {
+          resolve = r;
+        });
+      },
+    };
+
+    const promises = [
+      embedTextForChunk('shared text longer than threshold', deps),
+      embedTextForChunk('shared text longer than threshold', deps),
+      embedTextForChunk('shared text longer than threshold', deps),
+    ];
+    // sha256 hashing is genuinely async; allow the inflight registration to settle.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(sendCalls).toBe(1);
+    resolve!(fakeReply(unitArray(1)));
+    const results = await Promise.all(promises);
+    expect(results).toHaveLength(3);
+    expect(sendCalls).toBe(1);
+    for (const r of results) expect(r).not.toBeNull();
+  });
+
+  it('returns null when send throws', async () => {
+    const deps: FakeDeps = {
+      send: async () => {
+        throw new Error('SW → offscreen channel disconnected');
+      },
+    };
+    const result = await embedTextForChunk('a long enough chunk to clear MIN_EMBED_CHARS', deps);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when offscreen replies with null embedding (model load failure)', async () => {
+    const deps: FakeDeps = {
+      send: async () => fakeReply(null),
+    };
+    const result = await embedTextForChunk('a long enough chunk to clear MIN_EMBED_CHARS', deps);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when reply embedding has wrong dim', async () => {
+    const deps: FakeDeps = {
+      send: async () => fakeReply(unitArray(1, 100)),
+    };
+    const result = await embedTextForChunk('a long enough chunk to clear MIN_EMBED_CHARS', deps);
+    expect(result).toBeNull();
+  });
+
+  it('skips RPC for short text', async () => {
+    let sendCalls = 0;
+    const deps: FakeDeps = {
+      send: async () => {
+        sendCalls++;
+        return fakeReply(unitArray(1));
+      },
+    };
+    const result = await embedTextForChunk('hi', deps);
+    expect(result).toBeNull();
+    expect(sendCalls).toBe(0);
+    expect(MIN_EMBED_CHARS).toBeGreaterThan(2);
+  });
+
+  it('returns Float32Array of length 384 when reply is well-formed', async () => {
+    const vec = unitArray(7);
+    const deps: FakeDeps = {
+      send: async () => fakeReply(vec),
+    };
+    const result = await embedTextForChunk('payload longer than the threshold for embedding', deps);
+    expect(result).toBeInstanceOf(Float32Array);
+    expect(result!.length).toBe(384);
+    for (let i = 0; i < 384; i++) {
+      expect(result![i]).toBeCloseTo(vec[i]!, 5);
+    }
+  });
+
+  it('caches null replies so repeat calls do not retry', async () => {
+    let sendCalls = 0;
+    const deps: FakeDeps = {
+      send: async () => {
+        sendCalls++;
+        return fakeReply(null);
+      },
+    };
+    await embedTextForChunk('a long enough chunk to clear MIN_EMBED_CHARS', deps);
+    await embedTextForChunk('a long enough chunk to clear MIN_EMBED_CHARS', deps);
+    expect(sendCalls).toBe(1);
+  });
+});

--- a/src/service-worker/embed-router.ts
+++ b/src/service-worker/embed-router.ts
@@ -1,0 +1,89 @@
+import { sha256Hex } from '@/shared/hash.js';
+import { EMBEDDING_DIM } from '@/offscreen/embedding-engine.js';
+import type { EmbedResultMessage, EmbedTextMessage } from '@/types/messages.js';
+
+/**
+ * Issue #129 Stage 4 — minimum chunk length to surface to the embedding
+ * pipeline. Shorter strings produce noisy mean-pooled vectors and burn an
+ * offscreen RPC round-trip plus a ~30–60 ms warm inference each. Mirrors
+ * `MIN_NER_CHARS` so the two SW-side routers behave consistently.
+ */
+export const MIN_EMBED_CHARS = 20;
+
+export interface EmbedRouterDeps {
+  readonly send: (text: string) => Promise<EmbedResultMessage>;
+}
+
+const cache = new Map<string, Float32Array | null>();
+const inflight = new Map<string, Promise<Float32Array | null>>();
+
+async function defaultSend(text: string): Promise<EmbedResultMessage> {
+  const message: EmbedTextMessage = { type: 'EMBED_TEXT', text };
+  const reply = (await chrome.runtime.sendMessage(message)) as EmbedResultMessage;
+  return reply;
+}
+
+const defaultDeps: EmbedRouterDeps = { send: defaultSend };
+
+function rehydrate(reply: EmbedResultMessage): Float32Array | null {
+  if (reply.embedding === null) return null;
+  if (reply.embedding.length !== EMBEDDING_DIM) return null;
+  const out = new Float32Array(EMBEDDING_DIM);
+  for (let i = 0; i < EMBEDDING_DIM; i++) {
+    const v = reply.embedding[i]!;
+    if (typeof v !== 'number' || !Number.isFinite(v)) return null;
+    out[i] = v;
+  }
+  return out;
+}
+
+/**
+ * Issue #129 Stage 4 — sha256(text)-keyed single-flight + persistent cache
+ * for the embeddings Hunter's per-chunk vector lookup. Mirrors
+ * `ner-router.ts`'s shape: cache survives for the SW lifetime so navigations
+ * that re-emit the same chunk text skip the offscreen round-trip. Total /
+ * never-throws contract: returns `null` on send rejection, short input,
+ * dim-mismatch, or `null` reply embedding so the embeddings Hunter folds
+ * into the no-signal branch (`cleanResult`) in `createEmbeddingsHunter`.
+ *
+ * `null` results are cached so a one-time init failure does not loop the
+ * orchestrator into N retries on the next N chunks. The next SW wakeup
+ * starts with a fresh cache.
+ */
+export async function embedTextForChunk(
+  text: string,
+  deps: EmbedRouterDeps = defaultDeps,
+): Promise<Float32Array | null> {
+  if (text.length < MIN_EMBED_CHARS) return null;
+
+  const key = await sha256Hex(text);
+
+  if (cache.has(key)) {
+    return cache.get(key) ?? null;
+  }
+
+  const pending = inflight.get(key);
+  if (pending !== undefined) return pending;
+
+  const promise = (async (): Promise<Float32Array | null> => {
+    try {
+      const reply = await deps.send(text);
+      const vec = rehydrate(reply);
+      cache.set(key, vec);
+      return vec;
+    } catch {
+      cache.set(key, null);
+      return null;
+    } finally {
+      inflight.delete(key);
+    }
+  })();
+
+  inflight.set(key, promise);
+  return promise;
+}
+
+export function _resetForTesting(): void {
+  cache.clear();
+  inflight.clear();
+}

--- a/src/service-worker/embeddings-bootstrap.test.ts
+++ b/src/service-worker/embeddings-bootstrap.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { EMBEDDING_DIM } from '@/offscreen/embedding-engine.js';
+import {
+  bootstrapEmbeddingsHunter,
+  embeddingsHunter,
+  _resetForTesting,
+  _setBootstrapDepsForTesting,
+} from './embeddings-bootstrap.js';
+import type { CorpusEntry } from '@/hunters/embeddings/types.js';
+
+function unitArray(seed: number): number[] {
+  const out: number[] = [];
+  let sumSq = 0;
+  for (let i = 0; i < EMBEDDING_DIM; i++) {
+    const x = Math.sin(seed * 7919 + i * 31);
+    out.push(x);
+    sumSq += x * x;
+  }
+  const norm = Math.sqrt(sumSq);
+  return out.map((x) => x / norm);
+}
+
+function corpusEntry(id: string, embedding: number[], lang = 'en'): CorpusEntry {
+  return {
+    id,
+    source: 'test-fixture',
+    text: `payload ${id}`,
+    lang,
+    techniques: ['ignore-instructions'],
+    embedding,
+  };
+}
+
+const HONEYPOT_VEC = unitArray(1);
+
+const stubGetURL = (path: string): string => `chrome-extension://stub/${path}`;
+
+beforeEach(() => {
+  _resetForTesting();
+  _setBootstrapDepsForTesting({
+    getURL: stubGetURL,
+    loadCorpus: async () => [corpusEntry('honeypot/foo', HONEYPOT_VEC)],
+    embedFn: async () => new Float32Array(HONEYPOT_VEC),
+  });
+});
+
+describe('bootstrapEmbeddingsHunter (issue #129 Stage 4)', () => {
+  it('loads the corpus from the dist URL on first call and builds a wired hunter', async () => {
+    const loadCorpus = vi.fn(async () => [corpusEntry('honeypot/foo', HONEYPOT_VEC)]);
+    _setBootstrapDepsForTesting({
+      getURL: stubGetURL,
+      loadCorpus,
+      embedFn: async () => new Float32Array(HONEYPOT_VEC),
+    });
+
+    await bootstrapEmbeddingsHunter();
+
+    expect(loadCorpus).toHaveBeenCalledTimes(1);
+    expect(loadCorpus).toHaveBeenCalledWith({
+      url: 'chrome-extension://stub/data/injection-corpus.json',
+    });
+  });
+
+  it('is idempotent — second call does not re-load the corpus', async () => {
+    const loadCorpus = vi.fn(async () => [corpusEntry('honeypot/foo', HONEYPOT_VEC)]);
+    _setBootstrapDepsForTesting({
+      getURL: stubGetURL,
+      loadCorpus,
+      embedFn: async () => new Float32Array(HONEYPOT_VEC),
+    });
+
+    await bootstrapEmbeddingsHunter();
+    await bootstrapEmbeddingsHunter();
+
+    expect(loadCorpus).toHaveBeenCalledTimes(1);
+  });
+
+  it('single-flight: concurrent calls share one load', async () => {
+    let resolveLoad: ((entries: readonly CorpusEntry[]) => void) | undefined;
+    const loadCorpus = vi.fn(
+      () =>
+        new Promise<readonly CorpusEntry[]>((r) => {
+          resolveLoad = r;
+        }),
+    );
+    _setBootstrapDepsForTesting({
+      getURL: stubGetURL,
+      loadCorpus,
+      embedFn: async () => new Float32Array(HONEYPOT_VEC),
+    });
+
+    const promises = [
+      bootstrapEmbeddingsHunter(),
+      bootstrapEmbeddingsHunter(),
+      bootstrapEmbeddingsHunter(),
+    ];
+    expect(loadCorpus).toHaveBeenCalledTimes(1);
+    resolveLoad!([corpusEntry('honeypot/foo', HONEYPOT_VEC)]);
+    await Promise.all(promises);
+    expect(loadCorpus).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to a no-op hunter when corpus load throws', async () => {
+    _setBootstrapDepsForTesting({
+      getURL: stubGetURL,
+      loadCorpus: async () => {
+        throw new Error('fetch failed');
+      },
+      embedFn: async () => new Float32Array(HONEYPOT_VEC),
+    });
+
+    const hunter = await bootstrapEmbeddingsHunter();
+    const result = await hunter.scan('payload');
+    expect(result.matched).toBe(false);
+    expect(result.errorMessage).toBeNull();
+    expect(result.score).toBe(0);
+  });
+
+  it('falls back to a no-op hunter when corpus is empty', async () => {
+    _setBootstrapDepsForTesting({
+      getURL: stubGetURL,
+      loadCorpus: async () => [],
+      embedFn: async () => new Float32Array(HONEYPOT_VEC),
+    });
+
+    const hunter = await bootstrapEmbeddingsHunter();
+    const result = await hunter.scan('payload');
+    expect(result.matched).toBe(false);
+    expect(result.errorMessage).toBeNull();
+  });
+});
+
+describe('embeddingsHunter (proxy)', () => {
+  it('exposes name "embeddings" so the orchestrator can attribute results', () => {
+    expect(embeddingsHunter.name).toBe('embeddings');
+  });
+
+  it('returns clean while the bootstrap is still pending', async () => {
+    let resolveLoad: ((entries: readonly CorpusEntry[]) => void) | undefined;
+    _setBootstrapDepsForTesting({
+      getURL: stubGetURL,
+      loadCorpus: () =>
+        new Promise<readonly CorpusEntry[]>((r) => {
+          resolveLoad = r;
+        }),
+      embedFn: async () => new Float32Array(HONEYPOT_VEC),
+    });
+
+    // Trigger bootstrap but do not await.
+    void bootstrapEmbeddingsHunter();
+    const result = await embeddingsHunter.scan('payload longer than threshold');
+    expect(result.matched).toBe(false);
+    expect(result.errorMessage).toBeNull();
+
+    // Cleanup: settle the pending load so vitest does not warn about hanging promises.
+    resolveLoad!([corpusEntry('honeypot/foo', HONEYPOT_VEC)]);
+  });
+
+  it('delegates to the wired hunter once bootstrap resolves and embedFn matches the corpus', async () => {
+    _setBootstrapDepsForTesting({
+      getURL: stubGetURL,
+      loadCorpus: async () => [corpusEntry('honeypot/foo', HONEYPOT_VEC)],
+      embedFn: async () => new Float32Array(HONEYPOT_VEC),
+    });
+
+    await bootstrapEmbeddingsHunter();
+    const result = await embeddingsHunter.scan('ignore previous instructions');
+    expect(result.matched).toBe(true);
+    expect(result.flags).toContain('embeddings:honeypot/foo');
+  });
+});

--- a/src/service-worker/embeddings-bootstrap.ts
+++ b/src/service-worker/embeddings-bootstrap.ts
@@ -1,0 +1,125 @@
+import type { Hunter, HunterResult } from '@/hunters/base-hunter.js';
+import { cleanResult } from '@/hunters/base-hunter.js';
+import {
+  createEmbeddingsHunter,
+  embeddingsHunter as embeddingsHunterNoOp,
+} from '@/hunters/embeddings/index.js';
+import { loadInjectionCorpus } from '@/hunters/embeddings/corpus-loader.js';
+import { createVectorIndex } from '@/hunters/embeddings/vector-index.js';
+import type { ChunkEmbedFn, CorpusEntry } from '@/hunters/embeddings/types.js';
+import { embedTextForChunk } from './embed-router.js';
+import { createLogger } from '@/shared/logger.js';
+
+const log = createLogger('EmbeddingsBootstrap');
+
+/**
+ * Issue #129 Stage 4 — SW-side bootstrap that wires the embeddings Hunter.
+ *
+ * Stages 1–3 shipped the corpus + the offscreen embedding pipeline + the
+ * vector-index module + a no-op Hunter default. This bootstrap is the
+ * connective tissue that loads the populated corpus on SW startup, builds
+ * the in-memory cosine-similarity index, and creates the live Hunter that
+ * the orchestrator's `runHunters([...])` call actually invokes.
+ *
+ * Failure modes (any of these → fall back to the Stage 3 no-op so the
+ * Phase 2 byte-locked baseline (162 rows in `inbrowser-results.json`) still
+ * sees zero changed verdicts):
+ * - `chrome.runtime.getURL` unavailable (test env) → no-op
+ * - Corpus fetch / parse / verify fails → empty corpus → empty index →
+ *   `createEmbeddingsHunter` already short-circuits to clean
+ * - Init throws unexpectedly → caught here, bootstrap returns no-op
+ *
+ * The exported `embeddingsHunter` is a synchronous proxy: the orchestrator
+ * imports it once at module load, but its `scan()` waits on the bootstrap
+ * promise and delegates. Until the bootstrap resolves the proxy returns a
+ * clean result (no-op). This preserves the orchestrator's existing import
+ * shape and the Phase 2 baseline contract during the cold-load window.
+ */
+
+interface BootstrapDeps {
+  readonly getURL: (path: string) => string;
+  readonly loadCorpus: (opts: { url: string }) => Promise<readonly CorpusEntry[]>;
+  readonly embedFn: ChunkEmbedFn;
+}
+
+const CORPUS_PATH = 'data/injection-corpus.json';
+
+let resolvedHunter: Hunter | null = null;
+let initPromise: Promise<Hunter> | null = null;
+let testDeps: BootstrapDeps | null = null;
+
+function getDefaultDeps(): BootstrapDeps {
+  return {
+    getURL: (path) => chrome.runtime.getURL(path),
+    loadCorpus: loadInjectionCorpus,
+    embedFn: embedTextForChunk,
+  };
+}
+
+async function doBootstrap(deps: BootstrapDeps): Promise<Hunter> {
+  try {
+    const url = deps.getURL(CORPUS_PATH);
+    const corpus = await deps.loadCorpus({ url });
+    if (corpus.length === 0) {
+      log.warn('Embeddings corpus loaded empty; staying as no-op');
+      return embeddingsHunterNoOp;
+    }
+    const index = createVectorIndex(corpus);
+    if (index.size === 0) {
+      log.warn('Vector index built with zero indexable rows; staying as no-op');
+      return embeddingsHunterNoOp;
+    }
+    log.info(`Embeddings hunter wired with ${index.size} corpus rows`);
+    return createEmbeddingsHunter({ embedFn: deps.embedFn, index });
+  } catch (err) {
+    log.warn('Embeddings bootstrap failed; staying as no-op', err);
+    return embeddingsHunterNoOp;
+  }
+}
+
+/**
+ * Trigger the corpus load + index build. Idempotent + single-flight: every
+ * caller after the first joins the same promise. On failure we fall back to
+ * the Stage 3 no-op hunter and remember that result — no retry loop in the
+ * orchestrator hot path. The next SW wakeup gets a fresh state.
+ */
+export function bootstrapEmbeddingsHunter(): Promise<Hunter> {
+  if (resolvedHunter !== null) return Promise.resolve(resolvedHunter);
+  if (initPromise !== null) return initPromise;
+
+  const deps = testDeps ?? getDefaultDeps();
+  initPromise = doBootstrap(deps).then((hunter) => {
+    resolvedHunter = hunter;
+    return hunter;
+  });
+  return initPromise;
+}
+
+/**
+ * Synchronous proxy used by the orchestrator. Until `bootstrapEmbeddingsHunter`
+ * resolves, `scan()` returns a clean (no-op) result so the Phase 2 byte-locked
+ * baseline stays byte-identical during cold-load. After resolution every call
+ * delegates to the wired hunter (or the no-op fallback if init failed).
+ */
+export const embeddingsHunter: Hunter = {
+  name: 'embeddings',
+  async scan(chunk: string): Promise<HunterResult> {
+    if (resolvedHunter !== null) return resolvedHunter.scan(chunk);
+    if (initPromise === null) return cleanResult('embeddings');
+    // Bootstrap is in flight. Returning clean here (rather than awaiting
+    // the init) keeps the orchestrator's chunk loop responsive during the
+    // cold-load window. The Phase 2 baseline contract permits this — the
+    // Stage 3 no-op is the fallback.
+    return cleanResult('embeddings');
+  },
+};
+
+export function _resetForTesting(): void {
+  resolvedHunter = null;
+  initPromise = null;
+  testDeps = null;
+}
+
+export function _setBootstrapDepsForTesting(deps: BootstrapDeps | null): void {
+  testDeps = deps;
+}

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -16,6 +16,7 @@ import { verifyStamp } from './stamp.js';
 import { dispatchVerdictMessages, handleRescanWithMitigation, handleRescanPage } from './dispatch.js';
 import { scanUrl } from './url-scanner.js';
 import { loadRegistryOnce } from '@/registry/lookup.js';
+import { bootstrapEmbeddingsHunter } from './embeddings-bootstrap.js';
 
 const log = createLogger('ServiceWorker');
 
@@ -43,11 +44,25 @@ function bootstrapRegistry(): void {
   });
 }
 
+// Issue #129 Stage 4 — bootstrap the embeddings Hunter on every SW wakeup.
+// Loads the populated injection corpus from `dist/data/injection-corpus.json`,
+// builds the in-memory cosine-similarity index, and wires the offscreen
+// EMBED_TEXT bridge as the chunk embed function. bootstrapEmbeddingsHunter
+// is idempotent + single-flight; any failure path (corpus missing / parse
+// error / unexpected throw) falls back to the Stage 3 no-op hunter so the
+// Phase 2 byte-locked baseline is preserved.
+function bootstrapEmbeddings(): void {
+  bootstrapEmbeddingsHunter().catch((err) => {
+    log.warn('Embeddings bootstrap failed; staying as no-op for SW lifetime', err);
+  });
+}
+
 chrome.runtime.onInstalled.addListener(() => {
   log.info('HoneyLLM installed');
   startKeepalive();
   bootstrapInstallSecret();
   bootstrapRegistry();
+  bootstrapEmbeddings();
 });
 
 chrome.runtime.onStartup.addListener(() => {
@@ -55,6 +70,7 @@ chrome.runtime.onStartup.addListener(() => {
   startKeepalive();
   bootstrapInstallSecret();
   bootstrapRegistry();
+  bootstrapEmbeddings();
 });
 
 // Phase 4 Stage 4D.4 — per-tab icon state lifecycle hooks.

--- a/src/service-worker/orchestrator.ts
+++ b/src/service-worker/orchestrator.ts
@@ -16,7 +16,7 @@ import { detectLanguage } from '@/hunters/hawk/language-router.js';
 import { runHunters } from '@/hunters/hunt-runner.js';
 import { spiderHunter } from '@/hunters/spider/index.js';
 import { hawkHunter } from '@/hunters/hawk/index.js';
-import { embeddingsHunter } from '@/hunters/embeddings/index.js';
+import { embeddingsHunter } from './embeddings-bootstrap.js';
 import { createLogger } from '@/shared/logger.js';
 import { ensureOffscreenDocument } from './offscreen-manager.js';
 import { connectOffscreenPort } from './keepalive.js';
@@ -468,11 +468,17 @@ export async function analyzeSnapshot(
       // Issue #112 (N1) — Hunters first; k=2 router gates the LLM tier.
       // BENIGN chunks skip probes entirely. Hunter aggregateError → UNCERTAIN
       // (fail-open) so a hunter crash never silently suppresses detection.
-      // Issue #129 Stage 3 — register embeddingsHunter as a 3rd Hunter
-      // sibling to Spider/Hawk. Stage 3 ships it as a no-op (deps null) so
-      // the Phase 2 byte-locked baseline (162 rows in inbrowser-results.json)
-      // sees zero changed verdicts. Stage 4 will swap in a wired hunter
-      // once the SW↔offscreen embed-text bridge + corpus loader are live.
+      // Issue #129 Stage 4 — embeddingsHunter is the SW-side bootstrap proxy
+      // (`embeddings-bootstrap.ts`). On first SW wakeup it loads the
+      // populated corpus from `dist/data/injection-corpus.json`, builds the
+      // in-memory cosine-similarity index, and wires the `EMBED_TEXT`
+      // offscreen bridge as the chunk embed function. Until the bootstrap
+      // resolves the proxy returns a clean (no-op) result so the Phase 2
+      // byte-locked baseline (162 rows in inbrowser-results.json) stays
+      // byte-identical during the cold-load window. Bootstrap failure
+      // (missing corpus / verify error / fetch failure) falls back to the
+      // Stage 3 no-op hunter — the baseline contract is preserved on every
+      // failure path.
       const huntReport = await runHunters(
         [spiderHunter, hawkHunter, embeddingsHunter],
         chunk,

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -49,6 +49,16 @@ export type MessageType =
   // sha256(text) so a repeated chunk doesn't re-cross the boundary.
   | 'RUN_NER'
   | 'NER_RESULT'
+  // Issue #129 Stage 4 — sentence-embedding RPC. SW (orchestrator chunk
+  // loop, via `service-worker/embed-router.ts`) → offscreen request with
+  // chunk text; offscreen replies with a 384-dim L2-normalised embedding
+  // produced by `intfloat/multilingual-e5-small`. The router caches by
+  // sha256(text) so repeated chunk text never re-crosses the boundary.
+  // Embedding is serialised as `number[]` (chrome.runtime messages are
+  // JSON-cloneable; Float32Array does not survive the bridge); the SW
+  // router rehydrates to Float32Array on the receive side.
+  | 'EMBED_TEXT'
+  | 'EMBED_RESULT'
   // Issue #126 (N7a) — chat-portal observer dispatches RESPONSE_CAPTURED
   // when an assistant response finishes streaming. Handled by the SW's
   // response-analyzer; runs the existing 3-probe stack on the captured
@@ -298,6 +308,24 @@ export interface NerResultMessage extends BaseMessage {
   readonly inferenceMs: number;
 }
 
+// Issue #129 Stage 4 — embedding RPC. `mode` selects the e5 instruction
+// prefix: `passage` for corpus/document text (default; chunks the
+// orchestrator routes here), `query` for retrieval queries against the
+// corpus index. `embedding` on the reply is `number[]` of length 384
+// (`EMBEDDING_DIM`) or `null` on init/inference failure — the SW router
+// wraps null into the embeddings hunter's "no signal" path.
+export interface EmbedTextMessage extends BaseMessage {
+  readonly type: 'EMBED_TEXT';
+  readonly text: string;
+  readonly mode?: 'passage' | 'query';
+}
+
+export interface EmbedResultMessage extends BaseMessage {
+  readonly type: 'EMBED_RESULT';
+  readonly embedding: readonly number[] | null;
+  readonly inferenceMs: number;
+}
+
 // Issue #126 (N7a) — content-script dispatches RESPONSE_CAPTURED to the
 // SW when a chat-portal assistant response finishes streaming. The SW
 // response-analyzer reads `tabId` from `sender.tab?.id ?? message.tabId`
@@ -405,6 +433,8 @@ export type HoneyLLMMessage =
   | LanguageResultMessage
   | RunNerMessage
   | NerResultMessage
+  | EmbedTextMessage
+  | EmbedResultMessage
   | ResponseCapturedMessage
   | InterceptScanRequestMessage
   | InterceptVerdictMessage


### PR DESCRIPTION
## Summary

Item 8 Stage 4 — wires the Stage 3 embeddings module end-to-end. The orchestrator's third Hunter is now backed by a real embedding pipeline. Until SW startup finishes loading the corpus the proxy returns clean (no-op), preserving the Phase 2 byte-locked baseline contract during the cold-load window.

- `EMBED_TEXT` / `EMBED_RESULT` SW↔offscreen RPC (`src/types/messages.ts` + `src/offscreen/index.ts` handler delegating to the Stage 2 `embedText`)
- `src/service-worker/embed-router.ts` — sha256(text)-keyed single-flight cache mirroring `ner-router.ts`; total / never-throws; serialises Float32Array as `number[]` and rehydrates on receive
- `src/service-worker/embeddings-bootstrap.ts` — idempotent SW startup hook that fetches `dist/data/injection-corpus.json`, builds the vector index, and creates the wired Hunter; synchronous proxy keeps the orchestrator import shape unchanged
- `bootstrapEmbeddings()` invoked from `chrome.runtime.onStartup` + `onInstalled` alongside `bootstrapInstallSecret` / `bootstrapRegistry`
- Embedding model pre-warm at offscreen-doc creation alongside the NER pre-warm

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 1350 → 1367 (+17: 9 embed-router TDD + 8 embeddings-bootstrap TDD)
- [x] `npm run build` — clean; `dist/data/injection-corpus.json` copied via existing BUILD_ASSETS; bundle stays 7.3 MB
- [x] Phase 2 byte-locked baseline (162 rows in `inbrowser-results.json`) byte-identical
- [x] `npm audit` — 0 vulnerabilities
- [x] AIza-≥20 secret grep — clean

Refs #129. Stage 5 (popup-render) + Stage 6 (polish) remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)