### PR TITLE
feat(embeddings-#129): Stage 5 — popup-render of embeddings-Hunter signal

### DIFF
--- a/src/hunters/embeddings/finding.test.ts
+++ b/src/hunters/embeddings/finding.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+
+import type { HunterResult } from '../base-hunter.js';
+import { buildEmbeddingsFinding } from './finding.js';
+
+function makeMatchResult(overrides: Partial<HunterResult> = {}): HunterResult {
+  return {
+    hunterName: 'embeddings',
+    matched: true,
+    flags: ['embeddings:injection-0042', 'lang:es', 'technique:role-play'],
+    score: 40,
+    confidence: 0.91,
+    features: [
+      {
+        name: 'cosine_similarity',
+        weight: 0.91,
+        activations: [
+          'injection-0042@0.910',
+          'injection-0017@0.880',
+          'injection-0099@0.860',
+        ],
+      },
+    ],
+    errorMessage: null,
+    ...overrides,
+  };
+}
+
+describe('buildEmbeddingsFinding', () => {
+  it('flattens flags into a structured finding for a matched embeddings result', () => {
+    const finding = buildEmbeddingsFinding(2, makeMatchResult());
+    expect(finding).not.toBeNull();
+    expect(finding!.chunkIndex).toBe(2);
+    expect(finding!.topId).toBe('injection-0042');
+    expect(finding!.topScore).toBe(0.91);
+    expect(finding!.topLang).toBe('es');
+    expect(finding!.topTechniques).toEqual(['role-play']);
+    expect(finding!.activations).toEqual([
+      'injection-0042@0.910',
+      'injection-0017@0.880',
+      'injection-0099@0.860',
+    ]);
+  });
+
+  it('preserves multiple techniques on the top match', () => {
+    const finding = buildEmbeddingsFinding(
+      0,
+      makeMatchResult({
+        flags: [
+          'embeddings:injection-0042',
+          'lang:zh-CN',
+          'technique:role-play',
+          'technique:system-override',
+        ],
+      }),
+    );
+    expect(finding!.topTechniques).toEqual(['role-play', 'system-override']);
+    expect(finding!.topLang).toBe('zh-CN');
+  });
+
+  it('returns null for a non-embeddings hunter result', () => {
+    const finding = buildEmbeddingsFinding(
+      0,
+      makeMatchResult({ hunterName: 'spider' }),
+    );
+    expect(finding).toBeNull();
+  });
+
+  it('returns null for an unmatched embeddings result', () => {
+    const finding = buildEmbeddingsFinding(
+      0,
+      makeMatchResult({ matched: false, flags: [], features: [] }),
+    );
+    expect(finding).toBeNull();
+  });
+
+  it('returns null when the cosine_similarity feature is missing', () => {
+    const finding = buildEmbeddingsFinding(
+      0,
+      makeMatchResult({
+        features: [{ name: 'other', weight: 0.5, activations: [] }],
+      }),
+    );
+    expect(finding).toBeNull();
+  });
+
+  it('falls back to "unknown" when no lang flag is present', () => {
+    const finding = buildEmbeddingsFinding(
+      1,
+      makeMatchResult({
+        flags: ['embeddings:injection-0042', 'technique:role-play'],
+      }),
+    );
+    expect(finding!.topLang).toBe('unknown');
+    expect(finding!.topId).toBe('injection-0042');
+  });
+
+  it('emits empty topTechniques when no technique flags are present', () => {
+    const finding = buildEmbeddingsFinding(
+      1,
+      makeMatchResult({ flags: ['embeddings:injection-0042', 'lang:en'] }),
+    );
+    expect(finding!.topTechniques).toEqual([]);
+  });
+
+  it('falls back to empty topId when the embeddings flag is missing', () => {
+    const finding = buildEmbeddingsFinding(
+      0,
+      makeMatchResult({ flags: ['lang:en', 'technique:role-play'] }),
+    );
+    expect(finding!.topId).toBe('');
+  });
+
+  it('keeps activations array byte-identical (does not re-sort)', () => {
+    const activations = ['a@0.9', 'b@0.95', 'c@0.85'];
+    const finding = buildEmbeddingsFinding(
+      0,
+      makeMatchResult({
+        features: [
+          { name: 'cosine_similarity', weight: 0.9, activations },
+        ],
+      }),
+    );
+    expect(finding!.activations).toEqual(activations);
+  });
+});

--- a/src/hunters/embeddings/finding.ts
+++ b/src/hunters/embeddings/finding.ts
@@ -1,0 +1,44 @@
+import type { HunterResult } from '../base-hunter.js';
+import type { EmbeddingsFinding } from './types.js';
+
+const FLAG_PREFIX_ID = 'embeddings:';
+const FLAG_PREFIX_LANG = 'lang:';
+const FLAG_PREFIX_TECHNIQUE = 'technique:';
+const COSINE_FEATURE_NAME = 'cosine_similarity';
+
+/**
+ * Issue #129 Stage 5 — project a single chunk's embeddings-Hunter
+ * `HunterResult` into the persisted `EmbeddingsFinding` shape consumed by
+ * the popup explainability accordion. Returns `null` when the result
+ * isn't an embeddings match (wrong hunter / unmatched / missing feature)
+ * so the orchestrator can `.filter(Boolean)` without separate gating.
+ */
+export function buildEmbeddingsFinding(
+  chunkIndex: number,
+  result: HunterResult,
+): EmbeddingsFinding | null {
+  if (result.hunterName !== 'embeddings' || !result.matched) return null;
+
+  const feature = result.features.find((f) => f.name === COSINE_FEATURE_NAME);
+  if (feature === undefined) return null;
+
+  let topId = '';
+  let topLang = 'unknown';
+  const topTechniques: string[] = [];
+  for (const flag of result.flags) {
+    if (flag.startsWith(FLAG_PREFIX_ID)) topId = flag.slice(FLAG_PREFIX_ID.length);
+    else if (flag.startsWith(FLAG_PREFIX_LANG)) topLang = flag.slice(FLAG_PREFIX_LANG.length);
+    else if (flag.startsWith(FLAG_PREFIX_TECHNIQUE)) {
+      topTechniques.push(flag.slice(FLAG_PREFIX_TECHNIQUE.length));
+    }
+  }
+
+  return {
+    chunkIndex,
+    topId,
+    topScore: feature.weight,
+    topLang,
+    topTechniques,
+    activations: feature.activations,
+  };
+}

--- a/src/hunters/embeddings/types.ts
+++ b/src/hunters/embeddings/types.ts
@@ -29,3 +29,33 @@ export interface VectorIndexMatch {
 }
 
 export type ChunkEmbedFn = (text: string) => Promise<Float32Array | null>;
+
+/**
+ * Issue #129 Stage 5 — popup-render-friendly summary of one chunk's
+ * embeddings-Hunter signal. Produced from a single `HunterResult` whose
+ * `hunterName === 'embeddings'` and `matched === true`; flattens the top
+ * match's flag breakdown plus the raw `<id>@<score>` activations array
+ * for the explainability surface.
+ *
+ * The hunter already carries everything in `flags` + `features[0]` (see
+ * `src/hunters/embeddings/index.ts:78-84`); this shape is the
+ * persisted projection so the popup never has to re-parse flag prefixes.
+ */
+export interface EmbeddingsFinding {
+  /** Index of the chunk in `chunks` (matches `ChunkAnalysis.index`). */
+  readonly chunkIndex: number;
+  /** Top-1 corpus entry id (e.g. `injection-0042`). */
+  readonly topId: string;
+  /** Top-1 cosine similarity in [threshold, 1]. */
+  readonly topScore: number;
+  /** Top-1 corpus entry language tag (e.g. `en`, `es`, `zh-CN`). */
+  readonly topLang: string;
+  /** Top-1 entry's techniques (e.g. `role-play`, `system-override`). */
+  readonly topTechniques: readonly string[];
+  /**
+   * Verbatim `<id>@<score>` strings from `features[0].activations` —
+   * top-K matches in score-descending order. Capped server-side by the
+   * vector index's `EMBEDDING_TOP_K` (5).
+   */
+  readonly activations: readonly string[];
+}

--- a/src/policy/engine.ts
+++ b/src/policy/engine.ts
@@ -74,6 +74,7 @@ export function evaluatePolicy(
       responseVerdict: null,
       // Issue #131 — same; the SW thinking-analyzer writes the slot.
       thinkingVerdict: null,
+      embeddingsFindings: null,
     };
   }
 
