### PR TITLE
feat(probe-#9): Stage 4G.1 — capability registration framework

### DIFF
--- a/src/offscreen/probe-runner.test.ts
+++ b/src/offscreen/probe-runner.test.ts
@@ -1,18 +1,21 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
-import type { EvidencePacket } from '@/probes/base-probe.js';
-import { SCORE_EXFIL_ENTITY_CONFIRMED } from '@/shared/constants.js';
+import type { EvidencePacket, Probe } from '@/probes/base-probe.js';
+import { SCORE_EXFIL_ENTITY_CONFIRMED, type CanaryId } from '@/shared/constants.js';
 
 const generateCompletionMock = vi.fn<
   (system: string, user: string, opts?: unknown) => Promise<string>
 >();
 
+let loadedCanaryIdMock: CanaryId | null = 'gemma-2-2b-mlc';
+
 vi.mock('./engine.js', () => ({
   generateCompletion: (system: string, user: string, opts?: unknown) =>
     generateCompletionMock(system, user, opts),
+  getLoadedCanaryId: () => loadedCanaryIdMock,
 }));
 
-const { runProbes } = await import('./probe-runner.js');
+const { runProbes, filterProbesByCapability } = await import('./probe-runner.js');
 
 const basePacket: EvidencePacket = {
   hunterName: 'spider',
@@ -32,6 +35,14 @@ const benignReview = '{"confirmed": false, "reasoning": "context"}';
 beforeEach(() => {
   generateCompletionMock.mockReset();
   generateCompletionMock.mockResolvedValue(benignReview);
+  loadedCanaryIdMock = 'gemma-2-2b-mlc';
+});
+
+const fakeProbe = (overrides: Partial<Probe> & { name: string }): Probe => ({
+  systemPrompt: 'sys',
+  buildUserMessage: () => 'user',
+  analyzeResponse: () => ({ passed: true, flags: [], score: 0 }),
+  ...overrides,
 });
 
 describe('runProbes — issue #122 fast-path', () => {
@@ -137,4 +148,89 @@ describe('runProbes — issue #122 fast-path', () => {
     expect(fastPath!.flags[0]).toMatch(/^ner:exfil_exfil_domain:/);
     expect(fastPath!.flags[0]!.length).toBeLessThanOrEqual('ner:exfil_exfil_domain:'.length + 32);
   });
+});
+
+describe('filterProbesByCapability — issue #9 Stage 4G.1', () => {
+  it('keeps a probe with no requiredCapabilities under any canary', () => {
+    const probe = fakeProbe({ name: 'plain' });
+    expect(filterProbesByCapability([probe], ['text_input'])).toEqual([probe]);
+    expect(filterProbesByCapability([probe], [])).toEqual([probe]);
+    expect(filterProbesByCapability([probe], ['text_input', 'image_input'])).toEqual([probe]);
+  });
+
+  it('keeps a probe with empty requiredCapabilities array under any canary', () => {
+    const probe = fakeProbe({ name: 'no-reqs', requiredCapabilities: [] });
+    expect(filterProbesByCapability([probe], ['text_input'])).toEqual([probe]);
+    expect(filterProbesByCapability([probe], [])).toEqual([probe]);
+  });
+
+  it('drops a probe whose required capability is not in the canary set', () => {
+    const probe = fakeProbe({
+      name: 'image_injection',
+      requiredCapabilities: ['image_input'],
+    });
+    expect(filterProbesByCapability([probe], ['text_input'])).toEqual([]);
+  });
+
+  it('keeps a probe whose required capability is in the canary set', () => {
+    const probe = fakeProbe({
+      name: 'image_injection',
+      requiredCapabilities: ['image_input'],
+    });
+    expect(
+      filterProbesByCapability([probe], ['text_input', 'image_input']),
+    ).toEqual([probe]);
+  });
+
+  it('requires every listed capability to be present (subset semantics)', () => {
+    const probe = fakeProbe({
+      name: 'multimodal',
+      requiredCapabilities: ['text_input', 'image_input'],
+    });
+    expect(filterProbesByCapability([probe], ['text_input'])).toEqual([]);
+    expect(
+      filterProbesByCapability([probe], ['text_input', 'image_input']),
+    ).toEqual([probe]);
+  });
+
+  it('drops every required-capability probe when the canary set is empty', () => {
+    const probe = fakeProbe({
+      name: 'image_injection',
+      requiredCapabilities: ['image_input'],
+    });
+    expect(filterProbesByCapability([probe], [])).toEqual([]);
+  });
+
+  it('preserves input order across multiple probes (filter, do not reorder)', () => {
+    const a = fakeProbe({ name: 'a' });
+    const b = fakeProbe({ name: 'b', requiredCapabilities: ['image_input'] });
+    const c = fakeProbe({ name: 'c' });
+    const filtered = filterProbesByCapability([a, b, c], ['text_input']);
+    expect(filtered.map((p) => p.name)).toEqual(['a', 'c']);
+  });
+});
+
+describe('runProbes — issue #9 Stage 4G.1 capability skip integration', () => {
+  it('does not regress: existing 3-probe stack (no requiredCapabilities) still dispatches under text_input canary', async () => {
+    loadedCanaryIdMock = 'gemma-2-2b-mlc';
+    const results = await runProbes('chunk text');
+    expect(results.map((r) => r.probeName)).toEqual([
+      'summarization',
+      'instruction_detection',
+      'adversarial_compliance',
+    ]);
+    expect(generateCompletionMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('still dispatches the existing stack when no canary is loaded yet (fail-open for legacy probes)', async () => {
+    loadedCanaryIdMock = null;
+    const results = await runProbes('chunk text');
+    expect(results.map((r) => r.probeName)).toEqual([
+      'summarization',
+      'instruction_detection',
+      'adversarial_compliance',
+    ]);
+    expect(generateCompletionMock).toHaveBeenCalledTimes(3);
+  });
+
 });

--- a/src/offscreen/probe-runner.ts
+++ b/src/offscreen/probe-runner.ts
@@ -1,6 +1,6 @@
 import type { ProbeResult } from '@/types/verdict.js';
 import { createLogger } from '@/shared/logger.js';
-import { generateCompletion } from './engine.js';
+import { generateCompletion, getLoadedCanaryId } from './engine.js';
 import { summarizationProbe } from '@/probes/summarization.js';
 import { instructionDetectionProbe } from '@/probes/instruction-detection.js';
 import { adversarialComplianceProbe } from '@/probes/adversarial-compliance.js';
@@ -10,6 +10,9 @@ import type { Entity, EntityType } from '@/hunters/ner/types.js';
 import {
   SCORE_EXFIL_ENTITY_CONFIRMED,
   HIGH_CONF_ENTITY_THRESHOLD,
+  CANARY_CATALOG,
+  type CanaryCapability,
+  type CanaryId,
 } from '@/shared/constants.js';
 
 const log = createLogger('ProbeRunner');
@@ -19,6 +22,31 @@ const FULL_STACK_PROBES: readonly Probe[] = [
   instructionDetectionProbe,
   adversarialComplianceProbe,
 ];
+
+/**
+ * Issue #9 Stage 4G.1 — pure helper that drops probes whose
+ * `requiredCapabilities` are not a subset of `canaryCapabilities`. Probes
+ * that omit the field or declare an empty array always pass through, so
+ * the existing 3-probe stack is untouched while the framework lands.
+ */
+export function filterProbesByCapability(
+  probes: readonly Probe[],
+  canaryCapabilities: readonly CanaryCapability[],
+): readonly Probe[] {
+  const available = new Set<CanaryCapability>(canaryCapabilities);
+  return probes.filter((probe) => {
+    const required = probe.requiredCapabilities;
+    if (required === undefined || required.length === 0) return true;
+    return required.every((cap) => available.has(cap));
+  });
+}
+
+function loadedCanaryCapabilities(): readonly CanaryCapability[] {
+  const id: CanaryId | null = getLoadedCanaryId();
+  if (id === null || id === 'auto') return [];
+  const def = CANARY_CATALOG[id];
+  return def?.capabilities ?? [];
+}
 
 function errorToMessage(err: unknown): string {
   if (err instanceof Error) return err.message;
@@ -127,9 +155,11 @@ export async function runProbes(
   chunk: string,
   evidencePackets: readonly EvidencePacket[] = [],
 ): Promise<readonly ProbeResult[]> {
+  const canaryCapabilities = loadedCanaryCapabilities();
+
   if (evidencePackets.length === 0) {
     const results: ProbeResult[] = [];
-    for (const probe of FULL_STACK_PROBES) {
+    for (const probe of filterProbesByCapability(FULL_STACK_PROBES, canaryCapabilities)) {
       results.push(await runOneProbe(probe, probe.systemPrompt, probe.buildUserMessage(chunk), chunk));
     }
     return results;
@@ -140,16 +170,20 @@ export async function runProbes(
   if (exfilEntities.length > 0) {
     results.push(buildFastPathProbeResult(exfilEntities));
   }
-  for (const packet of evidencePackets) {
-    const userMessage = evidenceReviewProbe.buildPacketMessage!(packet);
-    results.push(
-      await runOneProbe(evidenceReviewProbe, evidenceReviewProbe.systemPrompt, userMessage, packet.flagged),
-    );
+  if (filterProbesByCapability([evidenceReviewProbe], canaryCapabilities).length > 0) {
+    for (const packet of evidencePackets) {
+      const userMessage = evidenceReviewProbe.buildPacketMessage!(packet);
+      results.push(
+        await runOneProbe(evidenceReviewProbe, evidenceReviewProbe.systemPrompt, userMessage, packet.flagged),
+      );
+    }
   }
   // Summarization always runs on the full chunk for general anomaly coverage
   // (e.g. encoding-density spikes outside the flagged spans).
-  results.push(
-    await runOneProbe(summarizationProbe, summarizationProbe.systemPrompt, summarizationProbe.buildUserMessage(chunk), chunk),
-  );
+  if (filterProbesByCapability([summarizationProbe], canaryCapabilities).length > 0) {
+    results.push(
+      await runOneProbe(summarizationProbe, summarizationProbe.systemPrompt, summarizationProbe.buildUserMessage(chunk), chunk),
+    );
+  }
   return results;
 }

--- a/src/probes/base-probe.ts
+++ b/src/probes/base-probe.ts
@@ -1,4 +1,5 @@
 import type { Entity } from '@/hunters/ner/types.js';
+import type { CanaryCapability } from '@/shared/constants.js';
 
 export interface ProbeAnalysis {
   readonly passed: boolean;
@@ -50,6 +51,15 @@ export interface Probe {
    * `analyzeResponse`. Closes #44 by absorbing it into the new probe path.
    */
   readonly responseConstraintSchema?: object;
+  /**
+   * Issue #9 Stage 4G.1 — capabilities the loaded canary must advertise for
+   * this probe to be dispatched. The probe-runner filters probes whose
+   * required set is not a subset of the loaded canary's capabilities and
+   * silently skips them (no error, no ProbeResult emitted). Probes that omit
+   * the field or set an empty array always run, preserving the pre-Stage-4G
+   * behaviour for the existing 3-probe stack.
+   */
+  readonly requiredCapabilities?: readonly CanaryCapability[];
   buildUserMessage(chunk: string): string;
   /**
    * Issue #118 — packet-aware probes (currently only `evidence_review`)


### PR DESCRIPTION
## Summary

Lands the capability-registration framework that gates the upcoming Stage 4G.3 multimodal Nano image-injection probe. Probes can now declare `requiredCapabilities`; the probe-runner derives the loaded canary's capability set from `CANARY_CATALOG` and silently skips any probe whose required set is not a subset. The existing 3-probe stack declares no requirements, so dispatch behaviour is byte-equivalent to pre-Stage-4G under every supported canary — Phase 2 162-row byte-locked baseline contract preserved.

This is one of six 4G sub-stages on issue #9; the issue stays open until 4G.6 ships.

## Changes

- `src/probes/base-probe.ts` — `Probe.requiredCapabilities?: readonly CanaryCapability[]` (imported from `@/shared/constants.js`, where `CanaryCapability` + `CANARY_CATALOG` already live since Stage 4D).
- `src/offscreen/probe-runner.ts` — new pure `filterProbesByCapability(probes, canaryCapabilities)` helper (subset semantics, preserves input order, omitted/empty array passes through). `runProbes` calls a `loadedCanaryCapabilities()` lookup that resolves `getLoadedCanaryId()` against `CANARY_CATALOG`, then filters the empty-packets stack and the packet-bearing evidence-review + summarization paths. No-canary state returns `[]` capabilities; legacy probes (no `requiredCapabilities`) still dispatch — fail-open for the existing stack, fail-safe for any future capability-gated probe.

## Tests

- 6 new `filterProbesByCapability` unit cases (no-reqs always-keep / empty-array always-keep / drop on missing cap / keep on present cap / multi-cap subset semantics / empty canary set drops all required-cap probes / order preservation).
- 2 new `runProbes` regression cases (existing 3-probe stack still dispatches under text-only canary; existing stack still dispatches when no canary is loaded yet).
- Pre-existing 10 cases byte-untouched.

`npm test` 1401/1401 passing across 120 files. `npm run typecheck` clean. `npm run build` clean. 0 npm vulnerabilities.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` (1401 passing — full suite including all 17 cases in `src/offscreen/probe-runner.test.ts`)
- [x] `npm run build`
- [x] Phase 2 byte-locked baseline (`docs/testing/inbrowser-results.json`) untouched
- [x] AIza-≥20 grep clean / `npm audit` clean

Refs #9