### PR TITLE
fix(extension-#207): drop 'blob:' from worker-src CSP

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -62,6 +62,6 @@
     "matches": ["http://127.0.0.1:8765/*"]
   },
   "content_security_policy": {
-    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; worker-src 'self' blob:; object-src 'self'"
+    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; worker-src 'self'; object-src 'self'"
   }
 }


### PR DESCRIPTION
## Summary

Recent Chrome MV3 rejects `blob:` in `worker-src` as an Insecure CSP value, blocking the unpacked-extension load entirely (verified locally via screen recording at `/Users/node3/Documents/projects/HoneyLLM/docs/Recordings/Screen Recording 2026-05-01 at 7.28.45 pm.mov`).

## Root cause

`manifest.json` line 65 has `worker-src 'self' blob:`. This was added in `7befb1d` (2026-04-16) so ONNX runtime could spawn its WASM proxy worker via a blob URL when transformers.js was loaded as a Vite-bundled inline import.

Since #156 (`4e2a2c1`), transformers.js loads via a prebuilt browser bundle copied to `dist/transformers/` and `import()`-ed by `chrome.runtime.getURL`. `scriptSrc` is now `chrome-extension://<id>/dist/transformers/transformers.web.min.js` — same-origin with the offscreen doc.

In `onnxruntime-web/dist/ort.mjs` (`importProxyWorker`):

```js
if (isSameOrigin(scriptSrc)) {
  return [void 0, createProxyWorker()];   // no blob URL needed
}
const url = await preload(scriptSrc);     // blob URL only when cross-origin
```

The pthread worker (`ort-wasm-simd-threaded.mjs`) is only spawned when `numThreads > 1`. We set `wasm.numThreads = 1` in `src/offscreen/transformers-runtime.ts`, so that path is dead.

## Fix

One-line CSP change: `worker-src 'self' blob:` → `worker-src 'self'`. Any worker ORT spawns loads from the extension origin via its module URL.

## Validation

- [x] `npm run typecheck` clean
- [x] `npm test` — 1431 / 1431 passing
- [x] `npm run build` clean
- [x] `npm audit` — 0 vulnerabilities
- [ ] Maintainer reload: load `dist/` unpacked in Chrome — confirm manifest now accepted; confirm NER (#156) and embeddings (#129) hunters still produce verdicts on a known-injection honeypot.

## Unblocks

- Item 9 Stage 4G.5 — Nano image smoke sweep (#9)
- Item 8 Stage 6 — client-side embeddings popup smoke (#129)
- Item 7 Stage 6 — client-side MCP smoke (#124)

## Out of scope

- Updating `@huggingface/transformers` or `onnxruntime-web` versions
- Migrating off transformers.js entirely
- If ORT does spawn a worker that needs `blob:` in some edge path we haven't traced, follow-up: ship a static proxy worker via `web_accessible_resources` and override `scriptSrc`. Empirical maintainer smoke will surface this if needed.

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)