@@ -104,5 +105,9 @@ export function evaluatePolicy(
     responseVerdict: null,
     // Issue #131 — same for the thinking verdict slot.
     thinkingVerdict: null,
+    // Issue #129 Stage 5 — orchestrator overwrites via spread when chunks
+    // produced findings; null here matches the perChunkAnalysis default for
+    // engine-only callers.
+    embeddingsFindings: null,
   };
 }

--- a/src/policy/storage.test.ts
+++ b/src/policy/storage.test.ts
@@ -97,6 +97,7 @@ function buildVerdict(overrides: Partial<SecurityVerdict> = {}): SecurityVerdict
     entitySummary: null,
     responseVerdict: null,
     thinkingVerdict: null,
+    embeddingsFindings: null,
     ...overrides,
   };
 }
@@ -385,5 +386,92 @@ describe('storage — thinkingVerdict (issue #131)', () => {
       const merged = await mergeWithStoredVerdict(next);
       expect(merged.thinkingVerdict).toEqual(THINKING_VERDICT);
     });
+  });
+});
+
+describe('storage — embeddingsFindings migration (issue #129 Stage 5)', () => {
+  beforeEach(() => vi.unstubAllGlobals());
+  afterEach(() => vi.unstubAllGlobals());
+
+  const FINDINGS = [
+    {
+      chunkIndex: 1,
+      topId: 'injection-0042',
+      topScore: 0.91,
+      topLang: 'es',
+      topTechniques: ['role-play'],
+      activations: ['injection-0042@0.910', 'injection-0017@0.880'],
+    },
+  ] as const;
+
+  it('round-trips a verdict with embeddingsFindings populated', async () => {
+    stubChrome();
+    await persistVerdict(buildVerdict({ embeddingsFindings: FINDINGS }));
+    const restored = await getVerdict(URL);
+    expect(restored?.embeddingsFindings).toEqual(FINDINGS);
+  });
+
+  it('coalesces undefined embeddingsFindings on legacy records to null', async () => {
+    stubChrome({
+      [ORIGIN_KEY]: {
+        status: 'CLEAN',
+        confidence: 0.9,
+        totalScore: 5,
+        timestamp: 1700000000000,
+        url: URL,
+        flags: [],
+        behavioralFlags: {
+          roleDrift: false,
+          exfiltrationIntent: false,
+          instructionFollowing: false,
+          hiddenContentAwareness: false,
+        },
+        analysisError: null,
+        canaryId: null,
+        stamp: null,
+        perChunkAnalysis: null,
+        responseVerdict: null,
+        thinkingVerdict: null,
+      },
+    });
+    const restored = await getVerdict(URL);
+    expect(restored?.embeddingsFindings).toBeNull();
+  });
+
+  it('preserves null embeddingsFindings when persisted as null', async () => {
+    stubChrome({
+      [ORIGIN_KEY]: {
+        status: 'CLEAN',
+        confidence: 0.9,
+        totalScore: 5,
+        timestamp: 1700000000000,
+        url: URL,
+        flags: [],
+        behavioralFlags: {
+          roleDrift: false,
+          exfiltrationIntent: false,
+          instructionFollowing: false,
+          hiddenContentAwareness: false,
+        },
+        analysisError: null,
+        canaryId: null,
+        stamp: null,
+        perChunkAnalysis: null,
+        responseVerdict: null,
+        thinkingVerdict: null,
+        embeddingsFindings: null,
+      },
+    });
+    const restored = await getVerdict(URL);
+    expect(restored?.embeddingsFindings).toBeNull();
+  });
+
+  it('persists embeddingsFindings verbatim on persistVerdict', async () => {
+    const { readStore } = stubChrome();
+    await persistVerdict(buildVerdict({ embeddingsFindings: FINDINGS }));
+    const stored = readStore()[ORIGIN_KEY] as {
+      embeddingsFindings: typeof FINDINGS;
+    };
+    expect(stored.embeddingsFindings).toEqual(FINDINGS);
   });
 });

