### PR TITLE
fix(mitigation-#220): tear down network-guard + redirect-blocker on downgrade

### DIFF
--- a/src/content/apply-mitigations.test.ts
+++ b/src/content/apply-mitigations.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SecurityVerdict, SecurityStatus } from '@/types/verdict.js';
+import { applyMitigations, type MitigationDeps } from './apply-mitigations.js';
+
+function makeVerdict(status: SecurityStatus, mitigationsApplied: readonly string[] = []): SecurityVerdict {
+  return {
+    status,
+    confidence: 0.9,
+    totalScore: status === 'COMPROMISED' ? 80 : status === 'SUSPICIOUS' ? 40 : 0,
+    probeResults: [],
+    behavioralFlags: {} as SecurityVerdict['behavioralFlags'],
+    mitigationsApplied,
+    timestamp: 1_000_000,
+    url: 'https://x.example/page',
+    analysisError: null,
+    canaryId: null,
+    perChunkAnalysis: [],
+    perChunkVisibility: [],
+    hunterSummary: null,
+    stamp: null,
+  } as unknown as SecurityVerdict;
+}
+
+let deps: MitigationDeps;
+let sanitize: ReturnType<typeof vi.fn<() => readonly string[]>>;
+let activateNG: ReturnType<typeof vi.fn<() => void>>;
+let deactivateNG: ReturnType<typeof vi.fn<() => void>>;
+let activateRB: ReturnType<typeof vi.fn<() => void>>;
+let deactivateRB: ReturnType<typeof vi.fn<() => void>>;
+
+beforeEach(() => {
+  sanitize = vi.fn<() => readonly string[]>(() => []);
+  activateNG = vi.fn<() => void>();
+  deactivateNG = vi.fn<() => void>();
+  activateRB = vi.fn<() => void>();
+  deactivateRB = vi.fn<() => void>();
+  deps = {
+    sanitizeSuspiciousNodes: sanitize,
+    activateNetworkGuard: activateNG,
+    deactivateNetworkGuard: deactivateNG,
+    activateRedirectBlocker: activateRB,
+    deactivateRedirectBlocker: deactivateRB,
+  };
+});
+
+describe('applyMitigations — COMPROMISED activates', () => {
+  it('activates network guard and redirect blocker on COMPROMISED', () => {
+    const result = applyMitigations(makeVerdict('COMPROMISED'), deps);
+    expect(activateNG).toHaveBeenCalledTimes(1);
+    expect(activateRB).toHaveBeenCalledTimes(1);
+    expect(deactivateNG).not.toHaveBeenCalled();
+    expect(deactivateRB).not.toHaveBeenCalled();
+    expect(result.mitigationsApplied).toEqual(
+      expect.arrayContaining(['network_guard_active', 'redirect_blocker_active']),
+    );
+  });
+
+  it('records dom_sanitized count when sanitize returns removed nodes', () => {
+    sanitize.mockReturnValueOnce(['node-a', 'node-b', 'node-c']);
+    const result = applyMitigations(makeVerdict('COMPROMISED'), deps);
+    expect(result.mitigationsApplied).toContain('dom_sanitized:3');
+  });
+
+  it('omits dom_sanitized label when sanitize removed nothing', () => {
+    sanitize.mockReturnValueOnce([]);
+    const result = applyMitigations(makeVerdict('COMPROMISED'), deps);
+    expect(result.mitigationsApplied.some((m) => m.startsWith('dom_sanitized:'))).toBe(false);
+    expect(result.mitigationsApplied).toContain('network_guard_active');
+  });
+});
+
+// Issue #220 — the lifecycle bug. These pin the deactivation contract:
+// once a tab transitions out of COMPROMISED, the network guard and redirect
+// blocker MUST be torn down. Without these, the tab can't be navigated
+// (beforeunload listener) or fetch external resources (network guard) even
+// after a clean rescan or testing-mode toggle.
+describe('applyMitigations — downgrade deactivates (#220 lifecycle)', () => {
+  it('deactivates both on CLEAN', () => {
+    applyMitigations(makeVerdict('CLEAN'), deps);
+    expect(deactivateNG).toHaveBeenCalledTimes(1);
+    expect(deactivateRB).toHaveBeenCalledTimes(1);
+    expect(activateNG).not.toHaveBeenCalled();
+    expect(activateRB).not.toHaveBeenCalled();
+  });
+
+  it('deactivates both on SUSPICIOUS (only DOM-sanitize stays)', () => {
+    sanitize.mockReturnValueOnce(['removed-1']);
+    const result = applyMitigations(makeVerdict('SUSPICIOUS'), deps);
+    expect(deactivateNG).toHaveBeenCalledTimes(1);
+    expect(deactivateRB).toHaveBeenCalledTimes(1);
+    expect(activateNG).not.toHaveBeenCalled();
+    expect(activateRB).not.toHaveBeenCalled();
+    expect(result.mitigationsApplied).toContain('dom_sanitized:1');
+    expect(result.mitigationsApplied).not.toContain('network_guard_active');
+  });
+
+  it('deactivates on UNKNOWN status', () => {
+    applyMitigations(makeVerdict('UNKNOWN'), deps);
+    expect(deactivateNG).toHaveBeenCalledTimes(1);
+    expect(deactivateRB).toHaveBeenCalledTimes(1);
+  });
+
+  it('end-to-end lifecycle: COMPROMISED then CLEAN deactivates exactly once each', () => {
+    applyMitigations(makeVerdict('COMPROMISED'), deps);
+    expect(activateNG).toHaveBeenCalledTimes(1);
+    expect(activateRB).toHaveBeenCalledTimes(1);
+    expect(deactivateNG).not.toHaveBeenCalled();
+
+    applyMitigations(makeVerdict('CLEAN'), deps);
+    expect(deactivateNG).toHaveBeenCalledTimes(1);
+    expect(deactivateRB).toHaveBeenCalledTimes(1);
+  });
+
+  it('end-to-end lifecycle: COMPROMISED then SUSPICIOUS deactivates network/redirect, runs sanitize', () => {
+    applyMitigations(makeVerdict('COMPROMISED'), deps);
+    sanitize.mockReturnValueOnce(['node']);
+
+    const result = applyMitigations(makeVerdict('SUSPICIOUS'), deps);
+    expect(deactivateNG).toHaveBeenCalledTimes(1);
+    expect(deactivateRB).toHaveBeenCalledTimes(1);
+    expect(result.mitigationsApplied).toContain('dom_sanitized:1');
+  });
+
+  it('CLEAN-after-CLEAN is idempotent (deactivators called each time but no-op semantically)', () => {
+    applyMitigations(makeVerdict('CLEAN'), deps);
+    applyMitigations(makeVerdict('CLEAN'), deps);
+    expect(deactivateNG).toHaveBeenCalledTimes(2);
+    expect(deactivateRB).toHaveBeenCalledTimes(2);
+    expect(activateNG).not.toHaveBeenCalled();
+    expect(activateRB).not.toHaveBeenCalled();
+  });
+});
+
+describe('applyMitigations — verdict immutability', () => {
+  it('returns the same verdict reference when nothing was applied', () => {
+    const verdict = makeVerdict('CLEAN');
+    sanitize.mockReturnValueOnce([]);
+    const result = applyMitigations(verdict, deps);
+    expect(result).toBe(verdict);
+  });
+
+  it('returns a new verdict object when mitigations were added', () => {
+    const verdict = makeVerdict('COMPROMISED');
+    const result = applyMitigations(verdict, deps);
+    expect(result).not.toBe(verdict);
+    expect(result.mitigationsApplied.length).toBeGreaterThan(verdict.mitigationsApplied.length);
+  });
+
+  it('preserves existing mitigationsApplied entries from the input', () => {
+    const verdict = makeVerdict('COMPROMISED', ['prior_entry']);
+    const result = applyMitigations(verdict, deps);
+    expect(result.mitigationsApplied[0]).toBe('prior_entry');
+    expect(result.mitigationsApplied).toContain('network_guard_active');
+  });
+});

