### PR TITLE
fix(extension-#209): resolve onnxruntime-web/webgpu via import map

### DIFF
--- a/scripts/build-assets.ts
+++ b/scripts/build-assets.ts
@@ -30,6 +30,15 @@ export const BUILD_ASSETS: readonly AssetPair[] = [
     'node_modules/@huggingface/transformers/dist/ort-wasm-simd-threaded.jsep.mjs',
     'dist/transformers/ort-wasm-simd-threaded.jsep.mjs',
   ],
+  // Issue #209 — `transformers.web.min.js` contains an unconditional static
+  // `import * as cA from "onnxruntime-web/webgpu"` that fires at module
+  // evaluation time regardless of `device: 'wasm'`. Browsers can only
+  // resolve bare specifiers via an import map; `offscreen.html` declares
+  // one mapping `onnxruntime-web/webgpu` to the asset copied here.
+  [
+    'node_modules/onnxruntime-web/dist/ort.webgpu.bundle.min.mjs',
+    'dist/transformers/onnxruntime-web/webgpu.mjs',
+  ],
   ['registry/signed-registry.json', 'dist/registry/signed-registry.json'],
   // Issue #129 Stage 3 — multilingual injection corpus with 384-dim
   // L2-normalised embeddings (schema v2). Copied verbatim into the dist

--- a/src/offscreen/offscreen.html
+++ b/src/offscreen/offscreen.html
@@ -3,6 +3,13 @@
 <head>
   <meta charset="utf-8">
   <title>HoneyLLM Offscreen</title>
+  <script type="importmap">
+  {
+    "imports": {
+      "onnxruntime-web/webgpu": "../transformers/onnxruntime-web/webgpu.mjs"
+    }
+  }
+  </script>
 </head>
 <body>
   <script type="module" src="index.js"></script>


### PR DESCRIPTION
## Summary

\`@huggingface/transformers\` v4.2.0's \`transformers.web.min.js\` contains an unconditional static \`import * as cA from "onnxruntime-web/webgpu"\` that fires at module-evaluation time regardless of \`device: 'wasm'\`. Without an import map, every NER (#156) and embeddings (#129) pipeline init throws \`Failed to resolve module specifier "onnxruntime-web/webgpu"\` and both ML hunters fall back to no-op — verdicts still produced by Spider/Hawk but two-thirds of the Hunter layer is silently dark.

Verified via offscreen-doc devtools after #208 (CSP fix) merged:
- WebGPU adapter mode: core (Apple Metal-3) — transformers detects WebGPU, attempts the bare-specifier import, throws
- Every page produces \`[NerEngine] WARN: NER pipeline init failed\` and \`[EmbeddingEngine] WARN: Embedder pipeline init failed\`

## Fix

Two-piece change:

1. **\`scripts/build-assets.ts\`** — copy \`node_modules/onnxruntime-web/dist/ort.webgpu.bundle.min.mjs\` (112,901 bytes; WASM inlined) to \`dist/transformers/onnxruntime-web/webgpu.mjs\` at build time.
2. **\`src/offscreen/offscreen.html\`** — declare an import map mapping \`onnxruntime-web/webgpu\` → \`../transformers/onnxruntime-web/webgpu.mjs\` (relative from the post-build location \`dist/offscreen/offscreen.html\`).

The bare specifier now resolves to a real module. Transformers loads cleanly. \`device: 'wasm'\` (unchanged at \`ner-engine.ts:15\` and \`embedding-engine.ts:20\`) continues to pin actual inference to the WASM backend — this PR does NOT flip ML execution to GPU.

## Validation

- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 1431 / 1431 passing
- [x] \`npm run build\` clean
- [x] Build asset copied to \`dist/transformers/onnxruntime-web/webgpu.mjs\` (112,901 bytes)
- [x] \`dist/offscreen/offscreen.html\` contains the import map post-build
- [x] \`npm audit\` — 0 vulnerabilities
- [ ] Maintainer reload: \`npm run build\` then reload unpacked in Chrome → confirm no "Failed to resolve module specifier" warnings on page analysis; confirm NER hunter produces PER/LOC/ORG findings on a real page; confirm embeddings hunter matches the corpus on a known-injection honeypot.

## dist/ size delta

+112,901 bytes (one bundle copy). Phase 2 byte-locked baseline untouched.

## Out of scope

- Updating @huggingface/transformers or onnxruntime-web versions
- Migrating off transformers.js entirely
- Issue #210 (chunk cap applied at wrong layer) — separate redesign

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)