--- a/src/policy/storage.ts
+++ b/src/policy/storage.ts
@@ -66,6 +66,12 @@ export async function persistVerdict(verdict: SecurityVerdict): Promise<void> {
       // thinking block was observed. Page, response, and thinking verdicts
       // all coexist on the same per-origin record.
       thinkingVerdict: verdict.thinkingVerdict,
+      // Issue #129 Stage 5 — per-chunk embeddings-Hunter findings. Null on
+      // every chunk-loop path that didn't produce a match (the steady
+      // state when the corpus index is no-op or every cosine sat below
+      // threshold). Pre-Stage-5 records come back undefined and are
+      // coalesced to null on read.
+      embeddingsFindings: verdict.embeddingsFindings,
     },
   });
 
@@ -164,17 +170,20 @@ export async function getVerdict(url: string): Promise<SecurityVerdict | null> {
   // re-saved with a null field round-trips without re-coalescing.
   // Issue #131 — same migration for thinkingVerdict: pre-#131 verdicts
   // come back with `thinkingVerdict === undefined`.
+  // Issue #129 Stage 5 — same for embeddingsFindings.
   const restored = stored as SecurityVerdict & {
     stamp?: unknown;
     perChunkAnalysis?: unknown;
     responseVerdict?: unknown;
     thinkingVerdict?: unknown;
+    embeddingsFindings?: unknown;
   };
   if (
     restored.stamp === undefined ||
     restored.perChunkAnalysis === undefined ||
     restored.responseVerdict === undefined ||
-    restored.thinkingVerdict === undefined
+    restored.thinkingVerdict === undefined ||
+    restored.embeddingsFindings === undefined
   ) {
     return {
       ...(restored as SecurityVerdict),
@@ -188,6 +197,9 @@ export async function getVerdict(url: string): Promise<SecurityVerdict | null> {
       thinkingVerdict: restored.thinkingVerdict === undefined
         ? null
         : (restored.thinkingVerdict as SecurityVerdict['thinkingVerdict']),
+      embeddingsFindings: restored.embeddingsFindings === undefined
+        ? null
+        : (restored.embeddingsFindings as SecurityVerdict['embeddingsFindings']),
     };
   }
   return restored as SecurityVerdict;

--- a/src/popup/embeddings-findings.test.ts
+++ b/src/popup/embeddings-findings.test.ts
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+
+import { renderEmbeddingsFindings } from './embeddings-findings';
+import type { EmbeddingsFinding } from '@/hunters/embeddings/types';
+
+function makeBody(): HTMLElement {
+  const div = document.createElement('div');
+  div.id = 'embeddings-findings-body';
+  div.className = 'placeholder';
+  div.textContent = 'Loading…';
+  return div;
+}
+
+const F1: EmbeddingsFinding = {
+  chunkIndex: 0,
+  topId: 'injection-0042',
+  topScore: 0.91,
+  topLang: 'es',
+  topTechniques: ['role-play'],
+  activations: ['injection-0042@0.910', 'injection-0017@0.880'],
+};
+
+const F2: EmbeddingsFinding = {
+  chunkIndex: 3,
+  topId: 'injection-0099',
+  topScore: 0.87,
+  topLang: 'zh-CN',
+  topTechniques: ['system-override', 'role-play'],
+  activations: ['injection-0099@0.870'],
+};
+
+describe('renderEmbeddingsFindings', () => {
+  it('renders one row per finding with chunk index, top id, score and lang', () => {
+    const body = makeBody();
+    renderEmbeddingsFindings(body, [F1, F2]);
+    const rows = body.querySelectorAll('.embeddings-finding-row');
+    expect(rows).toHaveLength(2);
+    expect(rows[0].textContent).toContain('chunk 0');
+    expect(rows[0].textContent).toContain('injection-0042');
+    expect(rows[0].textContent).toContain('0.910');
+    expect(rows[0].textContent).toContain('es');
+    expect(rows[1].textContent).toContain('chunk 3');
+    expect(rows[1].textContent).toContain('injection-0099');
+    expect(rows[1].textContent).toContain('0.870');
+    expect(rows[1].textContent).toContain('zh-CN');
+    expect(body.className).toBe('');
+  });
+
+  it('renders technique chips for the top match', () => {
+    const body = makeBody();
+    renderEmbeddingsFindings(body, [F2]);
+    const chips = body.querySelectorAll('.embeddings-technique-chip');
+    expect(chips).toHaveLength(2);
+    const labels = Array.from(chips).map((c) => c.textContent);
+    expect(labels).toContain('system-override');
+    expect(labels).toContain('role-play');
+  });
+
+  it('renders the full activations list under each finding', () => {
+    const body = makeBody();
+    renderEmbeddingsFindings(body, [F1]);
+    const items = body.querySelectorAll('.embeddings-activation-item');
+    expect(items).toHaveLength(2);
+    expect(items[0].textContent).toBe('injection-0042@0.910');
+    expect(items[1].textContent).toBe('injection-0017@0.880');
+  });
+
+  it('shows the no-match placeholder for null findings', () => {
+    const body = makeBody();
+    renderEmbeddingsFindings(body, null);
+    expect(body.className).toBe('placeholder');
+    expect(body.textContent).toContain('No embeddings matches');
+    expect(body.querySelector('.embeddings-finding-row')).toBeNull();
+  });
+
+  it('shows the no-match placeholder for an empty findings array', () => {
+    const body = makeBody();
+    renderEmbeddingsFindings(body, []);
+    expect(body.className).toBe('placeholder');
+    expect(body.textContent).toContain('No embeddings matches');
+  });
+
+  it('shows the legacy placeholder when findings is undefined', () => {
+    const body = makeBody();
+    renderEmbeddingsFindings(body, undefined);
+    expect(body.className).toBe('placeholder');
+    expect(body.textContent).toContain('No embeddings data yet');
+  });
+
+  it('replaces previous render on re-call (idempotency)', () => {
+    const body = makeBody();
+    renderEmbeddingsFindings(body, [F1, F2]);
+    expect(body.querySelectorAll('.embeddings-finding-row')).toHaveLength(2);
+    renderEmbeddingsFindings(body, [F1]);
+    expect(body.querySelectorAll('.embeddings-finding-row')).toHaveLength(1);
+    renderEmbeddingsFindings(body, null);
+    expect(body.querySelectorAll('.embeddings-finding-row')).toHaveLength(0);
+  });
+
+  it('formats the top score to three decimal places even when input has fewer', () => {
+    const body = makeBody();
+    renderEmbeddingsFindings(body, [{ ...F1, topScore: 0.9 }]);
+    const row = body.querySelector('.embeddings-finding-row')!;
+    expect(row.textContent).toContain('0.900');
+  });
+
+  it('omits the technique chip row entirely when topTechniques is empty', () => {
+    const body = makeBody();
+    renderEmbeddingsFindings(body, [{ ...F1, topTechniques: [] }]);
+    expect(body.querySelector('.embeddings-technique-chip')).toBeNull();
+  });
+});

--- a/src/popup/embeddings-findings.ts
+++ b/src/popup/embeddings-findings.ts
@@ -1,0 +1,95 @@
+import type { EmbeddingsFinding } from '@/hunters/embeddings/types.js';
+
+const PLACEHOLDER_LEGACY = 'No embeddings data yet.';
+const PLACEHOLDER_EMPTY = 'No embeddings matches on this page.';
+
+function formatScore(score: number): string {
+  return score.toFixed(3);
+}
+
+function buildFindingRow(finding: EmbeddingsFinding): HTMLElement {
+  const row = document.createElement('div');
+  row.className = 'embeddings-finding-row';
+
+  const head = document.createElement('div');
+  head.className = 'embeddings-finding-head';
+
+  const left = document.createElement('span');
+  left.className = 'embeddings-finding-id';
+  left.textContent = `chunk ${String(finding.chunkIndex)} · ${finding.topId}`;
+
+  const right = document.createElement('span');
+  right.className = 'embeddings-finding-score';
+  right.textContent = `${formatScore(finding.topScore)} · ${finding.topLang}`;
+
+  head.append(left, right);
+  row.appendChild(head);
+
+  if (finding.topTechniques.length > 0) {
+    const chips = document.createElement('div');
+    chips.className = 'embeddings-technique-row';
+    for (const technique of finding.topTechniques) {
+      const chip = document.createElement('span');
+      chip.className = 'embeddings-technique-chip';
+      chip.textContent = technique;
+      chips.appendChild(chip);
+    }
+    row.appendChild(chips);
+  }
+
+  if (finding.activations.length > 0) {
+    const list = document.createElement('ul');
+    list.className = 'embeddings-activations';
+    for (const activation of finding.activations) {
+      const li = document.createElement('li');
+      li.className = 'embeddings-activation-item';
+      li.textContent = activation;
+      list.appendChild(li);
+    }
+    row.appendChild(list);
+  }
+
+  return row;
+}
+
+/**
+ * Issue #129 Stage 5 — render the embeddings-Hunter explainability list:
+ * one row per chunk that produced a corpus match (top-K cosine matches
+ * are surfaced as `<id>@<score>` items beneath each row's chunk header).
+ *
+ * - `undefined`  → legacy verdict (pre-Stage-5); shows the "no data yet"
+ *   placeholder
+ * - `null` or `[]` → scan ran but no chunk matched the corpus; shows the
+ *   "no matches" placeholder. Both states are common: the index may be
+ *   empty (cold-load window) or every cosine sat below threshold.
+ * - non-empty array → renders one .embeddings-finding-row per finding,
+ *   in the order produced by the orchestrator (chunk-index ascending).
+ *
+ * Pure DOM construction; idempotent re-render via `replaceChildren`.
+ * No network or storage reads.
+ */
+export function renderEmbeddingsFindings(
+  body: HTMLElement,
+  findings: readonly EmbeddingsFinding[] | null | undefined,
+): void {
+  if (findings === undefined) {
+    body.replaceChildren();
+    body.className = 'placeholder';
+    body.textContent = PLACEHOLDER_LEGACY;
+    return;
+  }
+  if (findings === null || findings.length === 0) {
+    body.replaceChildren();
+    body.className = 'placeholder';
+    body.textContent = PLACEHOLDER_EMPTY;
+    return;
+  }
+
+  const wrapper = document.createElement('div');
+  wrapper.className = 'embeddings-finding-list';
+  for (const finding of findings) {
+    wrapper.appendChild(buildFindingRow(finding));
+  }
+  body.replaceChildren(wrapper);
+  body.className = '';
+}

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -363,6 +363,58 @@
       font-style: normal;
       font-weight: 600;
     }
+    /* Issue #129 Stage 5 — embeddings-Hunter explainability accordion. */
+    .embeddings-finding-list {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+    .embeddings-finding-row {
+      border-left: 2px solid #5a2d2d;
+      padding: 4px 0 4px 8px;
+    }
+    .embeddings-finding-head {
+      display: flex;
+      justify-content: space-between;
+      gap: 8px;
+      font-size: 12px;
+    }
+    .embeddings-finding-id {
+      color: #e0e0e0;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .embeddings-finding-score {
+      color: #facc15;
+      font-variant-numeric: tabular-nums;
+      white-space: nowrap;
+    }
+    .embeddings-technique-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 4px;
+      margin-top: 4px;
+    }
+    .embeddings-technique-chip {
+      font-size: 10px;
+      background: #2a2a2a;
+      color: #aaa;
+      padding: 2px 6px;
+      border-radius: 4px;
+    }
+    .embeddings-activations {
+      list-style: none;
+      padding: 0;
+      margin: 6px 0 0 0;
+    }
+    .embeddings-activation-item {
+      font-size: 10px;
+      color: #6b7280;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      line-height: 1.6;
+    }
   </style>
 </head>
 <body>
@@ -486,6 +538,13 @@
         <summary>Extracted entities</summary>
         <div class="card">
           <div class="placeholder" id="entities-body">No entity data yet.</div>
+        </div>
+      </details>
+
+      <details class="accordion" id="accordion-embeddings">
+        <summary>Embeddings matches</summary>
+        <div class="card">
+          <div class="placeholder" id="embeddings-findings-body">No embeddings data yet.</div>
         </div>
       </details>
 

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -24,6 +24,8 @@ import {
 } from './testing-mode-controls.js';
 import { renderHunterSummary, type HunterSummary } from './hunter-findings.js';
 import { renderEntitySummary, type EntitySummary } from './entities.js';
+import { renderEmbeddingsFindings } from './embeddings-findings.js';
+import type { EmbeddingsFinding } from '@/hunters/embeddings/types.js';
 import { renderResponseVerdict } from './response-analysis.js';
 import { renderThinkingVerdict } from './thinking-analysis.js';
 import type { ResponseVerdict, ThinkingVerdict } from '@/types/portal-response.js';
@@ -66,6 +68,10 @@ interface StoredVerdict {
   // pre-#131 verdicts; null on origins where no thinking block was
   // observed (the steady state for most conversations on most portals).
   thinkingVerdict?: ThinkingVerdict | null;
+  // Issue #129 Stage 5 — per-chunk embeddings-Hunter findings (top-K
+  // corpus matches + cosine scores). Absent on pre-Stage-5 verdicts;
+  // null when no chunk matched (the steady state on most pages).
+  embeddingsFindings?: readonly EmbeddingsFinding[] | null;
 }
 
 function $(id: string): HTMLElement {
@@ -407,6 +413,7 @@ async function loadVerdict(): Promise<void> {
 
   renderHunterSummary($('hunter-findings-body'), verdict.hunterSummary);
   renderEntitySummary($('entities-body'), verdict.entitySummary);
+  renderEmbeddingsFindings($('embeddings-findings-body'), verdict.embeddingsFindings);
   renderResponseVerdict($('response-analysis-body'), verdict.responseVerdict);
   renderThinkingVerdict($('thinking-analysis-body'), verdict.thinkingVerdict);
 

--- a/src/service-worker/dispatch.test.ts
+++ b/src/service-worker/dispatch.test.ts
@@ -65,6 +65,7 @@ function makeVerdict(status: SecurityStatus, analysisError: string | null = null
     entitySummary: null,
     responseVerdict: null,
     thinkingVerdict: null,
+    embeddingsFindings: null,
   };
 }
 

--- a/src/service-worker/orchestrator.test.ts
+++ b/src/service-worker/orchestrator.test.ts
@@ -201,6 +201,11 @@ describe('buildUnsupportedLanguageVerdict (issue #48)', () => {
     expect(verdict.thinkingVerdict).toBeNull();
   });
 
+  it('emits embeddingsFindings: null — chunk loop never ran (issue #129 Stage 5)', () => {
+    const verdict = buildUnsupportedLanguageVerdict(snapshotFixture(), 'ja');
+    expect(verdict.embeddingsFindings).toBeNull();
+  });
+
   it('emits webgpuAdapterMode: null — engine was not consulted', () => {
     const verdict = buildUnsupportedLanguageVerdict(snapshotFixture(), 'ja');
     expect(verdict.webgpuAdapterMode).toBeNull();

--- a/src/service-worker/orchestrator.ts
+++ b/src/service-worker/orchestrator.ts
@@ -44,6 +44,8 @@ import type { EvidencePacket } from '@/probes/base-probe.js';
 import type { Entity } from '@/hunters/ner/types.js';
 import { rollupEntities } from '@/hunters/ner/rollup.js';
 import { lookupRegistry } from '@/registry/lookup.js';
+import type { EmbeddingsFinding } from '@/hunters/embeddings/types.js';
+import { buildEmbeddingsFinding } from '@/hunters/embeddings/finding.js';
 
 const log = createLogger('Orchestrator');
 
@@ -156,6 +158,7 @@ export function buildOriginSkippedVerdict(
     // Issue #131 — same exclusivity: origin-skipped pages never observe a
     // thinking block.
     thinkingVerdict: null,
+    embeddingsFindings: null,
   };
 }
 
@@ -198,6 +201,7 @@ export function buildRegistryMatchVerdict(
     entitySummary: null,
     responseVerdict: null,
     thinkingVerdict: null,
+    embeddingsFindings: null,
   };
 }
 
@@ -236,6 +240,7 @@ export function buildUnsupportedLanguageVerdict(
     entitySummary: null,
     responseVerdict: null,
     thinkingVerdict: null,
+    embeddingsFindings: null,
   };
 }
 
@@ -421,6 +426,12 @@ export async function analyzeSnapshot(
     // Issue #122 (N14d) — accumulate entities across every chunk's
     // evidencePackets so the verdict can carry a rolled-up EntitySummary.
     const allEntities: Entity[] = [];
+    // Issue #129 Stage 5 — collect popup-render-friendly summaries of every
+    // chunk's embeddings-Hunter match. Empty after all chunks → null on the
+    // verdict so the popup renders the "no embeddings matches" placeholder
+    // (preserving the Phase 2 byte-locked baseline contract: with the index
+    // empty / hunter no-op, no chunks match and the field stays null).
+    const embeddingsFindingsAcc: EmbeddingsFinding[] = [];
     let canaryId: string | null = null;
     let webgpuAdapterMode: WebGPUAdapterMode | null = null;
     // Issue #145 — flipped when a chunk's HuntReport.shouldSkipProbes is true,
@@ -483,6 +494,13 @@ export async function analyzeSnapshot(
         [spiderHunter, hawkHunter, embeddingsHunter],
         chunk,
       );
+      // Issue #129 Stage 5 — surface the embeddings-Hunter signal. Pure
+      // projection over the existing HunterResult; no scoring/routing
+      // change here (tier routing still consumes huntReport unchanged).
+      for (const result of huntReport.results) {
+        const finding = buildEmbeddingsFinding(index, result);
+        if (finding !== null) embeddingsFindingsAcc.push(finding);
+      }
       const tierRouting = routeChunk(huntReport);
       log.info(
         `Chunk ${index}: tier=${tierRouting.decision} (primitives=${tierRouting.primitiveCount})`,
@@ -613,11 +631,14 @@ export async function analyzeSnapshot(
       log.error('Failed to generate page stamp', err);
     }
     const entitySummary = allEntities.length > 0 ? rollupEntities(allEntities) : null;
+    const embeddingsFindings =
+      embeddingsFindingsAcc.length > 0 ? embeddingsFindingsAcc : null;
     const verdict: SecurityVerdict = {
       ...verdict0,
       stamp,
       perChunkAnalysis,
       entitySummary,
+      embeddingsFindings,
     };
 
     await persistVerdict(verdict);

--- a/src/service-worker/response-analyzer.ts
+++ b/src/service-worker/response-analyzer.ts
@@ -126,6 +126,9 @@ function buildMinimalPageStub(url: string, timestamp: number, responseVerdict: R
     // Issue #131 — the response-analyzer's stub never carries a thinking
     // verdict; the thinking analyzer writes its own slot independently.
     thinkingVerdict: null,
+    // Issue #129 Stage 5 — response-analyzer stubs never produce embeddings
+    // findings; only the page-scan path's chunk loop populates this slot.
+    embeddingsFindings: null,
   };
 }
 

--- a/src/service-worker/thinking-analyzer.ts
+++ b/src/service-worker/thinking-analyzer.ts
@@ -124,6 +124,7 @@ function buildMinimalPageStub(url: string, timestamp: number, thinkingVerdict: T
     entitySummary: null,
     responseVerdict: null,
     thinkingVerdict,
+    embeddingsFindings: null,
   };
 }
 

--- a/src/types/verdict.ts
+++ b/src/types/verdict.ts
@@ -1,6 +1,7 @@
 import type { PageStamp } from './page-stamp.js';
 import type { ResponseVerdict, ThinkingVerdict } from './portal-response.js';
 import type { EntitySummary } from '@/hunters/ner/types.js';
+import type { EmbeddingsFinding } from '@/hunters/embeddings/types.js';
 
 export type SecurityStatus = 'CLEAN' | 'SUSPICIOUS' | 'COMPROMISED' | 'UNKNOWN';
 
@@ -114,6 +115,13 @@ export interface SecurityVerdict {
   // Coexists with responseVerdict; cross-comparison (CLEAN response +
   // SUSPICIOUS thinking) is the high-signal use case this slot enables.
   readonly thinkingVerdict: ThinkingVerdict | null;
+  // Issue #129 Stage 5 — per-chunk findings from the embeddings Hunter
+  // (top-K corpus matches + cosine scores). Null when no chunk matched
+  // (the steady state when the index is empty, the corpus is missing, or
+  // every cosine sat below threshold). Pre-Stage-5 verdicts come back
+  // with `embeddingsFindings === undefined`, coalesced to null by
+  // getVerdict — same migration shape as responseVerdict / thinkingVerdict.
+  readonly embeddingsFindings: readonly EmbeddingsFinding[] | null;
 }
 
 export interface AISecurityReport {


### PR DESCRIPTION
## Summary

Stage 5 of #129 — surface the third-Hunter signal in the popup explainability surface so users can see WHY a chunk was flagged.

- New `EmbeddingsFinding` projection on `SecurityVerdict` (optional; undefined→null migration mirroring `responseVerdict` / `thinkingVerdict` per `src/policy/storage.ts`).
- Orchestrator collects per-chunk findings from `huntReport.results` inside the existing chunk loop. **No scoring or routing change** — `tier-router.ts` still consumes `huntReport` byte-identically.
- Pure DOM renderer at `src/popup/embeddings-findings.ts` mirroring `registry-stats.ts`; accordion `Embeddings matches` added to `popup.html` between Extracted entities and Response analysis using the SR-G `accordion-registry` pattern.
- `buildEmbeddingsFinding` helper at `src/hunters/embeddings/finding.ts` parses the existing `embeddings:` / `lang:` / `technique:` flag prefixes into a typed projection.

## Phase 2 byte-locked baseline

`docs/testing/inbrowser-results.json` (162 rows) is **untouched**. With the embeddings index empty / hunter no-op (the steady state during the Stage-4 cold-load window and on every page where no chunk's cosine clears `EMBEDDING_COSINE_THRESHOLD = 0.85`), every chunk emits `matched=false` and `embeddingsFindings` stays null — so the verdict shape's content is identical to pre-Stage-5 for the baseline corpus.

Pedagogical-FP discipline (per `project_pedagogical_fpr_baseline.md`): display-only change, no impact on the 0/50 compromised baseline.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 1367 → 1390 (+23) across:
  - 9 `buildEmbeddingsFinding` cases (`src/hunters/embeddings/finding.test.ts`)
  - 9 `renderEmbeddingsFindings` cases (`src/popup/embeddings-findings.test.ts`)
  - 4 storage migration cases (round-trip, undefined→null coalesce, persisted-null preservation, persistVerdict verbatim)
  - 1 `buildUnsupportedLanguageVerdict` synthetic-verdict invariant (`embeddingsFindings: null`)
- [x] `npm run build` — clean (no bundle-size delta; pure source change)
- [x] `npm audit` — 0 vulnerabilities
- [x] Maintainer smoke (load `dist/` unpacked, hit a known-injection page once embeddings corpus has matched a chunk → accordion shows the row) — TODO maintainer chore (Stage 6 close-out)

Refs #129 (Stage 6 polish remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)