### PR TITLE
fix(extension-#209): override ORT wasm paths + switch NER to bert-base-NER

### DIFF
--- a/scripts/build-assets.ts
+++ b/scripts/build-assets.ts
@@ -39,6 +39,18 @@ export const BUILD_ASSETS: readonly AssetPair[] = [
     'node_modules/onnxruntime-web/dist/ort.webgpu.bundle.min.mjs',
     'dist/transformers/onnxruntime-web/webgpu.mjs',
   ],
+  // Issue #209 — Chrome (non-Safari) ORT wasm path defaults to the asyncify
+  // variant; ship both the JS factory and the WASM binary same-origin so
+  // `env.backends.onnx.wasm.wasmPaths` (set in transformers-runtime.ts) can
+  // resolve them under MV3 `script-src 'self'` without a CDN fetch.
+  [
+    'node_modules/onnxruntime-web/dist/ort-wasm-simd-threaded.asyncify.mjs',
+    'dist/transformers/onnxruntime-web/ort-wasm-simd-threaded.asyncify.mjs',
+  ],
+  [
+    'node_modules/onnxruntime-web/dist/ort-wasm-simd-threaded.asyncify.wasm',
+    'dist/transformers/onnxruntime-web/ort-wasm-simd-threaded.asyncify.wasm',
+  ],
   ['registry/signed-registry.json', 'dist/registry/signed-registry.json'],
   // Issue #129 Stage 3 — multilingual injection corpus with 384-dim
   // L2-normalised embeddings (schema v2). Copied verbatim into the dist

--- a/src/offscreen/ner-engine.ts
+++ b/src/offscreen/ner-engine.ts
@@ -11,7 +11,13 @@ const log = createLogger('NerEngine');
  * explicitly so an upstream default change doesn't silently degrade us to
  * fp32.
  */
-const NER_MODEL_ID = 'Xenova/distilbert-base-NER';
+// Issue #209 — `Xenova/distilbert-base-NER` is now gated / no longer publicly
+// resolvable from `huggingface.co/Xenova/...` and returns 404 to anonymous
+// extension fetches. `Xenova/bert-base-NER` is the closest publicly-available
+// ONNX-converted NER model on the same Hub namespace; same task signature
+// (token-classification with PER/LOC/ORG/MISC labels), slightly larger model
+// (~110 MB q8 vs ~65 MB), comparable accuracy on English NER.
+const NER_MODEL_ID = 'Xenova/bert-base-NER';
 const NER_DEVICE = 'wasm' as const;
 const NER_DTYPE = 'q8' as const;
 const NER_AGGREGATION = 'simple' as const;

--- a/src/offscreen/transformers-runtime.ts
+++ b/src/offscreen/transformers-runtime.ts
@@ -43,10 +43,19 @@ export async function loadTransformers(): Promise<TransformersModule> {
           const wasm = mod.env.backends.onnx.wasm;
           if (wasm !== undefined) {
             wasm.numThreads = 1;
+            // Issue #209 — `ort.webgpu.bundle.min.mjs` defaults `wasmPaths`
+            // to `https://cdn.jsdelivr.net/npm/onnxruntime-web@<version>/dist/`
+            // which our MV3 `script-src 'self' 'wasm-unsafe-eval'` rejects
+            // as a cross-origin script source. Override the prefix to point
+            // at our locally-shipped copies under
+            // `dist/transformers/onnxruntime-web/` so the threaded asyncify
+            // module + WASM binary load same-origin.
+            const wasmPrefix = chrome.runtime.getURL('dist/transformers/onnxruntime-web/');
+            wasm.wasmPaths = wasmPrefix;
           }
           envConfigured = true;
         } catch (err) {
-          log.warn('failed to set ONNX wasm numThreads', err);
+          log.warn('failed to set ONNX wasm config', err);
         }
       }
       cachedModule = mod;


### PR DESCRIPTION
## Summary

PR #214 resolved both bare-specifier imports. Maintainer reload surfaced two new runtime failures, both addressed here:

### A. ORT WASM paths default to jsdelivr CDN — blocked by MV3 CSP

\`ort.webgpu.bundle.min.mjs\` sets \`Ce.wasm.wasmPaths\` to \`https://cdn.jsdelivr.net/npm/onnxruntime-web@<v>/dist/\` when the caller doesn't override it. MV3 \`script-src 'self' 'wasm-unsafe-eval'\` rejects the cross-origin script load:

\`\`\`
Loading the script 'https://cdn.jsdelivr.net/.../ort-wasm-simd-threaded.asyncify.mjs' violates the following CSP directive: \"script-src 'self' 'wasm-unsafe-eval'\".
Embedder pipeline init failed Error: no available backend found.
\`\`\`

**Fix:** override \`env.backends.onnx.wasm.wasmPaths\` in \`transformers-runtime.ts\` to a \`chrome.runtime.getURL('dist/transformers/onnxruntime-web/')\` prefix and ship the matching files as static assets:
- \`ort-wasm-simd-threaded.asyncify.mjs\` (~47 KB)
- \`ort-wasm-simd-threaded.asyncify.wasm\` (~23.6 MB)

### B. \`Xenova/distilbert-base-NER\` returns 404

Model is gated / no longer publicly resolvable from the Hub. Switch to \`Xenova/bert-base-NER\` — same Hub namespace, same token-classification task signature (PER/LOC/ORG/MISC labels), slightly larger (~110 MB q8 vs ~65 MB), comparable English-NER accuracy. Per memory's transformers-bundling pattern (\`project_transformersjs_bundling.md\`) model bytes lazy-fetch once and cache.

## Validation

- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 1438 / 1438 passing
- [x] \`npm run build\` logs \`[build] patched transformers bundle bare specifier (issue #209)\`
- [x] \`dist/transformers/onnxruntime-web/\` contains \`webgpu.mjs\`, \`ort-wasm-simd-threaded.asyncify.mjs\`, \`ort-wasm-simd-threaded.asyncify.wasm\`
- [x] \`dist/\` size: 9.8 MB → 33 MB (the asyncify WASM is the bulk)
- [x] \`npm audit\` — 0 vulnerabilities
- [ ] **Maintainer reload**: \`npm run build\` then reload unpacked → confirm no \"Failed to fetch dynamically imported module\" / \"no available backend\" / \"Could not locate file\" warnings; renderer memory plateaus.

## Why ship the asyncify variant rather than disable the WASM threaded path

The webgpu bundle's selection logic is hardcoded:

\`\`\`js
Ce.wasm.wasmPaths = K.IS_SAFARI ? {mjs:'…simd-threaded.mjs', wasm:'…simd-threaded.wasm'}
                                : {mjs:'…simd-threaded.asyncify.mjs', wasm:'…simd-threaded.asyncify.wasm'};
\`\`\`

Chrome takes the asyncify path. Setting \`numThreads = 1\` doesn't change which WASM file is fetched — only how the threading runtime behaves once loaded. Shipping the file is the only way to satisfy the loader without bundle-patching deeper.

Refs #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)