### PR TITLE
feat(probe-#9): Stage 4G.2 — image extraction in PageSnapshot

### DIFF
--- a/src/content/ingestion/extractor.ts
+++ b/src/content/ingestion/extractor.ts
@@ -10,6 +10,7 @@ import { extractAriaLabels } from './aria-labels.js';
 import { extractCSSContent } from './css-content.js';
 import { extractDataAttributes } from './data-attrs.js';
 import { extractNoscriptText } from './noscript.js';
+import { extractImages } from './images.js';
 
 interface AuxiliarySection {
   readonly label: string;
@@ -61,6 +62,8 @@ export async function extractPageSnapshot(): Promise<PageSnapshot> {
   // SR-F (registry-#51) — capture the raw outer HTML so the SW can fingerprint
   // static-frame zones against the signed registry. Absent → registry MISS.
   const pageHtml = document.documentElement.outerHTML;
+  // Phase 4 Stage 4G.2 (#9) — top-N images for the future image-injection probe.
+  const images = extractImages();
 
   return {
     visibleText,
@@ -70,5 +73,6 @@ export async function extractPageSnapshot(): Promise<PageSnapshot> {
     extractedAt: Date.now(),
     charCount: visibleText.length + hiddenText.length,
     pageHtml,
+    images,
   };
 }

--- a/src/content/ingestion/images.test.ts
+++ b/src/content/ingestion/images.test.ts
@@ -1,0 +1,211 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import { extractImages } from './images.js';
+
+interface ImgSpec {
+  readonly src: string;
+  readonly width?: number;
+  readonly height?: number;
+  readonly alt?: string;
+}
+
+function appendImg(parent: Element, spec: ImgSpec): HTMLImageElement {
+  const img = parent.ownerDocument.createElement('img');
+  img.setAttribute('src', spec.src);
+  if (spec.width !== undefined) img.setAttribute('width', String(spec.width));
+  if (spec.height !== undefined) img.setAttribute('height', String(spec.height));
+  if (spec.alt !== undefined) img.setAttribute('alt', spec.alt);
+  parent.appendChild(img);
+  return img;
+}
+
+interface RectOverrides {
+  readonly [src: string]: { width: number; height: number; left?: number; top?: number };
+}
+
+function makeRectGetter(overrides: RectOverrides) {
+  function makeRect(width: number, height: number, left: number, top: number): DOMRect {
+    return {
+      width,
+      height,
+      left,
+      top,
+      right: left + width,
+      bottom: top + height,
+      x: left,
+      y: top,
+      toJSON() {
+        return {};
+      },
+    };
+  }
+
+  return (el: Element): DOMRect => {
+    const src = (el as HTMLImageElement).src;
+    const o = overrides[src];
+    if (o === undefined) {
+      const img = el as HTMLImageElement;
+      const w = img.width || 0;
+      const h = img.height || 0;
+      return makeRect(w, h, 0, 0);
+    }
+    return makeRect(o.width, o.height, o.left ?? 0, o.top ?? 0);
+  };
+}
+
+beforeEach(() => {
+  document.body.replaceChildren();
+});
+
+describe('extractImages', () => {
+  it('returns an empty array when the page has no <img>', () => {
+    const p = document.createElement('p');
+    p.textContent = 'no images here';
+    document.body.appendChild(p);
+    expect(extractImages({ getRect: makeRectGetter({}) })).toEqual([]);
+  });
+
+  it('includes images at or above the 50×50 throttle', () => {
+    appendImg(document.body, {
+      src: 'https://example.com/a.png',
+      width: 200,
+      height: 200,
+      alt: 'hello',
+    });
+    const images = extractImages({ getRect: makeRectGetter({}) });
+    expect(images).toHaveLength(1);
+    expect(images[0]!.src).toBe('https://example.com/a.png');
+    expect(images[0]!.altText).toBe('hello');
+    expect(images[0]!.width).toBe(200);
+    expect(images[0]!.height).toBe(200);
+  });
+
+  it('skips images below the 50×50 throttle (either dimension)', () => {
+    appendImg(document.body, { src: 'https://example.com/tiny-w.png', width: 40, height: 60 });
+    appendImg(document.body, { src: 'https://example.com/tiny-h.png', width: 60, height: 40 });
+    appendImg(document.body, { src: 'https://example.com/exactly-50.png', width: 50, height: 50 });
+    const images = extractImages({ getRect: makeRectGetter({}) });
+    expect(images.map((i) => i.src)).toEqual(['https://example.com/exactly-50.png']);
+  });
+
+  it('skips known tracking beacons even when sized above the throttle', () => {
+    appendImg(document.body, {
+      src: 'https://www.google-analytics.com/collect?v=1',
+      width: 100,
+      height: 100,
+    });
+    appendImg(document.body, {
+      src: 'https://stats.g.doubleclick.net/r/pixel?id=42',
+      width: 100,
+      height: 100,
+    });
+    appendImg(document.body, {
+      src: 'https://www.facebook.com/tr?id=999',
+      width: 100,
+      height: 100,
+    });
+    appendImg(document.body, { src: 'https://example.com/photo.jpg', width: 100, height: 100 });
+    const images = extractImages({ getRect: makeRectGetter({}) });
+    expect(images.map((i) => i.src)).toEqual(['https://example.com/photo.jpg']);
+  });
+
+  it('caps the result at 5 images per page', () => {
+    for (let i = 0; i < 8; i++) {
+      appendImg(document.body, {
+        src: `https://example.com/img-${i}.png`,
+        width: 100 + i,
+        height: 100 + i,
+      });
+    }
+    const images = extractImages({ getRect: makeRectGetter({}) });
+    expect(images).toHaveLength(5);
+  });
+
+  it('ranks the top-N by size × visibility (visible large beats invisible large beats visible small)', () => {
+    appendImg(document.body, {
+      src: 'https://example.com/visible-large.png',
+      width: 600,
+      height: 600,
+    });
+    appendImg(document.body, {
+      src: 'https://example.com/invisible-large.png',
+      width: 600,
+      height: 600,
+    });
+    appendImg(document.body, {
+      src: 'https://example.com/visible-small.png',
+      width: 80,
+      height: 80,
+    });
+    appendImg(document.body, {
+      src: 'https://example.com/visible-medium.png',
+      width: 300,
+      height: 300,
+    });
+    const getRect = makeRectGetter({
+      'https://example.com/visible-large.png': { width: 600, height: 600, left: 0, top: 0 },
+      'https://example.com/invisible-large.png': { width: 600, height: 600, left: 0, top: 5000 },
+      'https://example.com/visible-small.png': { width: 80, height: 80, left: 0, top: 100 },
+      'https://example.com/visible-medium.png': { width: 300, height: 300, left: 0, top: 200 },
+    });
+    const images = extractImages({ getRect, viewportWidth: 1024, viewportHeight: 768 });
+    expect(images.map((i) => i.src)).toEqual([
+      'https://example.com/visible-large.png',
+      'https://example.com/visible-medium.png',
+      'https://example.com/invisible-large.png',
+      'https://example.com/visible-small.png',
+    ]);
+  });
+
+  it('captures empty string when alt is missing (never undefined / null)', () => {
+    appendImg(document.body, { src: 'https://example.com/noalt.png', width: 200, height: 200 });
+    const images = extractImages({ getRect: makeRectGetter({}) });
+    expect(images[0]!.altText).toBe('');
+  });
+
+  it('resolves relative src to an absolute URL via HTMLImageElement.src', () => {
+    appendImg(document.body, { src: '/photo.png', width: 200, height: 200 });
+    const images = extractImages({ getRect: makeRectGetter({}) });
+    expect(images[0]!.src.startsWith('http')).toBe(true);
+    expect(images[0]!.src.endsWith('/photo.png')).toBe(true);
+  });
+
+  it('marks visibleInViewport=true when the rect intersects the viewport', () => {
+    appendImg(document.body, { src: 'https://example.com/in.png', width: 200, height: 200 });
+    const getRect = makeRectGetter({
+      'https://example.com/in.png': { width: 200, height: 200, left: 100, top: 100 },
+    });
+    const images = extractImages({ getRect, viewportWidth: 1024, viewportHeight: 768 });
+    expect(images[0]!.visibleInViewport).toBe(true);
+  });
+
+  it('marks visibleInViewport=false when the rect is fully offscreen below', () => {
+    appendImg(document.body, { src: 'https://example.com/out.png', width: 200, height: 200 });
+    const getRect = makeRectGetter({
+      'https://example.com/out.png': { width: 200, height: 200, left: 0, top: 5000 },
+    });
+    const images = extractImages({ getRect, viewportWidth: 1024, viewportHeight: 768 });
+    expect(images[0]!.visibleInViewport).toBe(false);
+  });
+
+  it('buckets sizeClass: small <200, medium <500, large ≥500 (max dimension)', () => {
+    appendImg(document.body, { src: 'https://example.com/small.png', width: 150, height: 150 });
+    appendImg(document.body, { src: 'https://example.com/medium.png', width: 300, height: 300 });
+    appendImg(document.body, { src: 'https://example.com/large.png', width: 800, height: 800 });
+    const images = extractImages({ getRect: makeRectGetter({}) });
+    const byId = Object.fromEntries(images.map((i) => [i.src.split('/').pop(), i.sizeClass]));
+    expect(byId['small.png']).toBe('small');
+    expect(byId['medium.png']).toBe('medium');
+    expect(byId['large.png']).toBe('large');
+  });
+
+  it('skips images with display:none ancestors', () => {
+    const hiddenWrap = document.createElement('div');
+    hiddenWrap.setAttribute('style', 'display:none');
+    appendImg(hiddenWrap, { src: 'https://example.com/hidden.png', width: 200, height: 200 });
+    document.body.appendChild(hiddenWrap);
+    appendImg(document.body, { src: 'https://example.com/shown.png', width: 200, height: 200 });
+    const images = extractImages({ getRect: makeRectGetter({}) });
+    expect(images.map((i) => i.src)).toEqual(['https://example.com/shown.png']);
+  });
+});

--- a/src/content/ingestion/images.ts
+++ b/src/content/ingestion/images.ts
@@ -1,0 +1,118 @@
+import type { ImageRef } from '@/types/snapshot.js';
+
+const MIN_DIMENSION_PX = 50;
+const MAX_IMAGES_PER_PAGE = 5;
+const SIZE_BUCKET_MEDIUM_PX = 200;
+const SIZE_BUCKET_LARGE_PX = 500;
+const INVISIBLE_SCORE_FACTOR = 0.2;
+
+// Tracking-beacon hostnames + path patterns. Hostname match is suffix-based
+// so subdomains (`stats.g.doubleclick.net`) match. Path patterns catch the
+// generic `/tr`, `/pixel`, `/beacon`, `/p.gif`-style endpoints that show up
+// on long-tail tracking servers we don't enumerate by hostname.
+const TRACKING_HOSTNAMES: readonly string[] = [
+  'google-analytics.com',
+  'googletagmanager.com',
+  'doubleclick.net',
+  'facebook.com',
+  'scorecardresearch.com',
+  'quantserve.com',
+  'adsystem.amazon.com',
+  'adservice.google.com',
+];
+
+const TRACKING_PATH_RE = /\/(?:tr|pixel|beacon|track|collect)(?:[/?]|\.gif$|\.png$|$)/i;
+
+interface RectLike {
+  readonly width: number;
+  readonly height: number;
+  readonly left: number;
+  readonly top: number;
+  readonly right: number;
+  readonly bottom: number;
+}
+
+export interface ExtractImagesOptions {
+  readonly doc?: Document;
+  readonly getRect?: (el: Element) => RectLike;
+  readonly viewportWidth?: number;
+  readonly viewportHeight?: number;
+}
+
+export function extractImages(opts: ExtractImagesOptions = {}): readonly ImageRef[] {
+  const doc = opts.doc ?? (typeof document !== 'undefined' ? document : null);
+  if (doc === null) return [];
+
+  const getRect = opts.getRect ?? ((el: Element) => el.getBoundingClientRect());
+  const viewportW =
+    opts.viewportWidth ?? (typeof window !== 'undefined' ? window.innerWidth : 1024);
+  const viewportH =
+    opts.viewportHeight ?? (typeof window !== 'undefined' ? window.innerHeight : 768);
+
+  const ranked: { ref: ImageRef; score: number }[] = [];
+
+  for (const el of Array.from(doc.querySelectorAll('img'))) {
+    const img = el as HTMLImageElement;
+    if (hasHiddenAncestor(img)) continue;
+
+    const rect = getRect(img);
+    const width = Math.round(rect.width || img.width || img.naturalWidth || 0);
+    const height = Math.round(rect.height || img.height || img.naturalHeight || 0);
+    if (width < MIN_DIMENSION_PX || height < MIN_DIMENSION_PX) continue;
+
+    const src = img.src;
+    if (src.length === 0) continue;
+    if (isTrackingBeacon(src)) continue;
+
+    const visibleInViewport = intersectsViewport(rect, viewportW, viewportH);
+    const sizeClass = bucketSize(Math.max(width, height));
+    const altText = img.getAttribute('alt')?.trim() ?? '';
+
+    const score = width * height * (visibleInViewport ? 1 : INVISIBLE_SCORE_FACTOR);
+    ranked.push({
+      ref: { src, altText, width, height, visibleInViewport, sizeClass },
+      score,
+    });
+  }
+
+  ranked.sort((a, b) => b.score - a.score);
+  return ranked.slice(0, MAX_IMAGES_PER_PAGE).map((r) => r.ref);
+}
+
+function bucketSize(maxDim: number): ImageRef['sizeClass'] {
+  if (maxDim < SIZE_BUCKET_MEDIUM_PX) return 'small';
+  if (maxDim < SIZE_BUCKET_LARGE_PX) return 'medium';
+  return 'large';
+}
+
+function intersectsViewport(rect: RectLike, viewportW: number, viewportH: number): boolean {
+  if (rect.width === 0 || rect.height === 0) return false;
+  return rect.bottom > 0 && rect.top < viewportH && rect.right > 0 && rect.left < viewportW;
+}
+
+function isTrackingBeacon(src: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(src);
+  } catch {
+    return false;
+  }
+  const host = url.hostname.toLowerCase();
+  for (const tracker of TRACKING_HOSTNAMES) {
+    if (host === tracker || host.endsWith(`.${tracker}`)) return true;
+  }
+  if (TRACKING_PATH_RE.test(url.pathname)) return true;
+  return false;
+}
+
+function hasHiddenAncestor(el: Element): boolean {
+  let cur: Element | null = el;
+  while (cur !== null) {
+    const style = cur.getAttribute('style') ?? '';
+    if (/display\s*:\s*none/i.test(style)) return true;
+    if (/visibility\s*:\s*hidden/i.test(style)) return true;
+    if (cur.hasAttribute('hidden')) return true;
+    cur = cur.parentElement;
+  }
+  return false;
+}

--- a/src/types/snapshot.ts
+++ b/src/types/snapshot.ts
@@ -5,6 +5,22 @@ export interface ScriptFingerprint {
   readonly length: number;
 }
 
+// Phase 4 Stage 4G.2 (issue #9) — page image reference. Captured by the
+// content-script extractor for Stage 4G.3's multimodal image-injection probe.
+// `sizeClass` is bucketed off `max(width, height)` (`small` < 200 px, `medium`
+// < 500 px, `large` ≥ 500 px) so probe scheduling can prioritise hero images
+// over thumbnails. `visibleInViewport` reflects extractor-time visibility, not
+// scroll state. `src` is the resolved absolute URL (`HTMLImageElement.src`),
+// not the raw attribute, so srcset / data: / blob: URLs survive serialisation.
+export interface ImageRef {
+  readonly src: string;
+  readonly altText: string;
+  readonly width: number;
+  readonly height: number;
+  readonly visibleInViewport: boolean;
+  readonly sizeClass: 'small' | 'medium' | 'large';
+}
+
 export interface PageMetadata {
   readonly title: string;
   readonly url: string;
@@ -30,4 +46,11 @@ export interface PageSnapshot {
   // registry lookup misses on absent / empty HTML by design (RFC §Q5
   // fail-safe — no HTML means full analysis runs).
   readonly pageHtml?: string;
+  // Phase 4 Stage 4G.2 (issue #9) — top-N images surfaced by the content-script
+  // extractor for the future image-injection probe (4G.3). Throttled at
+  // ≥50×50 px, tracking-beacon URLs filtered, capped at 5/page ranked by
+  // size×visibility. Optional: pre-4G.2 snapshots and synthetic test fixtures
+  // omit it; downstream consumers (the 4G.3 probe + 4G.6 popup column) treat
+  // absent / empty arrays identically as "no images to scan".
+  readonly images?: readonly ImageRef[];
 }


### PR DESCRIPTION
## Summary

Phase 4 Stage 4G.2 of the multimodal image-injection probe (#9). Populates `PageSnapshot.images` with the top-N images on the page so the future image-injection probe (Stage 4G.3) has a curated, capability-aware input set instead of the full DOM.

- New `ImageRef` shape (`src` / `altText` / `width` / `height` / `visibleInViewport` / `sizeClass`) on `src/types/snapshot.ts`. `images` is optional — mirrors the SR-F `pageHtml` precedent so existing PageSnapshot literals (5 test fixtures + the offscreen parse-html synthetic-snapshot path) need no changes.
- New `src/content/ingestion/images.ts` (~110 lines) — pure `extractImages(opts?)` with DI seams for `doc` / `getRect` / `viewportWidth` / `viewportHeight`. Throttles at ≥50×50 px per dimension, filters tracking beacons (hostname suffix list + `/tr|pixel|beacon|track|collect` path regex), skips `display:none` / `visibility:hidden` / `hidden` ancestors, caps at 5/page, ranks by `width × height × visibilityFactor` (0.2 invisibility factor). 3-bucket `sizeClass` keyed off max dimension: 'small' < 200 px, 'medium' < 500 px, 'large' ≥ 500.
- Wired into `extractPageSnapshot()`; offscreen `parseHtmlToSnapshot` path deliberately omits `images` (the synthetic snapshot is reduced-fidelity and 4G.3 will need actual image bytes a static HTML parse can't deliver).

## Tests

12 TDD-first cases on synthetic jsdom DOMs — wrote tests, watched them fail (module not found), then implemented to GREEN. One iteration on the GREEN side: ranking test forced the invisible-score factor down from 0.25 to 0.2 so the semantic intent ('visible-medium beats invisible-large of equal area') holds at the tested sizes.

- empty result on image-free pages
- ≥50×50 throttle on either dimension; exact-50 boundary inclusive
- tracking-beacon filter (google-analytics, doubleclick, facebook.com/tr)
- 5/page cap; top-N ranking (visible large → visible medium → invisible large → visible small)
- alt-missing → empty string (never undefined / null)
- relative src resolves to absolute URL via HTMLImageElement.src
- visibleInViewport: intersects vs fully-below-viewport
- sizeClass small/medium/large bucketing
- display:none ancestor skip

Tests 1401 → 1413 (+12). Typecheck clean. Build clean. 0 npm vulnerabilities. AIza grep clean. Phase 2 byte-locked baseline (`docs/testing/inbrowser-results.json`) untouched.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 1413/1413 passing
- [x] `npm run build` clean
- [x] `npm audit` 0 vulnerabilities
- [x] AIza grep clean
- [x] Phase 2 byte-locked baseline untouched

Refs #9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)