### PR TITLE
fix(extension-#209): use external import map to satisfy MV3 inline-script CSP

### DIFF
--- a/scripts/build-assets.ts
+++ b/scripts/build-assets.ts
@@ -20,6 +20,14 @@ export type AssetPair = readonly [src: string, dest: string];
 // `src/offscreen/transformers-runtime.ts`.
 export const BUILD_ASSETS: readonly AssetPair[] = [
   ['src/offscreen/offscreen.html', 'dist/offscreen/offscreen.html'],
+  // Issue #209 follow-up — external import map referenced by `offscreen.html`
+  // mapping `onnxruntime-web/webgpu` (the bare specifier the transformers.js
+  // bundle imports unconditionally) to the local copy under
+  // `dist/transformers/onnxruntime-web/webgpu.mjs`. Inline import maps would
+  // be cleaner but MV3 `script-src 'self' 'wasm-unsafe-eval'` rejects inline
+  // <script> tags; external src= is allowed. Chrome 134+ implements external
+  // import maps per the HTML spec.
+  ['src/offscreen/importmap.json', 'dist/offscreen/importmap.json'],
   ['src/popup/popup.html', 'dist/popup/popup.html'],
   ['src/tests/phase3/builtin-harness.html', 'dist/tests/phase3/builtin-harness.html'],
   [

--- a/src/offscreen/importmap.json
+++ b/src/offscreen/importmap.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "onnxruntime-web/webgpu": "../transformers/onnxruntime-web/webgpu.mjs"
+  }
+}

--- a/src/offscreen/offscreen.html
+++ b/src/offscreen/offscreen.html
@@ -3,13 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>HoneyLLM Offscreen</title>
-  <script type="importmap">
-  {
-    "imports": {
-      "onnxruntime-web/webgpu": "../transformers/onnxruntime-web/webgpu.mjs"
-    }
-  }
-  </script>
+  <script type="importmap" src="./importmap.json"></script>
 </head>
 <body>
   <script type="module" src="index.js"></script>


### PR DESCRIPTION
## Summary

PR #211 added an inline \`<script type=\"importmap\">{...}</script>\` to \`offscreen.html\`. Maintainer reload surfaced that MV3's \`script-src 'self' 'wasm-unsafe-eval'\` directive rejects ALL inline scripts (including \`type=\"importmap\"\`):

\`\`\`
offscreen.html:6 Executing inline script violates the following Content Security Policy directive 'script-src 'self' 'wasm-unsafe-eval''.
\`\`\`

The import map is blocked before any module evaluates → the original \`Failed to resolve module specifier \"onnxruntime-web/webgpu\"\` error reappears identically. NER + embeddings hunters still dark.

## Fix

External import map: move JSON to \`src/offscreen/importmap.json\` (copied to \`dist/offscreen/importmap.json\` at build time) and reference via \`<script type=\"importmap\" src=\"./importmap.json\"></script>\`. External src is treated as a same-origin script source allowed under \`script-src 'self'\` — no CSP changes needed.

Chrome 134+ implements external import maps per the HTML spec. Relative paths inside the import map resolve relative to the import-map URL itself, so \`onnxruntime-web/webgpu → ../transformers/onnxruntime-web/webgpu.mjs\` continues to resolve to \`dist/transformers/onnxruntime-web/webgpu.mjs\` post-build.

## Validation

- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 1431 / 1431 passing
- [x] \`npm run build\` clean
- [x] \`dist/offscreen/importmap.json\` present (98 bytes)
- [x] \`dist/offscreen/offscreen.html\` references external map
- [ ] Maintainer reload: \`npm run build\` then reload unpacked in Chrome → confirm no inline-CSP error AND no \"Failed to resolve module specifier\" warning

## Out of scope

- Hash-based CSP (alternate fallback if external import maps aren't available; rejected here as brittle to whitespace changes)
- Issue #210 (chunk cap at wrong layer)

Refs #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)