--- a/src/content/apply-mitigations.ts
+++ b/src/content/apply-mitigations.ts
@@ -1,0 +1,68 @@
+import type { SecurityVerdict } from '@/types/verdict.js';
+
+/**
+ * Mitigation lifecycle handler. Issue #220 — the original inline
+ * implementation in `content/index.ts` only activated mitigations on
+ * COMPROMISED but never deactivated them on a downgrade, so once a
+ * tab saw a COMPROMISED verdict the network guard and redirect blocker
+ * stayed on for the lifetime of the tab. The popup rescan flow (#114)
+ * and the testing-mode toggle (#113) both rely on a downgrade actually
+ * lifting the mitigations.
+ *
+ * Extracted from `content/index.ts` into its own module so the lifecycle
+ * can be unit-tested without pulling in `chrome.runtime`. Dependencies
+ * are passed in (DI), letting tests substitute spies.
+ */
+
+export interface MitigationDeps {
+  readonly sanitizeSuspiciousNodes: () => readonly string[];
+  readonly activateNetworkGuard: () => void;
+  readonly deactivateNetworkGuard: () => void;
+  readonly activateRedirectBlocker: () => void;
+  readonly deactivateRedirectBlocker: () => void;
+}
+
+/**
+ * Apply or tear down mitigations to match `verdict.status`. Returns the
+ * verdict with `mitigationsApplied` extended if anything was added; the
+ * deactivate path doesn't add to `mitigationsApplied` — the field
+ * records mitigations that *are* active right now, and a downgrade
+ * leaves the field unchanged on the verdict (the verdict is from the
+ * SW; the SW already knows what it asked for).
+ */
+export function applyMitigations(
+  verdict: SecurityVerdict,
+  deps: MitigationDeps,
+): SecurityVerdict {
+  const applied: string[] = [];
+
+  if (verdict.status === 'COMPROMISED') {
+    const removed = deps.sanitizeSuspiciousNodes();
+    if (removed.length > 0) {
+      applied.push(`dom_sanitized:${removed.length}`);
+    }
+
+    deps.activateNetworkGuard();
+    applied.push('network_guard_active');
+
+    deps.activateRedirectBlocker();
+    applied.push('redirect_blocker_active');
+  } else {
+    // Downgrade — tear down anything we previously activated. Both
+    // deactivators are idempotent (their underlying state is guarded),
+    // so calling them when nothing is active is a no-op.
+    deps.deactivateNetworkGuard();
+    deps.deactivateRedirectBlocker();
+
+    if (verdict.status === 'SUSPICIOUS') {
+      const removed = deps.sanitizeSuspiciousNodes();
+      if (removed.length > 0) {
+        applied.push(`dom_sanitized:${removed.length}`);
+      }
+    }
+  }
+
+  return applied.length > 0
+    ? { ...verdict, mitigationsApplied: [...verdict.mitigationsApplied, ...applied] }
+    : verdict;
+}

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -60,6 +60,7 @@ import {
   activateRedirectBlocker,
   deactivateRedirectBlocker,
 } from './mitigation/redirect-blocker.js';
