### PR TITLE
fix(extension-#210): move chunk cap from chunk-split to probe-dispatch

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -77,9 +77,8 @@ The core analysis pipeline:
 
 1. Receive `PAGE_SNAPSHOT` from content script
 2. Concatenate visible + hidden text
-3. Chunk into segments of `MAX_CHUNK_CHARS` (11,000) chars — sized for Gemma's 4096-token context window after accounting for system prompt + scaffolding
-4. Cap at `MAX_CHUNKS_PER_PAGE` (4) chunks (Phase 4 Stage 4B.1) — excess chunks are dropped and `analysisError: 'chunk_count_capped'` is stamped on the verdict
-5. For each chunk **sequentially** (not concurrently — Phase 4 Stage 4B.1), send `RUN_PROBES` to offscreen document and await results
+3. Chunk into segments of `MAX_CHUNK_CHARS` (11,000) chars — sized for Gemma's 4096-token context window after accounting for system prompt + scaffolding. Chunk count is **uncapped** at this layer (issue #210, restoring Phase 6 #127's chunk-cache architectural intent — every chunk gets hashed and feeds the IndexedDB cache so revisits dedupe across the whole page)
+4. For each chunk **sequentially** (not concurrently — Phase 4 Stage 4B.1), run Hunters first (Spider / Hawk / embeddings), feed results to the tier router, then dispatch `RUN_PROBES` only when the chunk routes non-BENIGN AND the per-page LLM probe budget (`MAX_PROBES_PER_PAGE` = 4) has not been exhausted. Non-BENIGN chunks beyond the budget are marked `notScanned: true` with their real Hunter-derived `tierRouting` preserved, and `analysisError: 'probe_count_capped'` is stamped on the verdict
 6. Collect `PROBE_RESULTS` + the `canaryId` the offscreen stamped (Phase 4 Stage 4D.3)
 7. Merge results — prefer non-errored chunk-runs; for non-errored results, keep highest score per probe name
 8. Aggregate `analysisError` across probes and chunks (Phase 4 Stage 4A)
@@ -340,7 +339,8 @@ All builds inline dependencies (no chunk splitting) and minify output.
 | `MAX_CHUNK_CHARS` | 11,000 | Text chunk size for probe input. Computed as `MAX_CHUNK_TOKENS × APPROX_CHARS_PER_TOKEN`. Reduced from 14000 in Phase 4F (`bd72857`) after Wikipedia-length prose overflowed Gemma's 4096-token context window. |
 | `MAX_CHUNK_TOKENS` | 2,750 | Token budget per chunk (leaves ~600–1000 tokens of headroom for system prompt + response) |
 | `APPROX_CHARS_PER_TOKEN` | 4 | Heuristic; Gemma's actual ratio is closer to 3.3–3.5 chars/token, factored into the 2,750 budget |
-| `MAX_CHUNKS_PER_PAGE` | 4 | Phase 4 Stage 4B.1 cap. Excess chunks dropped with `analysisError: 'chunk_count_capped'` on the verdict |
+| `MAX_PROBES_PER_PAGE` | 4 | Issue #210 — per-page LLM probe-dispatch budget (replaces the Phase 4 Stage 4B.1 chunk-split cap). Hunters still run on every chunk; only non-BENIGN chunks beyond the budget skip probe dispatch and surface `analysisError: 'probe_count_capped'` |
+| `MAX_CHUNKS_PER_PAGE` | 4 | Issue #210 transition alias for `MAX_PROBES_PER_PAGE`; kept for legacy import compatibility, no longer consulted by the orchestrator |
 | `MAX_VISIBLE_TEXT_CHARS` | 50,000 | Visible text extraction cap |
 | `MAX_HIDDEN_TEXT_CHARS` | 10,000 | Hidden text extraction cap |
 | `KEEPALIVE_ALARM_PERIOD_SECONDS` | 24 | Chrome alarm interval |

--- a/src/service-worker/orchestrator.integration.test.ts
+++ b/src/service-worker/orchestrator.integration.test.ts
@@ -436,6 +436,159 @@ function huntReportHawkOnlyNoActivations(): HuntReport {
   };
 }
 
