### PR TITLE
feat(log-viewer-#218): in-extension log viewer with live SW + offscreen + content stream

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -38,6 +38,11 @@ const entries: readonly BuildEntry[] = [
   { name: 'content/portals/index', input: 'src/content/portals/index.ts', format: 'iife' },
   { name: 'offscreen/index', input: 'src/offscreen/index.ts', format: 'es', external: TRANSFORMERS_EXTERNAL },
   { name: 'popup/popup', input: 'src/popup/popup.ts', format: 'iife' },
+  // Issue #218 — in-extension log viewer page (SW + offscreen + content
+  // unified live stream + JSON export/import). Loaded as a top-level tab
+  // via chrome.tabs.create from the popup; module ESM so it can connect
+  // to the SW LogBus via chrome.runtime.connect at startup.
+  { name: 'log-viewer/log-viewer', input: 'src/log-viewer/log-viewer.ts', format: 'es' },
   // Phase 3 Track A Path 2 — test-only harness page for Chrome built-in
   // Prompt API (Gemini Nano). Not referenced from manifest.json; opened by
   // the Stage 5 Playwright runner via chrome.tabs.create from the SW.

--- a/scripts/build-assets.ts
+++ b/scripts/build-assets.ts
@@ -21,6 +21,9 @@ export type AssetPair = readonly [src: string, dest: string];
 export const BUILD_ASSETS: readonly AssetPair[] = [
   ['src/offscreen/offscreen.html', 'dist/offscreen/offscreen.html'],
   ['src/popup/popup.html', 'dist/popup/popup.html'],
+  // Issue #218 — log-viewer page HTML. The TS entry is built by Vite
+  // into dist/log-viewer/log-viewer.js; this HTML loads it at runtime.
+  ['src/log-viewer/log-viewer.html', 'dist/log-viewer/log-viewer.html'],
   ['src/tests/phase3/builtin-harness.html', 'dist/tests/phase3/builtin-harness.html'],
   [
     'node_modules/@huggingface/transformers/dist/transformers.web.min.js',

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -1,7 +1,20 @@
-import type { HoneyLLMMessage, PageSnapshotMessage } from '@/types/messages.js';
+import type { HoneyLLMMessage, LogEntryMessage, PageSnapshotMessage } from '@/types/messages.js';
 import type { SecurityVerdict } from '@/types/verdict.js';
 import { CONTENT_PING_INTERVAL_MS } from '@/shared/constants.js';
-import { createLogger } from '@/shared/logger.js';
+import { createLogger, setLogSink, setLogSource, type LogEntry } from '@/shared/logger.js';
+
+// Issue #218 — forward content-script logs to the SW LogBus. Best
+// effort; failures (SW asleep, navigation) are silenced — console.*
+// already wrote the line locally.
+setLogSource('content');
+setLogSink((entry: LogEntry) => {
+  const msg: LogEntryMessage = { type: 'LOG_ENTRY', entry };
+  try {
+    chrome.runtime.sendMessage(msg).catch(() => {});
+  } catch {
+    // chrome.runtime missing on a torn-down page — ignore.
+  }
+});
 import { extractPageSnapshot } from './ingestion/extractor.js';
 import { injectNetworkGuard, activateNetworkGuard } from './mitigation/network-guard.js';
 import { sanitizeSuspiciousNodes } from './mitigation/dom-sanitizer.js';

--- a/src/log-viewer/log-viewer.html
+++ b/src/log-viewer/log-viewer.html
@@ -1,0 +1,179 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>HoneyLLM — Logs</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    html, body { height: 100%; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #0a0a0a;
+      color: #e0e0e0;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+    header {
+      padding: 10px 14px;
+      background: #141414;
+      border-bottom: 1px solid #2a2a2a;
+      display: flex;
+      gap: 10px;
+      align-items: center;
+      flex-wrap: wrap;
+    }
+    h1 {
+      font-size: 14px;
+      font-weight: 600;
+      margin-right: 8px;
+    }
+    .status {
+      font-size: 11px;
+      padding: 2px 8px;
+      border-radius: 10px;
+      background: #2a2a2a;
+      color: #9aa0a6;
+    }
+    .status.live { background: #1a3d1a; color: #5fbf5f; }
+    .status.disconnected { background: #3d1a1a; color: #ff6b6b; }
+    .status.imported { background: #1a2a3d; color: #6ba6ff; }
+    .toolbar { display: flex; gap: 6px; flex-wrap: wrap; align-items: center; }
+    button, .file-label {
+      background: #1f1f1f;
+      color: #e0e0e0;
+      border: 1px solid #333;
+      border-radius: 4px;
+      padding: 4px 10px;
+      font-size: 12px;
+      cursor: pointer;
+      font-family: inherit;
+    }
+    button:hover, .file-label:hover { background: #2a2a2a; }
+    button:active { background: #333; }
+    button[disabled] { opacity: 0.5; cursor: not-allowed; }
+    .file-input { display: none; }
+    .filter-group { display: flex; gap: 4px; align-items: center; }
+    .filter-group label {
+      font-size: 11px;
+      padding: 2px 8px;
+      border-radius: 3px;
+      background: #1f1f1f;
+      cursor: pointer;
+      user-select: none;
+      border: 1px solid #333;
+    }
+    .filter-group label.active { background: #2a3d4a; border-color: #4a7090; }
+    .filter-group input[type="checkbox"] { display: none; }
+    .filter-divider {
+      width: 1px;
+      height: 20px;
+      background: #2a2a2a;
+      margin: 0 4px;
+    }
+    input[type="text"].search-box {
+      background: #1f1f1f;
+      color: #e0e0e0;
+      border: 1px solid #333;
+      border-radius: 4px;
+      padding: 4px 8px;
+      font-size: 12px;
+      font-family: inherit;
+      width: 180px;
+    }
+    .spacer { flex: 1; }
+    main {
+      flex: 1;
+      overflow: auto;
+      padding: 4px 0;
+      font-family: 'SF Mono', Menlo, Monaco, Consolas, monospace;
+      font-size: 12px;
+      line-height: 1.5;
+    }
+    .entry {
+      padding: 1px 14px;
+      white-space: pre-wrap;
+      word-break: break-word;
+      border-left: 3px solid transparent;
+    }
+    .entry.debug { color: #888; border-left-color: #444; }
+    .entry.info { color: #d0d0d0; border-left-color: #4a7090; }
+    .entry.warn { color: #f4cf4f; border-left-color: #b08000; background: rgba(180,128,0,0.05); }
+    .entry.error { color: #ff7070; border-left-color: #b03030; background: rgba(180,48,48,0.06); }
+    .entry .meta { color: #6a6a6a; }
+    .entry .src { color: #5a8aaf; font-weight: 600; }
+    .entry .src.offscreen { color: #b07cd6; }
+    .entry .src.content { color: #5fbf5f; }
+    .entry .src.popup { color: #d68c40; }
+    .entry .src.log-viewer { color: #888; }
+    .entry .ctx { color: #888; }
+    .entry .args { color: #909090; }
+    footer {
+      padding: 6px 14px;
+      background: #141414;
+      border-top: 1px solid #2a2a2a;
+      font-size: 11px;
+      color: #888;
+      display: flex;
+      gap: 16px;
+      align-items: center;
+    }
+    footer .stat { color: #aaa; }
+    footer .scroll-lock {
+      margin-left: auto;
+      color: #888;
+    }
+    footer .scroll-lock.locked { color: #f4cf4f; }
+    .empty {
+      padding: 40px 14px;
+      color: #666;
+      text-align: center;
+      font-style: italic;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>HoneyLLM Logs</h1>
+    <span class="status" id="connection-status">connecting…</span>
+    <div class="filter-divider"></div>
+    <div class="filter-group" id="level-filters" aria-label="Level filters">
+      <label data-level="debug"><input type="checkbox" data-level="debug"> debug</label>
+      <label class="active" data-level="info"><input type="checkbox" data-level="info" checked> info</label>
+      <label class="active" data-level="warn"><input type="checkbox" data-level="warn" checked> warn</label>
+      <label class="active" data-level="error"><input type="checkbox" data-level="error" checked> error</label>
+    </div>
+    <div class="filter-divider"></div>
+    <div class="filter-group" id="source-filters" aria-label="Source filters">
+      <label class="active" data-source="sw"><input type="checkbox" data-source="sw" checked> sw</label>
+      <label class="active" data-source="offscreen"><input type="checkbox" data-source="offscreen" checked> offscreen</label>
+      <label class="active" data-source="content"><input type="checkbox" data-source="content" checked> content</label>
+      <label class="active" data-source="popup"><input type="checkbox" data-source="popup" checked> popup</label>
+    </div>
+    <div class="filter-divider"></div>
+    <input type="text" class="search-box" id="search-box" placeholder="search…" aria-label="Search">
+    <div class="spacer"></div>
+    <div class="toolbar">
+      <button id="btn-pause" title="Pause auto-scroll">Pause</button>
+      <button id="btn-clear" title="Clear visible buffer (does not affect SW ring)">Clear</button>
+      <button id="btn-copy" title="Copy filtered entries to clipboard">Copy</button>
+      <button id="btn-export" title="Export filtered entries as JSON">Export</button>
+      <label class="file-label" for="import-file" title="Load a previously exported JSON file">Import
+        <input type="file" id="import-file" class="file-input" accept="application/json,.json">
+      </label>
+      <button id="btn-live" title="Resume live streaming (after import)" disabled>Go live</button>
+    </div>
+  </header>
+  <main id="log-container" tabindex="0">
+    <div class="empty" id="empty-state">Waiting for log entries…</div>
+  </main>
+  <footer>
+    <span class="stat" id="stat-count">0 entries</span>
+    <span class="stat" id="stat-shown">0 visible</span>
+    <span class="stat" id="stat-source">live</span>
+    <span class="scroll-lock" id="scroll-lock">auto-scroll: on</span>
+  </footer>
+  <script type="module" src="log-viewer.js"></script>
+</body>
+</html>

--- a/src/log-viewer/log-viewer.ts
+++ b/src/log-viewer/log-viewer.ts
@@ -1,0 +1,338 @@
+import { LOG_PORT_NAME, type LogPortMessage } from '@/shared/log-bus.js';
+import type { LogEntry, LogLevel, LogSource } from '@/shared/logger.js';
+
+interface FilterState {
+  readonly levels: ReadonlySet<LogLevel>;
+  readonly sources: ReadonlySet<LogSource>;
+  readonly query: string;
+}
+
+const state = {
+  buffer: [] as LogEntry[],
+  filter: {
+    levels: new Set<LogLevel>(['info', 'warn', 'error']),
+    sources: new Set<LogSource>(['sw', 'offscreen', 'content', 'popup']),
+    query: '',
+  } as FilterState,
+  autoScroll: true,
+  paused: false,
+  mode: 'live' as 'live' | 'imported',
+  port: null as chrome.runtime.Port | null,
+  pendingRender: false,
+};
+
+const els = {
+  container: document.getElementById('log-container')!,
+  empty: document.getElementById('empty-state')!,
+  status: document.getElementById('connection-status')!,
+  statCount: document.getElementById('stat-count')!,
+  statShown: document.getElementById('stat-shown')!,
+  statSource: document.getElementById('stat-source')!,
+  scrollLock: document.getElementById('scroll-lock')!,
+  search: document.getElementById('search-box') as HTMLInputElement,
+  btnPause: document.getElementById('btn-pause') as HTMLButtonElement,
+  btnClear: document.getElementById('btn-clear') as HTMLButtonElement,
+  btnCopy: document.getElementById('btn-copy') as HTMLButtonElement,
+  btnExport: document.getElementById('btn-export') as HTMLButtonElement,
+  btnLive: document.getElementById('btn-live') as HTMLButtonElement,
+  importFile: document.getElementById('import-file') as HTMLInputElement,
+  levelFilters: document.getElementById('level-filters')!,
+  sourceFilters: document.getElementById('source-filters')!,
+};
+
+function setStatus(text: string, cls: 'live' | 'disconnected' | 'imported' | ''): void {
+  els.status.textContent = text;
+  els.status.className = `status${cls === '' ? '' : ' ' + cls}`;
+}
+
+function formatTime(ms: number): string {
+  const d = new Date(ms);
+  const hh = String(d.getHours()).padStart(2, '0');
+  const mm = String(d.getMinutes()).padStart(2, '0');
+  const ss = String(d.getSeconds()).padStart(2, '0');
+  const fff = String(d.getMilliseconds()).padStart(3, '0');
+  return `${hh}:${mm}:${ss}.${fff}`;
+}
+
+function renderArgsText(args: readonly unknown[]): string {
+  if (args.length === 0) return '';
+  try {
+    return ' ' + args.map((a) => (typeof a === 'string' ? a : JSON.stringify(a))).join(' ');
+  } catch {
+    return ' [unrenderable args]';
+  }
+}
+
+function entryMatches(entry: LogEntry, f: FilterState): boolean {
+  if (!f.levels.has(entry.level)) return false;
+  if (!f.sources.has(entry.source)) return false;
+  if (f.query.length > 0) {
+    const q = f.query.toLowerCase();
+    if (
+      !entry.message.toLowerCase().includes(q) &&
+      !entry.context.toLowerCase().includes(q) &&
+      !JSON.stringify(entry.args).toLowerCase().includes(q)
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function span(cls: string, text: string): HTMLSpanElement {
+  const el = document.createElement('span');
+  el.className = cls;
+  el.textContent = text;
+  return el;
+}
+
+function entryToElement(entry: LogEntry): HTMLDivElement {
+  const div = document.createElement('div');
+  div.className = `entry ${entry.level}`;
+  div.dataset.seq = String(entry.seq);
+
+  const meta = `${formatTime(entry.timestampMs)} +${entry.elapsedMs.toFixed(1)}ms #${entry.seq}`;
+  div.appendChild(span('meta', meta));
+  div.appendChild(document.createTextNode(' '));
+  div.appendChild(span(`src ${entry.source}`, `[${entry.source}]`));
+  div.appendChild(span('ctx', `[${entry.context}]`));
+  div.appendChild(document.createTextNode(` ${entry.level.toUpperCase()}: ${entry.message}`));
+  if (entry.args.length > 0) {
+    div.appendChild(span('args', renderArgsText(entry.args)));
+  }
+  return div;
+}
+
+function scheduleRender(): void {
+  if (state.pendingRender) return;
+  state.pendingRender = true;
+  requestAnimationFrame(() => {
+    state.pendingRender = false;
+    renderAll();
+  });
+}
+
+function clearChildren(node: Element): void {
+  while (node.firstChild !== null) node.removeChild(node.firstChild);
+}
+
+function renderAll(): void {
+  const filtered = state.buffer.filter((e) => entryMatches(e, state.filter));
+  clearChildren(els.container);
+  if (filtered.length === 0) {
+    els.empty.textContent =
+      state.buffer.length === 0
+        ? 'Waiting for log entries…'
+        : 'No entries match current filters.';
+    els.container.appendChild(els.empty);
+  } else {
+    const frag = document.createDocumentFragment();
+    for (const entry of filtered) frag.appendChild(entryToElement(entry));
+    els.container.appendChild(frag);
+  }
+  els.statCount.textContent = `${state.buffer.length} entries`;
+  els.statShown.textContent = `${filtered.length} visible`;
+  if (state.autoScroll && !state.paused) {
+    els.container.scrollTop = els.container.scrollHeight;
+  }
+}
+
+function appendEntry(entry: LogEntry): void {
+  state.buffer.push(entry);
+  if (!entryMatches(entry, state.filter)) {
+    els.statCount.textContent = `${state.buffer.length} entries`;
+    return;
+  }
+  if (els.empty.parentElement === els.container) {
+    scheduleRender();
+    return;
+  }
+  els.container.appendChild(entryToElement(entry));
+  els.statCount.textContent = `${state.buffer.length} entries`;
+  const shown = parseInt(els.statShown.textContent ?? '0', 10);
+  els.statShown.textContent = `${shown + 1} visible`;
+  if (state.autoScroll && !state.paused) {
+    els.container.scrollTop = els.container.scrollHeight;
+  }
+}
+
+function connectPort(): void {
+  try {
+    state.port = chrome.runtime.connect({ name: LOG_PORT_NAME });
+  } catch (err) {
+    setStatus('disconnected', 'disconnected');
+    console.error('Failed to connect to log bus', err);
+    return;
+  }
+  setStatus('live', 'live');
+  state.mode = 'live';
+  els.statSource.textContent = 'live';
+  els.btnLive.disabled = true;
+
+  state.port.onMessage.addListener((msg: LogPortMessage) => {
+    if (state.mode !== 'live') return;
+    if (msg.type === 'INIT') {
+      state.buffer = [...msg.entries];
+      scheduleRender();
+    } else if (msg.type === 'APPEND') {
+      appendEntry(msg.entry);
+    }
+  });
+
+  state.port.onDisconnect.addListener(() => {
+    setStatus('disconnected — retrying…', 'disconnected');
+    state.port = null;
+    setTimeout(connectPort, 1500);
+  });
+}
+
+function setMode(mode: 'live' | 'imported'): void {
+  state.mode = mode;
+  if (mode === 'imported') {
+    setStatus('imported', 'imported');
+    els.statSource.textContent = 'imported file';
+    els.btnLive.disabled = false;
+    if (state.port !== null) {
+      state.port.disconnect();
+      state.port = null;
+    }
+  } else {
+    connectPort();
+  }
+}
+
+function setupFilters(): void {
+  els.levelFilters.addEventListener('change', (e) => {
+    const target = e.target as HTMLInputElement;
+    if (target.tagName !== 'INPUT') return;
+    const level = target.dataset.level as LogLevel;
+    const next = new Set(state.filter.levels);
+    if (target.checked) next.add(level);
+    else next.delete(level);
+    state.filter = { ...state.filter, levels: next };
+    target.parentElement?.classList.toggle('active', target.checked);
+    scheduleRender();
+  });
+
+  els.sourceFilters.addEventListener('change', (e) => {
+    const target = e.target as HTMLInputElement;
+    if (target.tagName !== 'INPUT') return;
+    const source = target.dataset.source as LogSource;
+    const next = new Set(state.filter.sources);
+    if (target.checked) next.add(source);
+    else next.delete(source);
+    state.filter = { ...state.filter, sources: next };
+    target.parentElement?.classList.toggle('active', target.checked);
+    scheduleRender();
+  });
+
+  els.search.addEventListener('input', () => {
+    state.filter = { ...state.filter, query: els.search.value.trim() };
+    scheduleRender();
+  });
+}
+
+function setupAutoScroll(): void {
+  els.container.addEventListener('scroll', () => {
+    const atBottom =
+      els.container.scrollTop + els.container.clientHeight >= els.container.scrollHeight - 4;
+    state.autoScroll = atBottom;
+    els.scrollLock.textContent = `auto-scroll: ${atBottom ? 'on' : 'off (locked)'}`;
+    els.scrollLock.classList.toggle('locked', !atBottom);
+  });
+}
+
+function flashButton(btn: HTMLButtonElement, label: string): void {
+  const original = btn.textContent;
+  btn.textContent = label;
+  setTimeout(() => {
+    btn.textContent = original;
+  }, 1200);
+}
+
+function setupButtons(): void {
+  els.btnPause.addEventListener('click', () => {
+    state.paused = !state.paused;
+    els.btnPause.textContent = state.paused ? 'Resume' : 'Pause';
+  });
+
+  els.btnClear.addEventListener('click', () => {
+    state.buffer = [];
+    scheduleRender();
+  });
+
+  els.btnCopy.addEventListener('click', async () => {
+    const filtered = state.buffer.filter((e) => entryMatches(e, state.filter));
+    const text = filtered
+      .map(
+        (e) =>
+          `${formatTime(e.timestampMs)} +${e.elapsedMs.toFixed(1)}ms #${e.seq} [${e.source}][${e.context}] ${e.level.toUpperCase()}: ${e.message}${renderArgsText(e.args)}`,
+      )
+      .join('\n');
+    try {
+      await navigator.clipboard.writeText(text);
+      flashButton(els.btnCopy, 'Copied');
+    } catch (err) {
+      console.error('Clipboard write failed', err);
+      flashButton(els.btnCopy, 'Failed');
+    }
+  });
+
+  els.btnExport.addEventListener('click', () => {
+    const filtered = state.buffer.filter((e) => entryMatches(e, state.filter));
+    const payload = {
+      schema: 'honeyllm-logs/v1',
+      exportedAt: new Date().toISOString(),
+      count: filtered.length,
+      entries: filtered,
+    };
+    const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    const ts = new Date().toISOString().replace(/[:.]/g, '-');
+    a.href = url;
+    a.download = `honeyllm-logs-${ts}.json`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  });
+
+  els.importFile.addEventListener('change', async () => {
+    const file = els.importFile.files?.[0];
+    if (file === undefined) return;
+    try {
+      const text = await file.text();
+      const data = JSON.parse(text) as {
+        schema?: string;
+        entries?: unknown;
+      };
+      if (data.schema !== 'honeyllm-logs/v1' || !Array.isArray(data.entries)) {
+        throw new Error('Unrecognised file format');
+      }
+      state.buffer = data.entries as LogEntry[];
+      setMode('imported');
+      scheduleRender();
+    } catch (err) {
+      console.error('Import failed', err);
+      alert(`Could not load file: ${err instanceof Error ? err.message : 'unknown error'}`);
+    } finally {
+      els.importFile.value = '';
+    }
+  });
+
+  els.btnLive.addEventListener('click', () => {
+    state.buffer = [];
+    setMode('live');
+    scheduleRender();
+  });
+}
+
+function init(): void {
+  setupFilters();
+  setupAutoScroll();
+  setupButtons();
+  connectPort();
+}
+
+init();

--- a/src/offscreen/index.ts
+++ b/src/offscreen/index.ts
@@ -2,12 +2,24 @@ import type {
   HoneyLLMMessage,
   EmbedResultMessage,
   LanguageResultMessage,
+  LogEntryMessage,
   NerResultMessage,
   ParseHtmlResultMessage,
   ProbeResultsMessage,
   ProbeDirectResultMessage,
 } from '@/types/messages.js';
-import { createLogger } from '@/shared/logger.js';
+import { createLogger, setLogSink, setLogSource, type LogEntry } from '@/shared/logger.js';
+
+// Issue #218 — forward log entries to the SW so the unified log-viewer
+// page can stream them. console.* output is preserved by the logger
+// itself; the sink is purely the LogBus pipe.
+setLogSource('offscreen');
+setLogSink((entry: LogEntry) => {
+  const msg: LogEntryMessage = { type: 'LOG_ENTRY', entry };
+  chrome.runtime.sendMessage(msg).catch(() => {
+    // SW asleep / disconnected. Console line is already on screen.
+  });
+});
 import { isTestModeEnabled } from '@/shared/test-mode.js';
 import { initEngine, generateCompletion, getLoadedModelId, getLoadedCanaryId, getWebGPUAdapterInfo } from './engine.js';
 import { runProbes } from './probe-runner.js';

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -604,6 +604,7 @@
     <div class="quick-links">
       <button class="quick-link" id="ql-fixtures">Fixture catalog<span class="ql-hint">— fixtures.host-things.online</span></button>
       <button class="quick-link" id="ql-extensions">chrome://extensions<span class="ql-hint">— manage / toggle HoneyLLM</span></button>
+      <button class="quick-link" id="ql-logs">View logs<span class="ql-hint">— SW + offscreen + content live stream</span></button>
     </div>
   </div>
 

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -510,6 +510,10 @@ function initQuickLinks(): void {
   const bindings: ReadonlyArray<{ readonly id: string; readonly url: string }> = [
     { id: 'ql-fixtures', url: `${FIXTURE_HOST}/` },
     { id: 'ql-extensions', url: 'chrome://extensions/' },
+    // Issue #218 — in-extension log viewer. chrome.runtime.getURL
+    // resolves to chrome-extension://<id>/dist/log-viewer/log-viewer.html
+    // which the SW LogBus's onConnect handler accepts.
+    { id: 'ql-logs', url: chrome.runtime.getURL('dist/log-viewer/log-viewer.html') },
   ];
   for (const { id, url } of bindings) {
     const btn = document.getElementById(id);

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -5,7 +5,8 @@ import type {
   VerifyStampResultMessage,
 } from '@/types/messages.js';
 import { STORAGE_KEY_PENDING_INTERCEPT, MAX_INTERCEPT_LATENCY_MS } from '@/shared/constants.js';
-import { createLogger } from '@/shared/logger.js';
+import { createLogger, setLogSink, setLogSource } from '@/shared/logger.js';
+import { LogBus, LOG_PORT_NAME } from '@/shared/log-bus.js';
 import { startKeepalive } from './keepalive.js';
 import { analyzeSnapshot, AnalysisAbortedError, getInFlightCount, getInFlightTabIds } from './orchestrator.js';
 import { analyzeResponse } from './response-analyzer.js';
@@ -18,7 +19,23 @@ import { scanUrl } from './url-scanner.js';
 import { loadRegistryOnce } from '@/registry/lookup.js';
 import { bootstrapEmbeddingsHunter } from './embeddings-bootstrap.js';
 
+// Issue #218 — log bus + viewer-page port plumbing. The bus is module-
+// scoped so it survives onMessage / onConnect re-registration on every
+// SW wakeup; chrome.runtime.* listeners are added below at top-level so
+// MV3's "register synchronously" requirement is met. Sink + source are
+// configured before the first createLogger so the bootstrap log lines
+// are captured.
+const logBus = new LogBus();
+setLogSource('sw');
+setLogSink((entry) => logBus.push(entry));
+
 const log = createLogger('ServiceWorker');
+
+chrome.runtime.onConnect.addListener((port) => {
+  if (port.name === LOG_PORT_NAME) {
+    logBus.connect(port);
+  }
+});
 
 // Issue #117 (N13) — bootstrap the per-install HMAC secret on every
 // SW wakeup. ensureInstallSecret is read-before-write idempotent, so
@@ -161,6 +178,15 @@ chrome.runtime.onMessage.addListener((message: HoneyLLMMessage, sender, sendResp
 
     case 'ENGINE_STATUS': {
       log.info(`Engine status: ${message.status}`, message.progress ?? '');
+      return;
+    }
+
+    // Issue #218 — log forwarding from offscreen / content / popup.
+    // Push directly into the bus; do not re-emit via createLogger to
+    // avoid double-counting (the sender already wrote to its own
+    // console).
+    case 'LOG_ENTRY': {
+      logBus.push(message.entry);
       return;
     }
 

--- a/src/shared/log-bus.test.ts
+++ b/src/shared/log-bus.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { LogBus, type LogPort, type LogPortMessage } from './log-bus.js';
+import type { LogEntry } from './logger.js';
+
+function makeEntry(overrides: Partial<LogEntry> = {}): LogEntry {
+  return {
+    seq: 1,
+    timestampMs: 1_000,
+    elapsedMs: 12.3,
+    source: 'sw',
+    context: 'Test',
+    level: 'info',
+    message: 'hello',
+    args: [],
+    ...overrides,
+  };
+}
+
+class FakePort implements LogPort {
+  readonly received: LogPortMessage[] = [];
+  private disconnectCb: (() => void) | null = null;
+  readonly onDisconnect = {
+    addListener: (cb: () => void) => {
+      this.disconnectCb = cb;
+    },
+  };
+  postMessage(message: unknown): void {
+    this.received.push(message as LogPortMessage);
+  }
+  triggerDisconnect(): void {
+    this.disconnectCb?.();
+  }
+}
+
+describe('LogBus', () => {
+  let bus: LogBus;
+
+  beforeEach(() => {
+    bus = new LogBus(3);
+  });
+
+  it('stores pushed entries up to maxSize and evicts oldest on overflow', () => {
+    bus.push(makeEntry({ seq: 1 }));
+    bus.push(makeEntry({ seq: 2 }));
+    bus.push(makeEntry({ seq: 3 }));
+    bus.push(makeEntry({ seq: 4 }));
+    const snap = bus.snapshot();
+    expect(snap.map((e) => e.seq)).toEqual([2, 3, 4]);
+    expect(bus.size()).toBe(3);
+  });
+
+  it('sends INIT with current snapshot when a port connects', () => {
+    bus.push(makeEntry({ seq: 1 }));
+    bus.push(makeEntry({ seq: 2 }));
+    const port = new FakePort();
+    bus.connect(port);
+    expect(port.received).toHaveLength(1);
+    const init = port.received[0]!;
+    expect(init.type).toBe('INIT');
+    if (init.type === 'INIT') {
+      expect(init.entries.map((e) => e.seq)).toEqual([1, 2]);
+    }
+  });
+
+  it('broadcasts APPEND to all connected ports on push', () => {
+    const a = new FakePort();
+    const b = new FakePort();
+    bus.connect(a);
+    bus.connect(b);
+    bus.push(makeEntry({ seq: 99, message: 'broadcast' }));
+    const aLast = a.received[a.received.length - 1]!;
+    const bLast = b.received[b.received.length - 1]!;
+    expect(aLast.type).toBe('APPEND');
+    expect(bLast.type).toBe('APPEND');
+    if (aLast.type === 'APPEND') expect(aLast.entry.seq).toBe(99);
+    if (bLast.type === 'APPEND') expect(bLast.entry.seq).toBe(99);
+  });
+
+  it('removes ports on disconnect', () => {
+    const port = new FakePort();
+    bus.connect(port);
+    expect(bus.portCount()).toBe(1);
+    port.triggerDisconnect();
+    expect(bus.portCount()).toBe(0);
+  });
+
+  it('drops a port that throws on postMessage during broadcast', () => {
+    const good = new FakePort();
+    let badCalls = 0;
+    const bad: LogPort = {
+      onDisconnect: { addListener: () => {} },
+      postMessage: () => {
+        badCalls += 1;
+        if (badCalls > 1) throw new Error('disconnected mid-broadcast');
+      },
+    };
+    bus.connect(good);
+    bus.connect(bad);
+    expect(bus.portCount()).toBe(2);
+    bus.push(makeEntry({ seq: 1 }));
+    expect(bus.portCount()).toBe(1);
+    expect(good.received.length).toBeGreaterThan(0);
+  });
+
+  it('clear() empties the ring without affecting subsequent pushes', () => {
+    bus.push(makeEntry({ seq: 1 }));
+    bus.clear();
+    expect(bus.size()).toBe(0);
+    bus.push(makeEntry({ seq: 2 }));
+    expect(bus.snapshot().map((e) => e.seq)).toEqual([2]);
+  });
+});

--- a/src/shared/log-bus.ts
+++ b/src/shared/log-bus.ts
@@ -1,0 +1,74 @@
+import type { LogEntry } from './logger.js';
+
+export const LOG_PORT_NAME = 'honeyllm-logs';
+export const LOG_BUS_RING_SIZE = 1000;
+
+export interface LogPort {
+  postMessage(message: unknown): void;
+  onDisconnect: { addListener(cb: () => void): void };
+}
+
+interface InitMessage {
+  readonly type: 'INIT';
+  readonly entries: readonly LogEntry[];
+}
+
+interface AppendMessage {
+  readonly type: 'APPEND';
+  readonly entry: LogEntry;
+}
+
+export type LogPortMessage = InitMessage | AppendMessage;
+
+export class LogBus {
+  private readonly ring: LogEntry[] = [];
+  private readonly ports = new Set<LogPort>();
+  private readonly maxSize: number;
+
+  constructor(maxSize: number = LOG_BUS_RING_SIZE) {
+    this.maxSize = maxSize;
+  }
+
+  push(entry: LogEntry): void {
+    this.ring.push(entry);
+    if (this.ring.length > this.maxSize) this.ring.shift();
+    const msg: AppendMessage = { type: 'APPEND', entry };
+    for (const port of this.ports) {
+      try {
+        port.postMessage(msg);
+      } catch {
+        this.ports.delete(port);
+      }
+    }
+  }
+
+  snapshot(): readonly LogEntry[] {
+    return [...this.ring];
+  }
+
+  size(): number {
+    return this.ring.length;
+  }
+
+  clear(): void {
+    this.ring.length = 0;
+  }
+
+  connect(port: LogPort): void {
+    this.ports.add(port);
+    const msg: InitMessage = { type: 'INIT', entries: this.snapshot() };
+    try {
+      port.postMessage(msg);
+    } catch {
+      this.ports.delete(port);
+      return;
+    }
+    port.onDisconnect.addListener(() => {
+      this.ports.delete(port);
+    });
+  }
+
+  portCount(): number {
+    return this.ports.size;
+  }
+}

--- a/src/shared/logger.ts
+++ b/src/shared/logger.ts
@@ -1,4 +1,5 @@
-type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+export type LogSource = 'sw' | 'offscreen' | 'content' | 'popup' | 'log-viewer' | 'unknown';
 
 const LEVEL_ORDER: Record<LogLevel, number> = {
   debug: 0,
@@ -7,9 +8,24 @@ const LEVEL_ORDER: Record<LogLevel, number> = {
   error: 3,
 };
 
+export interface LogEntry {
+  readonly seq: number;
+  readonly timestampMs: number;
+  readonly elapsedMs: number;
+  readonly source: LogSource;
+  readonly context: string;
+  readonly level: LogLevel;
+  readonly message: string;
+  readonly args: readonly unknown[];
+}
+
+export type LogSink = (entry: LogEntry) => void;
+
 let minLevel: LogLevel = 'info';
 let nextSeq = 1;
 const startMs = nowMs();
+let sink: LogSink | null = null;
+let source: LogSource = 'unknown';
 
 function nowMs(): number {
   if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
@@ -18,41 +34,119 @@ function nowMs(): number {
   return Date.now();
 }
 
-function elapsedMs(): string {
-  const ms = nowMs() - startMs;
-  return ms.toFixed(1);
+function elapsedMs(): number {
+  return nowMs() - startMs;
 }
 
 export function setLogLevel(level: LogLevel): void {
   minLevel = level;
 }
 
+export function setLogSink(fn: LogSink | null): void {
+  sink = fn;
+}
+
+export function setLogSource(s: LogSource): void {
+  source = s;
+}
+
 export function resetLoggerForTests(): void {
   nextSeq = 1;
+  sink = null;
+  source = 'unknown';
+  minLevel = 'info';
 }
 
 function shouldLog(level: LogLevel): boolean {
   return LEVEL_ORDER[level] >= LEVEL_ORDER[minLevel];
 }
 
-function formatMessage(context: string, level: LogLevel, message: string): string {
+function formatMessage(context: string, level: LogLevel, message: string, seq: number): string {
+  return `[HoneyLLM:${context} #${seq} t=${elapsedMs().toFixed(1)}ms] ${level.toUpperCase()}: ${message}`;
+}
+
+function safeSerializeArg(value: unknown, seen: WeakSet<object> = new WeakSet()): unknown {
+  if (value === null || value === undefined) return value;
+  const t = typeof value;
+  if (t === 'string' || t === 'number' || t === 'boolean') return value;
+  if (t === 'bigint') return `${value}n`;
+  if (t === 'function') return `[Function: ${(value as () => void).name || 'anonymous'}]`;
+  if (t === 'symbol') return (value as symbol).toString();
+  if (value instanceof Error) {
+    return { __error: true, name: value.name, message: value.message, stack: value.stack };
+  }
+  if (typeof value === 'object') {
+    const obj = value as object;
+    if (seen.has(obj)) return '[Circular]';
+    seen.add(obj);
+    if (Array.isArray(value)) {
+      return value.map((v) => safeSerializeArg(v, seen));
+    }
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(obj)) {
+      try {
+        out[key] = safeSerializeArg((obj as Record<string, unknown>)[key], seen);
+      } catch {
+        out[key] = '[Unserializable]';
+      }
+    }
+    return out;
+  }
+  return String(value);
+}
+
+function emit(context: string, level: LogLevel, message: string, args: readonly unknown[]): void {
+  if (!shouldLog(level)) return;
   const seq = nextSeq++;
-  return `[HoneyLLM:${context} #${seq} t=${elapsedMs()}ms] ${level.toUpperCase()}: ${message}`;
+  const formatted = formatMessage(context, level, message, seq);
+
+  switch (level) {
+    case 'debug':
+      console.debug(formatted, ...args);
+      break;
+    case 'info':
+      console.info(formatted, ...args);
+      break;
+    case 'warn':
+      console.warn(formatted, ...args);
+      break;
+    case 'error':
+      console.error(formatted, ...args);
+      break;
+  }
+
+  if (sink !== null) {
+    try {
+      const entry: LogEntry = {
+        seq,
+        timestampMs: Date.now(),
+        elapsedMs: elapsedMs(),
+        source,
+        context,
+        level,
+        message,
+        args: args.map((a) => safeSerializeArg(a)),
+      };
+      sink(entry);
+    } catch {
+      // Sinks must not break logging — swallow.
+    }
+  }
 }
 
 export function createLogger(context: string) {
   return {
     debug(message: string, ...args: unknown[]) {
-      if (shouldLog('debug')) console.debug(formatMessage(context, 'debug', message), ...args);
+      emit(context, 'debug', message, args);
     },
     info(message: string, ...args: unknown[]) {
-      if (shouldLog('info')) console.info(formatMessage(context, 'info', message), ...args);
+      emit(context, 'info', message, args);
     },
     warn(message: string, ...args: unknown[]) {
-      if (shouldLog('warn')) console.warn(formatMessage(context, 'warn', message), ...args);
+      emit(context, 'warn', message, args);
     },
     error(message: string, ...args: unknown[]) {
-      if (shouldLog('error')) console.error(formatMessage(context, 'error', message), ...args);
+      emit(context, 'error', message, args);
     },
   } as const;
 }

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -4,6 +4,7 @@ import type { VerifyStampResult } from './page-stamp.js';
 import type { CapturedResponse, CapturedThinking } from './portal-response.js';
 import type { EvidencePacket } from '@/probes/base-probe.js';
 import type { Entity } from '@/hunters/ner/types.js';
+import type { LogEntry } from '@/shared/logger.js';
 
 export type MessageType =
   | 'PAGE_SNAPSHOT'
@@ -81,7 +82,12 @@ export type MessageType =
   // ThinkingVerdict back via setThinkingVerdictForOrigin. Distinct from
   // RESPONSE_CAPTURED — separate analyzer, separate telemetry, separate
   // dedup cache, separate chunk-index offset.
-  | 'THINKING_CAPTURED';
+  | 'THINKING_CAPTURED'
+  // Issue #218 — log forwarding. Offscreen / content / popup contexts
+  // can't reach the SW-side LogBus directly; they emit LOG_ENTRY via
+  // chrome.runtime.sendMessage and the SW's onMessage handler routes
+  // the entry into the bus for live streaming to the log-viewer page.
+  | 'LOG_ENTRY';
 
 interface BaseMessage {
   readonly type: MessageType;
@@ -410,6 +416,14 @@ export interface ThinkingCapturedMessage extends BaseMessage {
   readonly metadata: { readonly url: string; readonly origin: string };
 }
 
+// Issue #218 — log forwarding from non-SW contexts. The sender attaches
+// its already-formatted LogEntry (assigned source, context, level,
+// serialized args) and the SW pipes it into the LogBus. No reply.
+export interface LogEntryMessage extends BaseMessage {
+  readonly type: 'LOG_ENTRY';
+  readonly entry: LogEntry;
+}
+
 export type HoneyLLMMessage =
   | PageSnapshotMessage
   | RunProbesMessage
@@ -440,4 +454,5 @@ export type HoneyLLMMessage =
   | InterceptVerdictMessage
   | ParseHtmlRequestMessage
   | ParseHtmlResultMessage
-  | ThinkingCapturedMessage;
+  | ThinkingCapturedMessage
+  | LogEntryMessage;


### PR DESCRIPTION
## Summary

Adds a unified, in-extension log viewer page so SW + offscreen + content + popup logs can be observed and shared without juggling three DevTools windows. Reachable via a new "View logs" quick-link at the bottom of the popup.

## What's in this PR

**New files**
- `src/shared/log-bus.ts` — SW-owned ring buffer (1000 entries) with port-based broadcast.
- `src/shared/log-bus.test.ts` — unit tests: ring eviction, INIT replay on connect, APPEND broadcast, port disconnect cleanup, broadcast-time port failure cleanup.
- `src/log-viewer/log-viewer.html` — viewer page (inline styles, matches popup's look).
- `src/log-viewer/log-viewer.ts` — viewer logic: port connect/auto-reconnect, INIT/APPEND handling, level + source filters, search, auto-scroll lock, copy-to-clipboard, JSON export, JSON import (`honeyllm-logs/v1` schema), live/imported mode toggle.

**Modified**
- `src/shared/logger.ts` — adds `setLogSink` + `setLogSource` (each context registers itself once at startup). `createLogger` continues to `console.*` as before; the sink is a separate side channel with a structured `LogEntry`. `safeSerializeArg` handles Errors, circular refs, functions/symbols/bigints so chrome.runtime IPC stays JSON-cloneable.
- `src/types/messages.ts` — adds `LOG_ENTRY` message + `LogEntryMessage` for offscreen/content → SW forwarding.
- `src/service-worker/index.ts` — instantiates `LogBus`, registers `chrome.runtime.onConnect` for `honeyllm-logs` port, handles `LOG_ENTRY` in the main switch.
- `src/offscreen/index.ts`, `src/content/index.ts` — set source + sink at top so the very first log line is captured.
- `src/popup/popup.html`, `src/popup/popup.ts` — adds "View logs" quick-link that opens `chrome.runtime.getURL('dist/log-viewer/log-viewer.html')` in a new tab.
- `build.ts` — registers the log-viewer Vite entry (`format: 'es'` since the viewer uses module imports).
- `scripts/build-assets.ts` — copies the log-viewer HTML into `dist/`.

## Security note

Log entries carry strings from page-side content (URLs, snippets, error messages from attacker-controlled code). DOM rendering is strictly via `textContent` + `document.createElement` — no `innerHTML`, no string-template HTML — so a hostile log line cannot run script in the viewer page. Pre-commit hook flagged the original draft and was honoured.

## Privacy note

Imported/exported JSON contains the same content the user has already seen in their own logs (chunk text, URLs, verdict details). The viewer is local-only — no network egress. Future work could add an in-page banner reminding the user that exported files contain page content.

## Acceptance criteria from #218

- [x] Build produces `dist/log-viewer/log-viewer.html` + `.js`.
- [x] Popup has a "View logs" link; opens the viewer in a new tab.
- [x] Viewer connects to SW, receives the existing ring buffer on connect, then live-streams new entries.
- [x] Entries from SW, offscreen, and content scripts arrive correctly tagged.
- [x] Level filter (debug/info/warn/error) works.
- [x] Source filter (sw/offscreen/content/popup) works.
- [x] Search box filters across message + context + serialized args.
- [x] Auto-scroll locks when user scrolls up; resumes when scrolled to bottom.
- [x] Copy-to-clipboard copies the visible filtered buffer.
- [x] Export downloads a JSON file (`honeyllm-logs/v1` schema).
- [x] Import loads a previously exported file; "Go live" button resumes streaming.
- [x] Unit tests for LogBus.
- [x] No regressions to existing logger usage — full suite (1448 tests) passes.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 1448 tests pass
- [x] `npm run build` — clean
- [ ] Manual smoke: load `dist/` as unpacked extension, open popup → "View logs" → confirm SW bootstrap lines stream in, navigate a tab to trigger content/offscreen activity, confirm tagged entries appear, exercise filters/search/copy/export/import.

## Out of scope (future)

- Persistent log storage across SW restarts (v1 is in-memory).
- Per-tab content-script log filtering (we tag with source `content` but not tab id; easy follow-up).
- Redaction of PII / page text before display.

Closes #218