### PR TITLE
fix(extension-#209): also patch onnxruntime-common bare specifier

### DIFF
--- a/scripts/__tests__/build-assets.test.ts
+++ b/scripts/__tests__/build-assets.test.ts
@@ -211,7 +211,7 @@ describe('patchTransformersBundle', () => {
 
   const BUNDLE_REL = 'dist/transformers/transformers.web.min.js';
 
-  it('rewrites the bare specifier to a relative URL', async () => {
+  it('rewrites the webgpu bare specifier to a relative URL', async () => {
     const before = `prefix;import*as cA from"onnxruntime-web/webgpu";async function B(){}`;
     await writeFile(join(tmp, BUNDLE_REL), before);
 
@@ -221,6 +221,32 @@ describe('patchTransformersBundle', () => {
     const after = await readFile(join(tmp, BUNDLE_REL), 'utf-8');
     expect(after).toContain('"./onnxruntime-web/webgpu.mjs"');
     expect(after).not.toContain('"onnxruntime-web/webgpu"');
+  });
+
+  it('also rewrites the onnxruntime-common bare specifier to the same webgpu bundle (Tensor re-export)', async () => {
+    const before = `prefix;import{Tensor as Q0}from"onnxruntime-common";suffix`;
+    await writeFile(join(tmp, BUNDLE_REL), before);
+
+    const patched = patchTransformersBundle(tmp);
+
+    expect(patched).toBe(true);
+    const after = await readFile(join(tmp, BUNDLE_REL), 'utf-8');
+    expect(after).toContain('"./onnxruntime-web/webgpu.mjs"');
+    expect(after).not.toContain('"onnxruntime-common"');
+  });
+
+  it('rewrites both bare specifiers in a single pass when both are present', async () => {
+    const before = `prefix;import*as cA from"onnxruntime-web/webgpu";middle;import{Tensor as Q0}from"onnxruntime-common";suffix`;
+    await writeFile(join(tmp, BUNDLE_REL), before);
+
+    const patched = patchTransformersBundle(tmp);
+
+    expect(patched).toBe(true);
+    const after = await readFile(join(tmp, BUNDLE_REL), 'utf-8');
+    expect(after).not.toContain('"onnxruntime-web/webgpu"');
+    expect(after).not.toContain('"onnxruntime-common"');
+    // Both imports now point at the webgpu bundle (browsers dedupe module loads).
+    expect(after.split('"./onnxruntime-web/webgpu.mjs"').length - 1).toBe(2);
   });
 
   it('returns false (no-op) when the bundle is missing', () => {
@@ -243,7 +269,7 @@ describe('patchTransformersBundle', () => {
     await writeFile(join(tmp, BUNDLE_REL), ambiguous);
 
     expect(() => patchTransformersBundle(tmp)).toThrow(
-      /expected exactly 1 occurrence/,
+      /expected at most 1 occurrence/,
     );
   });
 

--- a/scripts/build-assets.ts
+++ b/scripts/build-assets.ts
@@ -65,32 +65,44 @@ export interface CopyBuildAssetsOptions {
   readonly releaseMode?: boolean;
 }
 
-// Issue #209 — `transformers.web.min.js` contains an unconditional static
-// `import * as cA from "onnxruntime-web/webgpu"`. Bare specifiers cannot be
+// Issue #209 — `transformers.web.min.js` contains TWO unconditional static
+// imports with bare specifiers: `import * as cA from "onnxruntime-web/webgpu"`
+// (the webgpu backend module) and `import { Tensor as Q0 } from
+// "onnxruntime-common"` (the Tensor class). Bare specifiers cannot be
 // resolved by browser ES module loaders without an import map, and Chrome
 // MV3's `script-src 'self' 'wasm-unsafe-eval'` rejects inline import maps
 // while external import maps are not yet implemented in any browser
 // (WICG/import-maps#235, archived 2025-02-26). Patch the bundle in place
-// after copy: rewrite the bare specifier to a relative URL pointing at the
-// onnxruntime-web webgpu bundle we already copy alongside it. This is the
+// after copy: rewrite each bare specifier to a relative URL pointing at the
+// onnxruntime-web webgpu bundle we already copy alongside it. The webgpu
+// bundle re-exports `Tensor`, so both imports can resolve to the same file
+// (browsers dedupe module loads — no second asset required). This is the
 // standard MV3 + transformers.js workaround used by other extensions that
 // don't go through a webpack/Vite bundle re-pass.
 const TRANSFORMERS_BUNDLE_DEST = 'dist/transformers/transformers.web.min.js';
-const ONNX_BARE_SPECIFIER = '"onnxruntime-web/webgpu"';
-const ONNX_RELATIVE_URL = '"./onnxruntime-web/webgpu.mjs"';
+const ONNX_BARE_SPECIFIER_REWRITES: ReadonlyArray<readonly [from: string, to: string]> = [
+  ['"onnxruntime-web/webgpu"', '"./onnxruntime-web/webgpu.mjs"'],
+  ['"onnxruntime-common"', '"./onnxruntime-web/webgpu.mjs"'],
+];
 
 export function patchTransformersBundle(projectRoot: string): boolean {
   const path = resolve(projectRoot, TRANSFORMERS_BUNDLE_DEST);
   if (!existsSync(path)) return false;
   const before = readFileSync(path, 'utf-8');
-  const occurrences = before.split(ONNX_BARE_SPECIFIER).length - 1;
-  if (occurrences === 0) return false;
-  if (occurrences > 1) {
-    throw new Error(
-      `patchTransformersBundle: expected exactly 1 occurrence of ${ONNX_BARE_SPECIFIER} in ${TRANSFORMERS_BUNDLE_DEST}, found ${occurrences} — bundle shape changed; review the patch before continuing`,
-    );
+  let after = before;
+  let didReplace = false;
+  for (const [fromSpec, toSpec] of ONNX_BARE_SPECIFIER_REWRITES) {
+    const occurrences = after.split(fromSpec).length - 1;
+    if (occurrences === 0) continue;
+    if (occurrences > 1) {
+      throw new Error(
+        `patchTransformersBundle: expected at most 1 occurrence of ${fromSpec} in ${TRANSFORMERS_BUNDLE_DEST}, found ${occurrences} — bundle shape changed; review the patch before continuing`,
+      );
+    }
+    after = after.replace(fromSpec, toSpec);
+    didReplace = true;
   }
-  const after = before.replace(ONNX_BARE_SPECIFIER, ONNX_RELATIVE_URL);
+  if (!didReplace) return false;
   writeFileSync(path, after);
   return true;
 }


### PR DESCRIPTION
## Summary

PR #213 patched \`\"onnxruntime-web/webgpu\"\` but the transformers v4.2.0 bundle also imports \`Tensor\` from a second bare specifier:

\`\`\`js
import { Tensor as Q0 } from \"onnxruntime-common\";
\`\`\`

That import still fired after #213, surfacing as \`Failed to resolve module specifier \"onnxruntime-common\"\` (verified by maintainer reload — the original webgpu specifier no longer errors, this new one does). NER + embeddings pipelines still fail to init, which keeps the per-chunk re-init / re-allocation cycle running and the renderer memory leaking (now ~7 GB visible vs 16 GB before).

## Fix

Extend \`patchTransformersBundle\` from one rewrite to a list of rewrites. Both bare specifiers point at the same \`dist/transformers/onnxruntime-web/webgpu.mjs\` — that bundle re-exports \`Tensor\` (\`Le as Tensor\` in its trailing \`export {…}\` block), so the single asset satisfies both imports. Browsers dedupe module loads so the second import is essentially free.

Each rewrite still asserts **at most 1** occurrence so a future bundle shape change fails loud rather than silently mutating the wrong byte. Threshold-error wording adjusted from \"exactly 1\" to \"at most 1\" since the no-occurrence case is now valid (already-patched bundle on a re-run).

## Validation

- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 1436 → **1438** (+2: \`onnxruntime-common\` rewrite + both-present single-pass)
- [x] \`npm run build\` logs \`[build] patched transformers bundle bare specifier (issue #209)\`
- [x] \`grep -o '\"onnxruntime-web/webgpu\"' dist/.../transformers.web.min.js | wc -l\` → 0
- [x] \`grep -o '\"onnxruntime-common\"' dist/.../transformers.web.min.js | wc -l\` → 0
- [x] \`grep -o '\"./onnxruntime-web/webgpu.mjs\"' dist/.../transformers.web.min.js | wc -l\` → 2 (both imports redirected)
- [x] \`npm audit\` — 0 vulnerabilities
- [ ] **Maintainer reload**: \`npm run build\` then reload unpacked → confirm no \"Failed to resolve module specifier\" warnings of any kind; NER + embeddings hunters produce findings; renderer memory plateaus rather than growing.

## Why path-A (re-export from webgpu bundle) over path-B (ship onnxruntime-common as separate asset)

Single named import (\`Tensor\`), already exposed by the webgpu bundle's trailing export list. Shipping a second asset would require copying the multi-file ESM directory \`node_modules/onnxruntime-common/dist/esm/\` and figuring out which entry point to point the rewrite at — extra surface for the same payload the browser would dedupe to 1 module evaluation anyway.

If a future transformers update imports more from \`onnxruntime-common\` than just \`Tensor\` and the webgpu bundle's re-export set doesn't cover it, the patch fails with \"named export not found\" at module-evaluation time — loud rather than silent. We re-evaluate at that point.

Refs #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)