+describe('analyzeSnapshot probe-cap layer (issue #210)', () => {
+  beforeEach(() => {
+    runHuntersMock.mockReset();
+    chunkTextMock.mockReset();
+    detectLanguageMock.mockReset();
+    detectLanguageMock.mockResolvedValue({ lang: 'und', confidence: 0, source: 'chrome-api' });
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  // Issue #210 — Hunters MUST cover the entire page. Phase 4 Stage 4B.1's
+  // chunk-split cap (MAX_CHUNKS_PER_PAGE) regressed Phase 6 #127's chunk-
+  // cache architectural intent on long pages: chunks ≥5 were never hashed
+  // and never entered the cache. With the cap moved to probe-dispatch,
+  // every chunk gets Hunter coverage and a real tierRouting.
+  it('runs Hunters on all chunks of a 6-chunk all-BENIGN page (no probe cap fires)', async () => {
+    const sixChunks = Array.from({ length: 6 }, (_, i) => buildChunk(i, `c${i}`));
+    chunkTextMock.mockResolvedValue(sixChunks);
+    runHuntersMock.mockResolvedValue(
+      buildHuntReport([
+        { name: 'spider', matched: false },
+        { name: 'hawk', matched: false },
+      ]),
+    );
+    const ctx = setupChrome([SAMPLE_PROBE_RESULT]);
+
+    const verdict = await analyzeSnapshot(210, snapshotFixture());
+
+    expect(runHuntersMock).toHaveBeenCalledTimes(6);
+    expect(ctx.runProbesCalls.length).toBe(0);
+    expect(verdict.perChunkAnalysis!.length).toBe(6);
+    expect(verdict.perChunkAnalysis!.every((c) => c.tierRouting.decision === 'BENIGN')).toBe(
+      true,
+    );
+    expect(verdict.perChunkAnalysis!.every((c) => c.notScanned !== true)).toBe(true);
+    expect(verdict.analysisError).toBeNull();
+  });
+
+  it('caps probe dispatch at MAX_PROBES_PER_PAGE on a 6-chunk all-FLAGGED page', async () => {
+    const sixChunks = Array.from({ length: 6 }, (_, i) => buildChunk(i, `c${i}`));
+    chunkTextMock.mockResolvedValue(sixChunks);
+    runHuntersMock.mockResolvedValue(
+      buildHuntReport([
+        { name: 'spider', matched: true },
+        { name: 'hawk', matched: true },
+      ]),
+    );
+    const ctx = setupChrome([SAMPLE_PROBE_RESULT]);
+
+    const verdict = await analyzeSnapshot(211, snapshotFixture());
+
+    // Hunters covered every chunk; probes dispatched on first 4 only.
+    expect(runHuntersMock).toHaveBeenCalledTimes(6);
+    expect(ctx.runProbesCalls.length).toBe(4);
+
+    // perChunkAnalysis still has all 6 entries; chunks 4-5 are notScanned.
+    expect(verdict.perChunkAnalysis!.length).toBe(6);
+    expect(verdict.perChunkAnalysis!.slice(0, 4).every((c) => c.probeResults !== null)).toBe(
+      true,
+    );
+    expect(verdict.perChunkAnalysis!.slice(4).every((c) => c.notScanned === true)).toBe(true);
+    expect(verdict.perChunkAnalysis!.slice(4).every((c) => c.probeResults === null)).toBe(true);
+
+    // probe_count_capped surfaces in the verdict's analysisError.
+    expect(verdict.analysisError).toContain('probe_count_capped');
+    expect(verdict.analysisError).toContain('2 flagged chunk(s) skipped');
+  });
+
+  it('mixed page (BENIGN + FLAGGED) consumes budget only on FLAGGED chunks', async () => {
+    const sixChunks = Array.from({ length: 6 }, (_, i) => buildChunk(i, `c${i}`));
+    chunkTextMock.mockResolvedValue(sixChunks);
+    // Pattern: B F B F B F → 3 probe dispatches, no cap.
+    runHuntersMock
+      .mockResolvedValueOnce(
+        buildHuntReport([
+          { name: 'spider', matched: false },
+          { name: 'hawk', matched: false },
+        ]),
+      )
+      .mockResolvedValueOnce(
+        buildHuntReport([
+          { name: 'spider', matched: true },
+          { name: 'hawk', matched: true },
+        ]),
+      )
+      .mockResolvedValueOnce(
+        buildHuntReport([
+          { name: 'spider', matched: false },
+          { name: 'hawk', matched: false },
+        ]),
+      )
+      .mockResolvedValueOnce(
+        buildHuntReport([
+          { name: 'spider', matched: true },
+          { name: 'hawk', matched: true },
+        ]),
+      )
+      .mockResolvedValueOnce(
+        buildHuntReport([
+          { name: 'spider', matched: false },
+          { name: 'hawk', matched: false },
+        ]),
+      )
+      .mockResolvedValueOnce(
+        buildHuntReport([
+          { name: 'spider', matched: true },
+          { name: 'hawk', matched: true },
+        ]),
+      );
+    const ctx = setupChrome([SAMPLE_PROBE_RESULT]);
+
+    const verdict = await analyzeSnapshot(212, snapshotFixture());
+
+    expect(runHuntersMock).toHaveBeenCalledTimes(6);
+    expect(ctx.runProbesCalls.length).toBe(3);
+    expect(verdict.perChunkAnalysis!.length).toBe(6);
+    expect(verdict.perChunkAnalysis!.every((c) => c.notScanned !== true)).toBe(true);
+    expect(verdict.analysisError).toBeNull();
+  });
+
+  it('5+ FLAGGED page: 4 probed + remainder notScanned with real Hunter tierRouting preserved', async () => {
+    const sevenChunks = Array.from({ length: 7 }, (_, i) => buildChunk(i, `c${i}`));
+    chunkTextMock.mockResolvedValue(sevenChunks);
+    runHuntersMock.mockResolvedValue(
+      buildHuntReport([
+        { name: 'spider', matched: true },
+        { name: 'hawk', matched: false },
+      ]),
+    );
+    const ctx = setupChrome([SAMPLE_PROBE_RESULT]);
+
+    const verdict = await analyzeSnapshot(213, snapshotFixture());
+
+    expect(ctx.runProbesCalls.length).toBe(4);
+    expect(verdict.perChunkAnalysis!.length).toBe(7);
+
+    // Chunks 4-6: notScanned, but tierRouting reflects this chunk's own
+    // Hunter result (UNCERTAIN here because spider matched, hawk didn't).
+    // Contrast with #145 early-exit padding which reuses the trigger
+    // chunk's tierRouting because Hunters never ran on padded chunks.
+    for (let i = 4; i < 7; i += 1) {
+      const entry = verdict.perChunkAnalysis![i]!;
+      expect(entry.notScanned).toBe(true);
+      expect(entry.tierRouting.decision).toBe('UNCERTAIN');
+      expect(entry.contentHash).toBe(sevenChunks[i]!.contentHash);
+    }
+
+    expect(verdict.analysisError).toContain('probe_count_capped');
+    expect(verdict.analysisError).toContain('3 flagged chunk(s) skipped');
+  });
+});
+
 describe('analyzeSnapshot evidence-packet routing (issue #118)', () => {
   beforeEach(() => {
     runHuntersMock.mockReset();

--- a/src/service-worker/orchestrator.test.ts
+++ b/src/service-worker/orchestrator.test.ts
@@ -38,15 +38,19 @@ describe('mergeErrors (Phase 4 Stage 4B)', () => {
   });
 
   it('passes through the chunk error when probe error is null', () => {
-    expect(mergeErrors(null, 'chunk_count_capped (8 chunks → kept first 4)')).toBe(
-      'chunk_count_capped (8 chunks → kept first 4)',
+    // Issue #210 — the chunk-split-layer "chunk_count_capped" error has been
+    // replaced by the probe-dispatch-layer "probe_count_capped" error; the
+    // mergeErrors helper itself doesn't care about the content, but using
+    // the post-#210 string keeps this test documentation in sync.
+    expect(mergeErrors(null, 'probe_count_capped (4 flagged chunk(s) skipped; budget=4)')).toBe(
+      'probe_count_capped (4 flagged chunk(s) skipped; budget=4)',
     );
   });
 
   it('joins both errors with "; " so both signals survive downstream', () => {
     expect(
-      mergeErrors('partial probe failure: summarization', 'chunk_count_capped (6 chunks → kept first 4)'),
-    ).toBe('partial probe failure: summarization; chunk_count_capped (6 chunks → kept first 4)');
+      mergeErrors('partial probe failure: summarization', 'probe_count_capped (2 flagged chunk(s) skipped; budget=4)'),
+    ).toBe('partial probe failure: summarization; probe_count_capped (2 flagged chunk(s) skipped; budget=4)');
   });
 });
 

--- a/src/service-worker/orchestrator.ts
+++ b/src/service-worker/orchestrator.ts
@@ -3,7 +3,7 @@ import type { ProbeResult, SecurityVerdict, WebGPUAdapterMode, ChunkAnalysis } f
 import type { PageStamp } from '@/types/page-stamp.js';
 import type { RunProbesMessage, ProbeResultsMessage } from '@/types/messages.js';
 import {
-  MAX_CHUNKS_PER_PAGE,
+  MAX_PROBES_PER_PAGE,
   EARLY_EXIT_ANALYSIS_ERROR,
   HUNTER_RULES_VERSION,
   CACHE_SCHEMA_VERSION,
@@ -370,19 +370,12 @@ export async function analyzeSnapshot(
     engineFingerprint !== 'auto' ? CANARY_CATALOG[engineFingerprint].contextWindow : null;
   const tokenBudget = effectiveChunkTokenBudget(canaryContextWindow);
 
-  const allChunks = await chunkText(fullText, { tokenBudget });
-
-  // Phase 4 Stage 4B — enforce MAX_CHUNKS_PER_PAGE cap to bound latency and
-  // avoid the sustained-engine-use failure mode. Truncation is recorded via
-  // the chunk-count-capped analysisError so downstream analysis sees the
-  // signal rather than silently dropping it.
-  const capped = allChunks.length > MAX_CHUNKS_PER_PAGE;
-  const chunks = capped ? allChunks.slice(0, MAX_CHUNKS_PER_PAGE) : allChunks;
-
-  if (capped) {
-    log.warn(`Page produced ${allChunks.length} chunks; capped at ${MAX_CHUNKS_PER_PAGE}`);
-  }
-  log.info(`Split into ${chunks.length} chunk(s)${capped ? ` (capped from ${allChunks.length})` : ''}`);
+  // Issue #210 — chunk-split is uncapped. Hunters run on every chunk
+  // (cheap, deterministic) and feed the #127 IndexedDB cache so revisits
+  // can dedupe across the whole page. Only LLM probe dispatch is bounded
+  // (see MAX_PROBES_PER_PAGE budget enforced inside the chunk loop below).
+  const chunks = await chunkText(fullText, { tokenBudget });
+  log.info(`Split into ${chunks.length} chunk(s)`);
 
   pendingChunks.set(tabId, []);
 
@@ -442,6 +435,13 @@ export async function analyzeSnapshot(
     // page replays as earlyExited=true so EARLY_EXIT_ANALYSIS_ERROR carries
     // forward identically.
     let earlyExited = fullCacheHit && cachedScan !== null ? cachedScan.earlyExited : false;
+    // Issue #210 — track probe-dispatch budget. BENIGN chunks and cache
+    // hits don't consume the budget; only fresh non-BENIGN chunks that
+    // actually call runChunkProbes do. When the budget is exhausted,
+    // remaining non-BENIGN fresh chunks are marked notScanned: true and
+    // probe_count_capped is folded into the verdict's aggregateError.
+    let probesDispatched = 0;
+    let probeBudgetExceededCount = 0;
     for (let index = 0; index < chunks.length; index += 1) {
       // Issue #11 — check the signal before dispatching each chunk. A new
       // PAGE_SNAPSHOT arriving mid-analysis flips this flag; reject rather
@@ -514,6 +514,27 @@ export async function analyzeSnapshot(
         continue;
       }
 
+      // Issue #210 — non-BENIGN chunk needs LLM probes. Enforce the
+      // per-page budget here (NOT at chunk-split — Phase 4 Stage 4B.1's
+      // original cap site, which blinded #127's chunk-cache layer on
+      // chunks ≥5 of long pages). Chunks that exceed the budget are
+      // marked notScanned: true with their real Hunter-derived
+      // tierRouting preserved (cf. early-exit's pad which reuses the
+      // trigger chunk's tierRouting because Hunters never ran on padded
+      // chunks; here Hunters DID run, so the routing is honest).
+      if (probesDispatched >= MAX_PROBES_PER_PAGE) {
+        probeBudgetExceededCount += 1;
+        allChunkResults.push([]);
+        perChunkAnalysis.push({
+          index,
+          contentHash,
+          tierRouting,
+          probeResults: null,
+          notScanned: true,
+        });
+        continue;
+      }
+
       // Issue #118 (N12) — build evidence packets from this chunk's hunt
       // report. Empty array → probe-runner falls through to the existing
       // 3-probe stack (Hawk-only chunk-level signal). Non-empty → runs
@@ -553,6 +574,7 @@ export async function analyzeSnapshot(
         origin: snapshot.metadata.origin,
         evidencePackets,
       });
+      probesDispatched += 1;
       allChunkResults.push(results);
       perChunkAnalysis.push({ index, contentHash, tierRouting, probeResults: results });
       // Prefer the first non-null canaryId we see. All chunks in a single
@@ -598,10 +620,23 @@ export async function analyzeSnapshot(
     }
 
     const mergedResults = mergeProbeResults(allChunkResults);
+    // Issue #210 — replace `chunk_count_capped` (Phase 4 Stage 4B.1, fired
+    // at chunk-split) with `probe_count_capped` (fires at probe-dispatch
+    // when SUSPICIOUS chunks are dropped because the per-page LLM budget
+    // was exhausted). A page with >MAX_PROBES_PER_PAGE chunks where all
+    // chunks are BENIGN no longer carries the legacy "capped" label —
+    // Hunters covered the full page and the verdict reflects that.
+    if (probeBudgetExceededCount > 0) {
+      log.warn(
+        `Probe budget exhausted: ${probeBudgetExceededCount} non-BENIGN chunk(s) marked notScanned (budget=${MAX_PROBES_PER_PAGE})`,
+      );
+    }
     const aggregateError = mergeErrors(
       mergeErrors(
         computeAggregateError(mergedResults),
-        capped ? `chunk_count_capped (${allChunks.length} chunks → kept first ${MAX_CHUNKS_PER_PAGE})` : null,
+        probeBudgetExceededCount > 0
+          ? `probe_count_capped (${probeBudgetExceededCount} flagged chunk(s) skipped; budget=${MAX_PROBES_PER_PAGE})`
+          : null,
       ),
       earlyExited ? EARLY_EXIT_ANALYSIS_ERROR : null,
     );

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -193,13 +193,16 @@ export const CHARS_PER_TOKEN_TABLE: Readonly<Record<string, number>> = Object.fr
   und: 4.0,
 });
 
-// Phase 4 Stage 4B — cap on concurrent MLC inference to avoid the
-// sustained-warm-engine failure mode observed on Gemma-2-2b in Track B.
-// Chunks beyond this cap are truncated and the verdict carries
-// analysisError='chunk_count_capped' so downstream analysis doesn't treat
-// the truncation as lost signal. Chunks are serialized (see orchestrator),
-// so total page latency scales ~linearly with chunk count up to the cap.
-export const MAX_CHUNKS_PER_PAGE = 4;
+// Phase 4 Stage 4B — cap originally added at the chunk-split layer to
+// bound MLC engine warmth on Gemma-2-2b. Issue #210 (regression against
+// Phase 6 #127's chunk-cache architectural intent) moves the cap to the
+// probe-dispatch layer: Hunters run on all chunks (cheap, deterministic,
+// feeds the #127 IndexedDB cache), only LLM probe dispatch is bounded.
+// `MAX_PROBES_PER_PAGE` is the new budget. `MAX_CHUNKS_PER_PAGE` is kept
+// for the moment so existing imports (docs / scripts) compile during the
+// transition; it is no longer consulted by the orchestrator.
+export const MAX_PROBES_PER_PAGE = 4;
+export const MAX_CHUNKS_PER_PAGE = MAX_PROBES_PER_PAGE;
 
 export const MAX_VISIBLE_TEXT_CHARS = 50_000;
 export const MAX_HIDDEN_TEXT_CHARS = 10_000;


### PR DESCRIPTION
## Summary

Phase 4 Stage 4B.1 added \`MAX_CHUNKS_PER_PAGE = 4\` at the chunk-split layer to bound MLC engine warmth on Gemma-2-2b. That cap regressed Phase 6 #127's chunk-cache architectural intent on long pages: chunks ≥5 were dropped before being hashed, so they never entered the IndexedDB cache and re-visits couldn't dedupe them. Maintainer offscreen console confirmed Wikipedia/Sourdough (6 chunks) shows \`Cache hit (full): bypassing 4 chunk(s)\` hitting only the first 4 hashes — chunks 5-6 are permanent blind spots.

## Architectural intent (per #127, CLOSED)

#127 specifies per-chunk content-hash dedupe across visits. Hit → reuse Hunter findings + LLM results. Miss → re-run probes on dirty chunks only, merge with cached, recompute. Pages chunked freely, all chunks hashed, cache + Hunters cheaply cover everything, only the LLM probe layer bounded by cost.

## Fix

Move the cap from chunk-split (\`orchestrator.ts:373-385\`) to probe-dispatch (in the per-chunk loop):

- **Chunk-split uncapped.** Every chunk gets a \`contentHash\` and feeds #127's cache layer.
- **Hunters run on every chunk.** Cheap, deterministic; IndexedDB cache amortises to ~zero on revisits.
- **\`probesDispatched\` counter** increments only on fresh \`runChunkProbes\` dispatches. Cache replays + BENIGN chunks don't consume budget.
- When \`probesDispatched >= MAX_PROBES_PER_PAGE\`, remaining non-BENIGN chunks are marked \`notScanned: true\` with their **real Hunter-derived \`tierRouting\` preserved** — contrast with #145 early-exit padding which reuses the trigger chunk's tierRouting because Hunters never ran on padded chunks; here Hunters DID run.
- \`analysisError: 'chunk_count_capped'\` → \`'probe_count_capped (M flagged chunk(s) skipped; budget=N)'\`, fires only when non-BENIGN chunks were dropped. A 6-chunk all-BENIGN page no longer carries a legacy \"capped\" label.

## Constants

- New: \`MAX_PROBES_PER_PAGE = 4\`
- \`MAX_CHUNKS_PER_PAGE\` kept as transition alias (= \`MAX_PROBES_PER_PAGE\`) so existing imports compile; no longer consulted by the orchestrator.

## Tests

1438 → **1442** (+4 probe-cap behavior cases in \`orchestrator.integration.test.ts\`):

| Case | Hunter calls | Probe calls | analysisError |
|---|---|---|---|
| 6-chunk all-BENIGN | 6 | 0 | null |
| 6-chunk all-FLAGGED | 6 | 4 | \`probe_count_capped (2 flagged chunk(s) skipped; budget=4)\` |
| Mixed BENIGN/FLAGGED (3 each) | 6 | 3 | null |
| 7-chunk all-FLAGGED | 7 | 4 | \`probe_count_capped (3 flagged chunk(s) skipped; budget=4)\` |

The 7-chunk case asserts the \`notScanned\` chunks (indices 4-6) carry their **own UNCERTAIN tierRouting** (not the trigger chunk's), so cache writes carry honest per-chunk routing for future replay.

Pre-existing \`mergeErrors\` tests updated to use \`probe_count_capped\` strings (\`mergeErrors\` is content-agnostic; documentation hygiene only, no behavior change).

## Docs

\`docs/ARCHITECTURE.md\` orchestrator pipeline + constants table updated to describe the new layer split and reference #127's intent.

## Validation

- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 1438 → 1442 passing
- [x] \`npm run build\` clean
- [x] \`npm audit\` — 0 vulnerabilities
- [x] Phase 2 byte-locked baseline (162 short pages, none ≥4 chunks) untouched — cap never fires on those rows; behavior is byte-identical
- [ ] **Maintainer reload**: \`npm run build\` then reload unpacked → confirm Wikipedia/Sourdough (6 chunks) now shows \`Split into 6 chunk(s)\` (no cap warning) AND \`Cache hit (full): bypassing 6 chunk(s)\` on revisit (vs. 4 before).

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)