+import { applyMitigations as applyMitigationsCore } from './apply-mitigations.js';
 import { setWindowGlobals } from './signaling/window-globals.js';
 import { setSecurityMetaTag } from './signaling/meta-tag.js';
 import {
@@ -90,31 +91,13 @@ function startKeepalivePing(): void {
 }
 
 function applyMitigations(verdict: SecurityVerdict): SecurityVerdict {
-  const applied: string[] = [];
-
-  if (verdict.status === 'COMPROMISED') {
-    const removed = sanitizeSuspiciousNodes();
-    if (removed.length > 0) {
-      applied.push(`dom_sanitized:${removed.length}`);
-    }
-
-    activateNetworkGuard();
-    applied.push('network_guard_active');
-
-    activateRedirectBlocker();
-    applied.push('redirect_blocker_active');
-  }
-
-  if (verdict.status === 'SUSPICIOUS') {
-    const removed = sanitizeSuspiciousNodes();
-    if (removed.length > 0) {
-      applied.push(`dom_sanitized:${removed.length}`);
-    }
-  }
-
-  return applied.length > 0
-    ? { ...verdict, mitigationsApplied: [...verdict.mitigationsApplied, ...applied] }
-    : verdict;
+  return applyMitigationsCore(verdict, {
+    sanitizeSuspiciousNodes,
+    activateNetworkGuard,
+    deactivateNetworkGuard,
+    activateRedirectBlocker,
+    deactivateRedirectBlocker,
+  });
 }
 
 // Issue #231 — track the active stamp lifecycle so a fresh VERDICT can


### PR DESCRIPTION
Closes #220.

`activateNetworkGuard` and `activateRedirectBlocker` were wired into the COMPROMISED branch of `applyMitigations` in `src/content/index.ts:49`, but the matching deactivators were exported and never called anywhere in the codebase. Once a tab saw a COMPROMISED verdict, the mitigations stayed on for the lifetime of the tab — even after a popup-rescan (#114) or testing-mode toggle (#113) returned a clean verdict.

Surfaced via an unused-export audit on `src/`:

```
$ grep -rn "deactivateNetworkGuard\|deactivateRedirectBlocker" src --include="*.ts"
src/content/mitigation/network-guard.ts:export function deactivateNetworkGuard(): void {
src/content/mitigation/redirect-blocker.ts:export function deactivateRedirectBlocker(): void {
```

Both deactivators were correctly implemented — they had no callers.

## User impact (the bug, in user terms)

After a stale `COMPROMISED` mitigation set:

- `beforeunload` listener stays on → user **can't navigate away or refresh** without dismissing the browser's "leave site?" prompt.
- Network guard stays on → outbound `fetch` / `XHR` to anything in the guard's blocklist remains blocked.
- Survives across rescans and testing-mode toggles, so the user sees mitigation behaviour on a page they just confirmed clean.

## Approach

Extracted `applyMitigations` into its own module (`src/content/apply-mitigations.ts`) with dependency injection so the lifecycle can be unit-tested without `chrome.runtime`. Added the deactivate calls on the non-COMPROMISED branch. Both deactivators are already idempotent (active-flag guard in redirect-blocker, postMessage setter in network-guard), so calling them on a CLEAN-after-CLEAN sequence is a safe no-op.

`src/content/index.ts` is now a thin wire-up that passes the real dependencies into the extracted function. Behaviour on `COMPROMISED` is unchanged — same `mitigationsApplied` entries (`dom_sanitized:N`, `network_guard_active`, `redirect_blocker_active`).

## What this PR is NOT doing

- Not adding new mitigation types or strategies; pure lifecycle fix.
- Not changing `SecurityVerdict` or any cross-context message types.
- Not addressing the other 22 candidate unused exports surfaced by the audit (some legitimate, some worth their own follow-ups).

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 1460 tests pass (124 files); +12 new in `apply-mitigations.test.ts`
- [x] `npm run build` clean
- [x] `npm run harness:build` + bundle drift check clean (per #107 CI step)
- [x] **Lifecycle pinning**: COMPROMISED activates both → CLEAN deactivates both (exactly once each); COMPROMISED → SUSPICIOUS deactivates network/redirect, runs sanitize; CLEAN → CLEAN idempotent; UNKNOWN deactivates both.
- [x] **Backward-compat**: `mitigationsApplied` field for COMPROMISED is identical (`dom_sanitized:N`, `network_guard_active`, `redirect_blocker_active`).
- [x] **Verdict immutability**: same-reference returned when nothing applied; new object when mitigations added; prior `mitigationsApplied` entries preserved.

## Cross-references

- Surfaced via the same audit pattern that produced #184 (six unused ingestion extractors). Different root cause (lifecycle gap, not unwired source) but the same diagnostic (`grep -rn` on the exported name returning only the export site).
- Related to #113 (testing-mode toggle, PR #140) and #114 (popup rescan button, PR #141) — both flows assume mitigations follow the verdict, but the assumption was never wired through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)