### PR TITLE
fix(extension-#209): patch transformers bundle bare specifier at build time

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -2,7 +2,7 @@ import { build } from 'vite';
 import { resolve } from 'path';
 import { existsSync, rmSync } from 'fs';
 
-import { BUILD_ASSETS, copyBuildAssets } from './scripts/build-assets.js';
+import { BUILD_ASSETS, copyBuildAssets, patchTransformersBundle } from './scripts/build-assets.js';
 
 // Issue #156 — @huggingface/transformers ships a prebuilt minified browser
 // ESM bundle at `dist/transformers.web.min.js` (~432 KB). We mark the
@@ -96,6 +96,13 @@ async function main() {
 
   if (releaseMode) {
     console.log('[build] release mode active — registry hard-gate enforced.');
+  }
+
+  // Issue #209 — rewrite the bare specifier `"onnxruntime-web/webgpu"` in the
+  // copied transformers bundle to a relative URL the offscreen doc can
+  // resolve. See patchTransformersBundle for full rationale.
+  if (patchTransformersBundle(__dirname)) {
+    console.log('[build] patched transformers bundle bare specifier (issue #209)');
   }
 
   console.log('Build complete.');

--- a/scripts/__tests__/build-assets.test.ts
+++ b/scripts/__tests__/build-assets.test.ts
@@ -11,6 +11,7 @@ import {
   BUILD_ASSETS,
   RELEASE_REQUIRED_SOURCES,
   copyBuildAssets,
+  patchTransformersBundle,
 } from '../build-assets.js';
 import { signRegistryFromDir } from '../sign-registry.js';
 import { bytesToHex } from '@/registry/canonical-bundle.js';
@@ -192,5 +193,71 @@ describe('signRegistryFromDir against committed registry/sites/', () => {
     // choice (e)). Future SR-E maintainer / CI signing reuses this contract.
     const sorted = [...bundle.entries.map((e) => e.origin)].sort();
     expect(bundle.entries.map((e) => e.origin)).toEqual(sorted);
+  });
+});
+
+// Issue #209 — verify the bundle-patch helper rewrites the bare specifier
+// exactly once and refuses to silently mutate a bundle whose shape changed.
+describe('patchTransformersBundle', () => {
+  let tmp: string;
+
+  beforeEach(async () => {
+    tmp = await mkdtemp(join(tmpdir(), 'issue-209-bundle-patch-'));
+    await mkdir(join(tmp, 'dist', 'transformers'), { recursive: true });
+  });
+  afterEach(async () => {
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  const BUNDLE_REL = 'dist/transformers/transformers.web.min.js';
+
+  it('rewrites the bare specifier to a relative URL', async () => {
+    const before = `prefix;import*as cA from"onnxruntime-web/webgpu";async function B(){}`;
+    await writeFile(join(tmp, BUNDLE_REL), before);
+
+    const patched = patchTransformersBundle(tmp);
+
+    expect(patched).toBe(true);
+    const after = await readFile(join(tmp, BUNDLE_REL), 'utf-8');
+    expect(after).toContain('"./onnxruntime-web/webgpu.mjs"');
+    expect(after).not.toContain('"onnxruntime-web/webgpu"');
+  });
+
+  it('returns false (no-op) when the bundle is missing', () => {
+    expect(patchTransformersBundle(tmp)).toBe(false);
+  });
+
+  it('returns false (no-op) when the bare specifier is absent (already-patched bundle)', async () => {
+    const alreadyPatched = `prefix;import*as cA from"./onnxruntime-web/webgpu.mjs";async function B(){}`;
+    await writeFile(join(tmp, BUNDLE_REL), alreadyPatched);
+
+    const patched = patchTransformersBundle(tmp);
+
+    expect(patched).toBe(false);
+    const after = await readFile(join(tmp, BUNDLE_REL), 'utf-8');
+    expect(after).toBe(alreadyPatched);
+  });
+
+  it('throws when the bare specifier appears more than once (bundle shape changed)', async () => {
+    const ambiguous = `import"onnxruntime-web/webgpu";import"onnxruntime-web/webgpu";`;
+    await writeFile(join(tmp, BUNDLE_REL), ambiguous);
+
+    expect(() => patchTransformersBundle(tmp)).toThrow(
+      /expected exactly 1 occurrence/,
+    );
+  });
+
+  it('preserves the rest of the bundle byte-for-byte', async () => {
+    const lhs = 'a'.repeat(1000);
+    const rhs = 'b'.repeat(1000);
+    const before = `${lhs}"onnxruntime-web/webgpu"${rhs}`;
+    await writeFile(join(tmp, BUNDLE_REL), before);
+
+    patchTransformersBundle(tmp);
+
+    const after = await readFile(join(tmp, BUNDLE_REL), 'utf-8');
+    expect(after.startsWith(lhs)).toBe(true);
+    expect(after.endsWith(rhs)).toBe(true);
+    expect(after.length).toBe(before.length + ('"./onnxruntime-web/webgpu.mjs"'.length - '"onnxruntime-web/webgpu"'.length));
   });
 });

--- a/scripts/build-assets.ts
+++ b/scripts/build-assets.ts
@@ -1,7 +1,7 @@
 // Pure asset-copy helpers + manifest used by build.ts. Lives in scripts/ so
 // tests can import without pulling in Vite's loader chain (which would drag
 // esbuild into the jsdom test environment and fail to initialise).
-import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 
 export type AssetPair = readonly [src: string, dest: string];
@@ -20,14 +20,6 @@ export type AssetPair = readonly [src: string, dest: string];
 // `src/offscreen/transformers-runtime.ts`.
 export const BUILD_ASSETS: readonly AssetPair[] = [
   ['src/offscreen/offscreen.html', 'dist/offscreen/offscreen.html'],
-  // Issue #209 follow-up — external import map referenced by `offscreen.html`
-  // mapping `onnxruntime-web/webgpu` (the bare specifier the transformers.js
-  // bundle imports unconditionally) to the local copy under
-  // `dist/transformers/onnxruntime-web/webgpu.mjs`. Inline import maps would
-  // be cleaner but MV3 `script-src 'self' 'wasm-unsafe-eval'` rejects inline
-  // <script> tags; external src= is allowed. Chrome 134+ implements external
-  // import maps per the HTML spec.
-  ['src/offscreen/importmap.json', 'dist/offscreen/importmap.json'],
   ['src/popup/popup.html', 'dist/popup/popup.html'],
   ['src/tests/phase3/builtin-harness.html', 'dist/tests/phase3/builtin-harness.html'],
   [
@@ -71,6 +63,36 @@ export interface CopyBuildAssetsOptions {
   readonly projectRoot?: string;
   readonly onSkip?: (src: string) => void;
   readonly releaseMode?: boolean;
+}
+
+// Issue #209 — `transformers.web.min.js` contains an unconditional static
+// `import * as cA from "onnxruntime-web/webgpu"`. Bare specifiers cannot be
+// resolved by browser ES module loaders without an import map, and Chrome
+// MV3's `script-src 'self' 'wasm-unsafe-eval'` rejects inline import maps
+// while external import maps are not yet implemented in any browser
+// (WICG/import-maps#235, archived 2025-02-26). Patch the bundle in place
+// after copy: rewrite the bare specifier to a relative URL pointing at the
+// onnxruntime-web webgpu bundle we already copy alongside it. This is the
+// standard MV3 + transformers.js workaround used by other extensions that
+// don't go through a webpack/Vite bundle re-pass.
+const TRANSFORMERS_BUNDLE_DEST = 'dist/transformers/transformers.web.min.js';
+const ONNX_BARE_SPECIFIER = '"onnxruntime-web/webgpu"';
+const ONNX_RELATIVE_URL = '"./onnxruntime-web/webgpu.mjs"';
+
+export function patchTransformersBundle(projectRoot: string): boolean {
+  const path = resolve(projectRoot, TRANSFORMERS_BUNDLE_DEST);
+  if (!existsSync(path)) return false;
+  const before = readFileSync(path, 'utf-8');
+  const occurrences = before.split(ONNX_BARE_SPECIFIER).length - 1;
+  if (occurrences === 0) return false;
+  if (occurrences > 1) {
+    throw new Error(
+      `patchTransformersBundle: expected exactly 1 occurrence of ${ONNX_BARE_SPECIFIER} in ${TRANSFORMERS_BUNDLE_DEST}, found ${occurrences} — bundle shape changed; review the patch before continuing`,
+    );
+  }
+  const after = before.replace(ONNX_BARE_SPECIFIER, ONNX_RELATIVE_URL);
+  writeFileSync(path, after);
+  return true;
 }
 
 export function copyBuildAssets(

--- a/src/offscreen/importmap.json
+++ b/src/offscreen/importmap.json
@@ -1,5 +1,0 @@
-{
-  "imports": {
-    "onnxruntime-web/webgpu": "../transformers/onnxruntime-web/webgpu.mjs"
-  }
-}

--- a/src/offscreen/offscreen.html
+++ b/src/offscreen/offscreen.html
@@ -3,7 +3,6 @@
 <head>
   <meta charset="utf-8">
   <title>HoneyLLM Offscreen</title>
-  <script type="importmap" src="./importmap.json"></script>
 </head>
 <body>
   <script type="module" src="index.js"></script>


### PR DESCRIPTION
## Summary

PRs #211 + #212 attempted to fix the bare-specifier import via inline then external import maps; **both failed**. After research:

- **Inline import maps** violate MV3 \`script-src 'self' 'wasm-unsafe-eval'\` (no \`'unsafe-inline'\` allowed).
- **External import maps** are an unimplemented WICG proposal ([WICG/import-maps#235](https://github.com/WICG/import-maps/issues/235), archived 2025-02-26 without ship). Chrome silently ignores \`<script type=\"importmap\" src=\"...\">\` with the console message "External import maps are not yet supported". My PR #212 description's claim that "Chrome 134+ implements external import maps per the HTML spec" was incorrect — the proposal never advanced past WICG.

Apologies for the wasted review cycles on #211/#212. Owed.

## Fix

The standard MV3 + transformers.js workaround: rewrite the bare specifier in the copied bundle to a relative URL the offscreen doc can resolve.

New \`patchTransformersBundle(projectRoot)\` in \`scripts/build-assets.ts\`:
- Reads \`dist/transformers/transformers.web.min.js\` after \`copyBuildAssets\` runs
- Asserts the bare specifier \`\"onnxruntime-web/webgpu\"\` appears **exactly once** (verified via \`grep -c\` on the v4.2.0 bundle). A bundle shape change fails loud rather than silently mutating the wrong byte.
- Rewrites it to \`\"./onnxruntime-web/webgpu.mjs\"\` — pointing at the \`ort.webgpu.bundle.min.mjs\` we already copy alongside the bundle (PR #211's asset-copy half — that part was correct).

\`build.ts\` calls the helper after \`copyBuildAssets\` and logs \`[build] patched transformers bundle bare specifier (issue #209)\` so the patch is visible in build output.

## Reverts dead import-map plumbing

- Deletes \`src/offscreen/importmap.json\` and its \`BUILD_ASSETS\` entry
- Removes \`<script type=\"importmap\" src=\"./importmap.json\">\` from \`offscreen.html\`

The \`dist/transformers/onnxruntime-web/webgpu.mjs\` asset copy stays — that's what the patched bundle now imports relatively.

## Validation

- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 1431 → **1436** (+5: rewrite / missing-bundle no-op / already-patched no-op / ambiguous-occurrence throws / byte-preserving)
- [x] \`npm run build\` logs \`[build] patched transformers bundle bare specifier (issue #209)\`
- [x] \`grep '\"onnxruntime-web/webgpu\"' dist/transformers/transformers.web.min.js\` → 0 (specifier replaced)
- [x] \`grep '\"./onnxruntime-web/webgpu.mjs\"' dist/transformers/transformers.web.min.js\` → 1 (relative URL present)
- [x] \`npm audit\` — 0 vulnerabilities
- [ ] **Maintainer reload**: \`npm run build\` then reload unpacked in Chrome → confirm no \`Failed to resolve module specifier\` warning; NER pipeline produces PER/LOC/ORG findings; embeddings hunter matches corpus on a known-injection honeypot; renderer memory does not balloon.

## Likely also fixes runaway memory

Per offscreen-doc devtools observation: renderer process at ~16 GB memory use. Each failed \`pipeline()\` init currently re-fires once per chunk (\`embedderInitPromise\` clears in \`finally\` → no failure caching → fresh transformers re-import and tensor allocation per attempt). With init succeeding, the singleflight cache holds and the allocation source closes.

## Sources for the import-map status

- [WICG/import-maps#235 — External import maps support (archived without ship)](https://github.com/WICG/import-maps/issues/235)
- [MDN: \`<script type=\"importmap\">\` — \`src\` attribute "must not be specified"](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script/type/importmap)
- [transformers.js#986 — bare specifier resolution workaround](https://github.com/huggingface/transformers.js/issues/986)
- [Vprprudhvi: Running Transformers.js inside a Chrome extension MV3 — practical patch](https://medium.com/@vprprudhvi/running-transformers-js-inside-a-chrome-extension-manifest-v3-a-practical-patch-d7ce4d6a0eac)

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)