### PR TITLE
feat(log-viewer-#222): stream logs to disk with per-session, per-page jsonl files

### DIFF
--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -6,9 +6,17 @@ import { createLogger, setLogSink, setLogSource, type LogEntry } from '@/shared/
 // Issue #218 — forward content-script logs to the SW LogBus. Best
 // effort; failures (SW asleep, navigation) are silenced — console.*
 // already wrote the line locally.
+// Issue #222 — stamp pageUrl on each outgoing entry so the file writer
+// can route to per-page jsonl files. window.location.href is captured
+// at sink time (each call) so SPA navigations route correctly without
+// a manual reset hook.
 setLogSource('content');
 setLogSink((entry: LogEntry) => {
-  const msg: LogEntryMessage = { type: 'LOG_ENTRY', entry };
+  const decorated: LogEntry = {
+    ...entry,
+    pageUrl: entry.pageUrl ?? (typeof window !== 'undefined' ? window.location.href : undefined),
+  };
+  const msg: LogEntryMessage = { type: 'LOG_ENTRY', entry: decorated };
   try {
     chrome.runtime.sendMessage(msg).catch(() => {});
   } catch {

--- a/src/log-viewer/file-writer.ts
+++ b/src/log-viewer/file-writer.ts
@@ -1,0 +1,314 @@
+import type { LogEntry } from '@/shared/logger.js';
+import { deriveTarget } from './page-routing.js';
+
+const IDB_NAME = 'honeyllm-log-viewer';
+const IDB_STORE = 'handles';
+const IDB_KEY = 'rootDirectory';
+
+interface SessionState {
+  readonly sessionDir: FileSystemDirectoryHandle;
+  readonly pagesDir: FileSystemDirectoryHandle;
+  readonly fullStream: FileSystemWritableFileStream;
+  readonly streams: Map<string, FileSystemWritableFileStream>;
+  readonly pageOrder: Map<string, number>;
+  readonly indexHandle: FileSystemFileHandle;
+  bytesWritten: number;
+  startedAtMs: number;
+  sessionId: string;
+}
+
+interface IndexFile {
+  readonly schema: 'honeyllm-logs/index/v1';
+  readonly sessionId: string;
+  readonly startedAt: string;
+  readonly pages: ReadonlyArray<{
+    readonly index: number;
+    readonly slug: string;
+    readonly firstUrl: string;
+    readonly firstSeenMs: number;
+    lastSeenMs: number;
+    lineCount: number;
+  }>;
+  readonly fullLines: number;
+}
+
+interface IndexFileMutable {
+  schema: 'honeyllm-logs/index/v1';
+  sessionId: string;
+  startedAt: string;
+  pages: Array<{
+    index: number;
+    slug: string;
+    firstUrl: string;
+    firstSeenMs: number;
+    lastSeenMs: number;
+    lineCount: number;
+  }>;
+  fullLines: number;
+}
+
+let session: SessionState | null = null;
+let indexState: IndexFileMutable | null = null;
+let indexFlushTimer: ReturnType<typeof setTimeout> | null = null;
+
+// IndexedDB helpers (no library; we only need one row).
+function idbOpen(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(IDB_NAME, 1);
+    req.onupgradeneeded = () => {
+      req.result.createObjectStore(IDB_STORE);
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+async function idbGetHandle(): Promise<FileSystemDirectoryHandle | null> {
+  const db = await idbOpen();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(IDB_STORE, 'readonly');
+    const req = tx.objectStore(IDB_STORE).get(IDB_KEY);
+    req.onsuccess = () => resolve(req.result ?? null);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+async function idbPutHandle(handle: FileSystemDirectoryHandle): Promise<void> {
+  const db = await idbOpen();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(IDB_STORE, 'readwrite');
+    tx.objectStore(IDB_STORE).put(handle, IDB_KEY);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+async function idbClearHandle(): Promise<void> {
+  const db = await idbOpen();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(IDB_STORE, 'readwrite');
+    tx.objectStore(IDB_STORE).delete(IDB_KEY);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+async function ensurePermission(
+  handle: FileSystemDirectoryHandle,
+): Promise<'granted' | 'prompt' | 'denied'> {
+  type WithPerm = FileSystemDirectoryHandle & {
+    queryPermission?: (opts: { mode: 'readwrite' }) => Promise<PermissionState>;
+    requestPermission?: (opts: { mode: 'readwrite' }) => Promise<PermissionState>;
+  };
+  const h = handle as WithPerm;
+  if (typeof h.queryPermission === 'function') {
+    const status = await h.queryPermission({ mode: 'readwrite' });
+    if (status === 'granted') return 'granted';
+  }
+  if (typeof h.requestPermission === 'function') {
+    const status = await h.requestPermission({ mode: 'readwrite' });
+    if (status === 'granted') return 'granted';
+    return status;
+  }
+  return 'denied';
+}
+
+export interface PickResult {
+  readonly handle: FileSystemDirectoryHandle;
+  readonly directoryName: string;
+}
+
+export async function pickDirectory(): Promise<PickResult> {
+  type WithPicker = Window & {
+    showDirectoryPicker?: (opts?: {
+      mode?: 'read' | 'readwrite';
+      id?: string;
+    }) => Promise<FileSystemDirectoryHandle>;
+  };
+  const picker = (window as WithPicker).showDirectoryPicker;
+  if (typeof picker !== 'function') {
+    throw new Error('File System Access API not available in this browser');
+  }
+  const handle = await picker.call(window, { mode: 'readwrite', id: 'honeyllm-log-root' });
+  await idbPutHandle(handle);
+  return { handle, directoryName: handle.name };
+}
+
+export async function getSavedHandle(): Promise<FileSystemDirectoryHandle | null> {
+  try {
+    return await idbGetHandle();
+  } catch {
+    return null;
+  }
+}
+
+export async function clearSavedHandle(): Promise<void> {
+  await idbClearHandle();
+}
+
+function makeSessionId(): string {
+  const ts = new Date().toISOString().replace(/[:.]/g, '-').replace('T', '_').slice(0, 19);
+  const rand = Math.random().toString(36).slice(2, 8);
+  return `session_${ts}_${rand}`;
+}
+
+async function writeIndex(): Promise<void> {
+  if (session === null || indexState === null) return;
+  const writable = await session.indexHandle.createWritable();
+  try {
+    await writable.write(JSON.stringify(indexState, null, 2));
+  } finally {
+    await writable.close();
+  }
+}
+
+function scheduleIndexFlush(): void {
+  if (indexFlushTimer !== null) return;
+  indexFlushTimer = setTimeout(() => {
+    indexFlushTimer = null;
+    writeIndex().catch((err) => {
+      console.error('[file-writer] index flush failed', err);
+    });
+  }, 5000);
+}
+
+export async function startSession(root: FileSystemDirectoryHandle): Promise<{
+  sessionPath: string;
+}> {
+  if (session !== null) await stopSession();
+  const sessionId = makeSessionId();
+  const sessionDir = await root.getDirectoryHandle(sessionId, { create: true });
+  const pagesDir = await sessionDir.getDirectoryHandle('pages', { create: true });
+  const fullHandle = await sessionDir.getFileHandle('full.jsonl', { create: true });
+  const fullStream = await fullHandle.createWritable({ keepExistingData: true });
+  // Position writer at end. Existing data is empty for a freshly-created file.
+  await fullStream.seek(0);
+  const indexHandle = await sessionDir.getFileHandle('index.json', { create: true });
+
+  session = {
+    sessionDir,
+    pagesDir,
+    fullStream,
+    streams: new Map(),
+    pageOrder: new Map(),
+    indexHandle,
+    bytesWritten: 0,
+    startedAtMs: Date.now(),
+    sessionId,
+  };
+  indexState = {
+    schema: 'honeyllm-logs/index/v1',
+    sessionId,
+    startedAt: new Date().toISOString(),
+    pages: [],
+    fullLines: 0,
+  };
+  await writeIndex();
+  return { sessionPath: `${root.name}/${sessionId}` };
+}
+
+async function getOrCreateBucketStream(filename: string): Promise<FileSystemWritableFileStream> {
+  if (session === null) throw new Error('No active session');
+  const cached = session.streams.get(filename);
+  if (cached !== undefined) return cached;
+  const isPageFile = !filename.startsWith('_');
+  const dir = isPageFile ? session.pagesDir : session.sessionDir;
+  const fh = await dir.getFileHandle(filename, { create: true });
+  const stream = await fh.createWritable({ keepExistingData: true });
+  await stream.seek(0);
+  session.streams.set(filename, stream);
+  return stream;
+}
+
+export async function writeEntry(entry: LogEntry): Promise<void> {
+  if (session === null || indexState === null) return;
+  const target = deriveTarget(entry);
+
+  let bucketFilename = target.filename;
+  if (target.kind === 'page') {
+    let order = session.pageOrder.get(target.key);
+    if (order === undefined) {
+      order = session.pageOrder.size + 1;
+      session.pageOrder.set(target.key, order);
+      bucketFilename = `${String(order).padStart(3, '0')}_${target.filename}`;
+      indexState.pages.push({
+        index: order,
+        slug: target.key,
+        firstUrl: entry.pageUrl ?? '',
+        firstSeenMs: entry.timestampMs,
+        lastSeenMs: entry.timestampMs,
+        lineCount: 0,
+      });
+    } else {
+      bucketFilename = `${String(order).padStart(3, '0')}_${target.filename}`;
+    }
+    const page = indexState.pages.find((p) => p.index === order);
+    if (page !== undefined) {
+      page.lastSeenMs = entry.timestampMs;
+      page.lineCount += 1;
+    }
+  }
+
+  const line = JSON.stringify(entry) + '\n';
+  const bytes = new TextEncoder().encode(line);
+
+  // Always write to full.jsonl in chronological order.
+  await session.fullStream.write(bytes);
+  session.bytesWritten += bytes.byteLength;
+  indexState.fullLines += 1;
+
+  // Then to the per-page or per-source bucket.
+  const bucket = await getOrCreateBucketStream(bucketFilename);
+  await bucket.write(bytes);
+  session.bytesWritten += bytes.byteLength;
+
+  scheduleIndexFlush();
+}
+
+export async function stopSession(): Promise<void> {
+  if (session === null) return;
+  if (indexFlushTimer !== null) {
+    clearTimeout(indexFlushTimer);
+    indexFlushTimer = null;
+  }
+  try {
+    await writeIndex();
+  } catch (err) {
+    console.error('[file-writer] final index flush failed', err);
+  }
+  try {
+    await session.fullStream.close();
+  } catch (err) {
+    console.error('[file-writer] full stream close failed', err);
+  }
+  for (const [name, stream] of session.streams) {
+    try {
+      await stream.close();
+    } catch (err) {
+      console.error(`[file-writer] bucket close failed for ${name}`, err);
+    }
+  }
+  session = null;
+  indexState = null;
+}
+
+export interface WriterStats {
+  readonly active: boolean;
+  readonly sessionId: string | null;
+  readonly bytesWritten: number;
+  readonly pageCount: number;
+}
+
+export function stats(): WriterStats {
+  if (session === null) {
+    return { active: false, sessionId: null, bytesWritten: 0, pageCount: 0 };
+  }
+  return {
+    active: true,
+    sessionId: session.sessionId,
+    bytesWritten: session.bytesWritten,
+    pageCount: session.pageOrder.size,
+  };
+}
+
+export { ensurePermission };

--- a/src/log-viewer/log-viewer.html
+++ b/src/log-viewer/log-viewer.html
@@ -163,6 +163,7 @@
         <input type="file" id="import-file" class="file-input" accept="application/json,.json">
       </label>
       <button id="btn-live" title="Resume live streaming (after import)" disabled>Go live</button>
+      <button id="btn-save" title="Save logs to disk in a chosen directory">Save to disk</button>
     </div>
   </header>
   <main id="log-container" tabindex="0">
@@ -172,6 +173,7 @@
     <span class="stat" id="stat-count">0 entries</span>
     <span class="stat" id="stat-shown">0 visible</span>
     <span class="stat" id="stat-source">live</span>
+    <span class="stat" id="stat-disk">disk: off</span>
     <span class="scroll-lock" id="scroll-lock">auto-scroll: on</span>
   </footer>
   <script type="module" src="log-viewer.js"></script>

--- a/src/log-viewer/log-viewer.ts
+++ b/src/log-viewer/log-viewer.ts
@@ -1,5 +1,14 @@
 import { LOG_PORT_NAME, type LogPortMessage } from '@/shared/log-bus.js';
 import type { LogEntry, LogLevel, LogSource } from '@/shared/logger.js';
+import {
+  ensurePermission,
+  getSavedHandle,
+  pickDirectory,
+  startSession,
+  stopSession,
+  writeEntry,
+  stats as writerStats,
+} from './file-writer.js';
 
 interface FilterState {
   readonly levels: ReadonlySet<LogLevel>;
@@ -28,6 +37,7 @@ const els = {
   statCount: document.getElementById('stat-count')!,
   statShown: document.getElementById('stat-shown')!,
   statSource: document.getElementById('stat-source')!,
+  statDisk: document.getElementById('stat-disk')!,
   scrollLock: document.getElementById('scroll-lock')!,
   search: document.getElementById('search-box') as HTMLInputElement,
   btnPause: document.getElementById('btn-pause') as HTMLButtonElement,
@@ -35,10 +45,38 @@ const els = {
   btnCopy: document.getElementById('btn-copy') as HTMLButtonElement,
   btnExport: document.getElementById('btn-export') as HTMLButtonElement,
   btnLive: document.getElementById('btn-live') as HTMLButtonElement,
+  btnSave: document.getElementById('btn-save') as HTMLButtonElement,
   importFile: document.getElementById('import-file') as HTMLInputElement,
   levelFilters: document.getElementById('level-filters')!,
   sourceFilters: document.getElementById('source-filters')!,
 };
+
+const writerState = {
+  active: false,
+  pendingWrites: Promise.resolve(),
+};
+
+function updateDiskStat(): void {
+  const s = writerStats();
+  if (!s.active) {
+    els.statDisk.textContent = 'disk: off';
+    return;
+  }
+  const kb = (s.bytesWritten / 1024).toFixed(1);
+  els.statDisk.textContent = `disk: ${s.sessionId} (${kb} KB, ${s.pageCount} pages)`;
+}
+
+function maybePersistEntry(entry: LogEntry): void {
+  if (!writerState.active) return;
+  // Serialise writes through a single tail-promise so concurrent
+  // appendEntry callbacks don't interleave at the FS level.
+  writerState.pendingWrites = writerState.pendingWrites
+    .then(() => writeEntry(entry))
+    .then(() => updateDiskStat())
+    .catch((err) => {
+      console.error('[log-viewer] write failed', err);
+    });
+}
 
 function setStatus(text: string, cls: 'live' | 'disconnected' | 'imported' | ''): void {
   els.status.textContent = text;
@@ -173,9 +211,15 @@ function connectPort(): void {
     if (state.mode !== 'live') return;
     if (msg.type === 'INIT') {
       state.buffer = [...msg.entries];
+      // Replay INIT entries into the disk session so the on-disk view
+      // matches the on-screen view from connect time forward.
+      if (writerState.active) {
+        for (const entry of msg.entries) maybePersistEntry(entry);
+      }
       scheduleRender();
     } else if (msg.type === 'APPEND') {
       appendEntry(msg.entry);
+      maybePersistEntry(msg.entry);
     }
   });
 
@@ -326,7 +370,71 @@ function setupButtons(): void {
     setMode('live');
     scheduleRender();
   });
+
+  els.btnSave.addEventListener('click', () => {
+    if (writerState.active) {
+      void deactivateWriter();
+    } else {
+      void activateWriter();
+    }
+  });
 }
+
+async function activateWriter(): Promise<void> {
+  els.btnSave.disabled = true;
+  els.btnSave.textContent = 'Starting…';
+  try {
+    let handle = await getSavedHandle();
+    if (handle !== null) {
+      const status = await ensurePermission(handle);
+      if (status !== 'granted') handle = null;
+    }
+    if (handle === null) {
+      const picked = await pickDirectory();
+      handle = picked.handle;
+    }
+    const { sessionPath } = await startSession(handle);
+    writerState.active = true;
+    els.btnSave.textContent = 'Stop saving';
+    els.statDisk.textContent = `disk: ${sessionPath}`;
+    // Backfill: write everything currently in the buffer so the disk
+    // record opens with the same context the user is looking at.
+    for (const entry of state.buffer) maybePersistEntry(entry);
+  } catch (err) {
+    console.error('[log-viewer] activate writer failed', err);
+    const msg = err instanceof Error ? err.message : 'unknown error';
+    alert(`Could not start saving to disk: ${msg}`);
+    writerState.active = false;
+    els.btnSave.textContent = 'Save to disk';
+    els.statDisk.textContent = 'disk: off';
+  } finally {
+    els.btnSave.disabled = false;
+  }
+}
+
+async function deactivateWriter(): Promise<void> {
+  els.btnSave.disabled = true;
+  els.btnSave.textContent = 'Stopping…';
+  writerState.active = false;
+  try {
+    await writerState.pendingWrites;
+    await stopSession();
+  } catch (err) {
+    console.error('[log-viewer] deactivate writer failed', err);
+  } finally {
+    els.btnSave.textContent = 'Save to disk';
+    els.statDisk.textContent = 'disk: off';
+    els.btnSave.disabled = false;
+  }
+}
+
+window.addEventListener('beforeunload', () => {
+  if (writerState.active) {
+    // Best effort; FS Access streams may not flush within the tear-down
+    // window, but stopSession at least closes the writable handles.
+    void stopSession();
+  }
+});
 
 function init(): void {
   setupFilters();

--- a/src/log-viewer/page-routing.test.ts
+++ b/src/log-viewer/page-routing.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { deriveTarget, urlToSlug } from './page-routing.js';
+import type { LogEntry } from '@/shared/logger.js';
+
+function entry(overrides: Partial<LogEntry>): LogEntry {
+  return {
+    seq: 1,
+    timestampMs: 0,
+    elapsedMs: 0,
+    source: 'sw',
+    context: 'Test',
+    level: 'info',
+    message: '',
+    args: [],
+    ...overrides,
+  };
+}
+
+describe('urlToSlug', () => {
+  it('hostname only when path is empty', () => {
+    expect(urlToSlug('https://example.com/')).toBe('example-com');
+  });
+
+  it('joins host and path tokens', () => {
+    expect(urlToSlug('https://www.officeworks.com.au/shop/officeworks/p/jbcpa5ct10')).toBe(
+      'www-officeworks-com-au_shop-officeworks-p-jbcpa5ct10',
+    );
+  });
+
+  it('drops query string and hash', () => {
+    expect(urlToSlug('https://example.com/path?a=1&b=2#frag')).toBe('example-com_path');
+  });
+
+  it('caps long paths at 60 chars', () => {
+    const long = 'https://x.com/' + 'a'.repeat(200);
+    expect(urlToSlug(long).length).toBeLessThanOrEqual(60);
+  });
+
+  it('falls back to sanitized raw string for non-URL input', () => {
+    expect(urlToSlug('Not A URL!!')).toBe('not-a-url');
+  });
+
+  it('returns "unknown" for empty / fully-invalid input', () => {
+    expect(urlToSlug('')).toBe('unknown');
+    expect(urlToSlug('!!!')).toBe('unknown');
+  });
+});
+
+describe('deriveTarget', () => {
+  it('routes to page bucket when pageUrl is set', () => {
+    const t = deriveTarget(entry({ pageUrl: 'https://example.com/p/1', source: 'content' }));
+    expect(t.kind).toBe('page');
+    expect(t.filename).toBe('example-com_p-1.jsonl');
+  });
+
+  it('routes to source bucket when no pageUrl', () => {
+    const t = deriveTarget(entry({ source: 'sw' }));
+    expect(t).toEqual({ kind: 'source', key: '_sw', filename: '_sw.jsonl' });
+  });
+
+  it('routes offscreen entries to _offscreen.jsonl regardless of context', () => {
+    const t = deriveTarget(entry({ source: 'offscreen', context: 'NerEngine' }));
+    expect(t.filename).toBe('_offscreen.jsonl');
+  });
+
+  it('treats empty pageUrl string the same as undefined', () => {
+    const t = deriveTarget(entry({ source: 'content', pageUrl: '' }));
+    expect(t.kind).toBe('source');
+  });
+});

--- a/src/log-viewer/page-routing.ts
+++ b/src/log-viewer/page-routing.ts
@@ -1,0 +1,38 @@
+import type { LogEntry } from '@/shared/logger.js';
+
+const SLUG_MAX = 60;
+
+export interface PageRoutingTarget {
+  readonly kind: 'page' | 'source';
+  readonly key: string;
+  readonly filename: string;
+}
+
+function sanitize(part: string): string {
+  return part
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+export function urlToSlug(url: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return sanitize(url).slice(0, SLUG_MAX) || 'unknown';
+  }
+  const host = sanitize(parsed.hostname);
+  const path = sanitize(parsed.pathname);
+  const slug = path.length > 0 ? `${host}_${path}` : host;
+  return slug.slice(0, SLUG_MAX) || 'unknown';
+}
+
+export function deriveTarget(entry: LogEntry): PageRoutingTarget {
+  if (entry.pageUrl !== undefined && entry.pageUrl.length > 0) {
+    const key = urlToSlug(entry.pageUrl);
+    return { kind: 'page', key, filename: `${key}.jsonl` };
+  }
+  const sourceKey = `_${entry.source}`;
+  return { kind: 'source', key: sourceKey, filename: `${sourceKey}.jsonl` };
+}

--- a/src/shared/logger.ts
+++ b/src/shared/logger.ts
@@ -17,6 +17,11 @@ export interface LogEntry {
   readonly level: LogLevel;
   readonly message: string;
   readonly args: readonly unknown[];
+  // Issue #222 — optional page-routing hints. Populated by the
+  // content-script sink decorator (which knows window.location); SW and
+  // offscreen leave them undefined and entries land in source buckets.
+  readonly tabId?: number;
+  readonly pageUrl?: string;
 }
 
 export type LogSink = (entry: LogEntry) => void;


### PR DESCRIPTION
## Summary

Adds a "Save to disk" toggle to the log viewer (#218). Once enabled, every received `LogEntry` is streamed to a user-chosen directory in a structured per-session, per-page layout that an external reader (Claude / a CLI watcher / a future remote-debug helper) can `tail` or `grep` directly.

## What's in this PR

**New files**
- `src/log-viewer/page-routing.ts` — `urlToSlug` and `deriveTarget`. Decides whether an entry routes to a page bucket (sanitised URL slug) or a source bucket (`_sw` / `_offscreen` / `_popup`).
- `src/log-viewer/page-routing.test.ts` — 10 cases covering trailing slashes, query/hash stripping, long paths capped at 60 chars, non-URL fallback, empty-input handling, and source-bucket routing.
- `src/log-viewer/file-writer.ts` — owns the FS Access API integration:
  - IDB-persisted directory handle (`indexedDB` directly, no library — single-row store).
  - `pickDirectory()` — `showDirectoryPicker({mode: 'readwrite'})` + IDB write.
  - `getSavedHandle()` / `ensurePermission()` — silent re-verify on subsequent loads.
  - `startSession()` — creates `session_<ISO>_<rand>/`, opens long-lived `WritableStream` for `full.jsonl` and each bucket on demand.
  - `writeEntry()` — appends to `full.jsonl` chronologically + the per-page or per-source bucket.
  - `stopSession()` — flushes `index.json`, closes all streams.

**Modified**
- `src/shared/logger.ts` — optional `tabId` and `pageUrl` on `LogEntry`. Default-undefined.
- `src/content/index.ts` — sink decorator stamps `pageUrl: window.location.href` on outgoing entries (captured at sink time so SPA navigations route correctly without a manual reset hook).
- `src/log-viewer/log-viewer.html` — "Save to disk" button in the toolbar, "disk: …" stat in the footer.
- `src/log-viewer/log-viewer.ts` — `activateWriter` / `deactivateWriter` wired to the toggle. Writes serialised through a tail-promise so concurrent INIT replay and APPEND callbacks don't interleave at the FS level. INIT replay backfills the on-disk record so the disk view matches the viewer view from connect time forward. `beforeunload` best-effort close.

## Layout

```
<chosen-dir>/
└── session_2026-05-02T08-35-12_xY7zQ/
    ├── full.jsonl                  # every entry, chronological
    ├── index.json                  # metadata + pages[] + line counts
    ├── _sw.jsonl                   # SW-source entries
    ├── _offscreen.jsonl            # offscreen-source entries
    ├── _popup.jsonl
    └── pages/
        ├── 001_www-officeworks-com-au_home.jsonl
        ├── 002_en-wikipedia-org_wiki-sourdough.jsonl
        └── 003_rebrickable-com_mocs-moc-240773.jsonl
```

Each `.jsonl` line is one `LogEntry` JSON object. Pages numbered in order of first appearance.

## Permissions

- File System Access API: requires user gesture for the initial picker. Subsequent loads re-verify the stored handle silently via `queryPermission({mode: 'readwrite'})`. If the browser has revoked permission, the toggle falls back to the picker.
- No new manifest entries — extension pages have FS Access API by default.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 1458 tests pass (10 new from `page-routing.test.ts`)
- [x] `npm run build` — clean; `dist/log-viewer/log-viewer.js` includes the writer module
- [ ] Manual smoke: load `dist/`, open viewer, click "Save to disk", pick a directory, navigate a few tabs, confirm `session_<ts>/` appears with `full.jsonl` + per-page buckets growing.

## Out of scope (future)

- JSONL importer (current Import button still expects the `honeyllm-logs/v1` envelope from Export, not raw JSONL). Easy follow-up if needed.
- Compression / rotation.
- Server-side / remote shipping.
- SW-driven file writing (not possible from MV3 SW context; this is page-driven by design).

Closes #222