### PR TITLE
feat(content-#224): diagnostic heartbeat for post-verdict log visibility

### DIFF
--- a/src/content/diagnostic-heartbeat.test.ts
+++ b/src/content/diagnostic-heartbeat.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { startHeartbeat, HEARTBEAT_DEFAULT_INTERVAL_MS } from './diagnostic-heartbeat.js';
+import { resetLoggerForTests, setLogSink, type LogEntry } from '@/shared/logger.js';
+
+describe('startHeartbeat', () => {
+  beforeEach(() => {
+    resetLoggerForTests();
+  });
+
+  it('emits a structured snapshot via tick() and returns deltas after the first tick', () => {
+    let now = 1000;
+    const heap = { usedJSHeapSize: 100, totalJSHeapSize: 200 };
+    let bodyChildren = 5;
+    let nodeCount = 50;
+
+    const handle = startHeartbeat({
+      setIntervalFn: () => 1, // never auto-fires in tests
+      clearIntervalFn: () => undefined,
+      nowFn: () => now,
+      readBodyChildren: () => bodyChildren,
+      readNodeCount: () => nodeCount,
+      readHeap: () => heap,
+    });
+
+    const first = handle.tick();
+    expect(first).toMatchObject({
+      tickIndex: 1,
+      elapsedMs: 0,
+      bodyChildren: 5,
+      nodeCount: 50,
+    });
+    expect(first.heap.usedJSHeapSize).toBe(100);
+    expect(first.heapDeltaBytes).toBeUndefined();
+    expect(first.nodeDelta).toBeUndefined();
+
+    now = 5500;
+    heap.usedJSHeapSize = 200;
+    bodyChildren = 6;
+    nodeCount = 75;
+
+    const second = handle.tick();
+    expect(second).toMatchObject({
+      tickIndex: 2,
+      elapsedMs: 4500,
+      bodyChildren: 6,
+      nodeCount: 75,
+    });
+    expect(second.heapDeltaBytes).toBe(100);
+    expect(second.nodeDelta).toBe(25);
+
+    handle.stop();
+  });
+
+  it('schedules the periodic fire via setIntervalFn and stops via clearIntervalFn', () => {
+    let scheduled: { ms: number; cb: () => void } | null = null;
+    let cleared: unknown = null;
+
+    const handle = startHeartbeat({
+      setIntervalFn: (cb, ms) => {
+        scheduled = { ms, cb };
+        return 'opaque-handle';
+      },
+      clearIntervalFn: (h) => {
+        cleared = h;
+      },
+      nowFn: () => 0,
+      readBodyChildren: () => 0,
+      readNodeCount: () => 0,
+      readHeap: () => ({}),
+    });
+
+    expect(scheduled).not.toBeNull();
+    expect(scheduled!.ms).toBe(HEARTBEAT_DEFAULT_INTERVAL_MS);
+
+    handle.stop();
+    expect(cleared).toBe('opaque-handle');
+  });
+
+  it('honors a custom intervalMs', () => {
+    let scheduledMs = 0;
+    startHeartbeat({
+      intervalMs: 250,
+      setIntervalFn: (_cb, ms) => {
+        scheduledMs = ms;
+        return 1;
+      },
+      clearIntervalFn: () => undefined,
+      nowFn: () => 0,
+      readBodyChildren: () => 0,
+      readNodeCount: () => 0,
+      readHeap: () => ({}),
+    });
+    expect(scheduledMs).toBe(250);
+  });
+
+  it('emits a log entry per tick via the logger sink', () => {
+    const entries: LogEntry[] = [];
+    setLogSink((e) => entries.push(e));
+
+    const handle = startHeartbeat({
+      setIntervalFn: () => 1,
+      clearIntervalFn: () => undefined,
+      nowFn: () => 0,
+      readBodyChildren: () => 1,
+      readNodeCount: () => 10,
+      readHeap: () => ({ usedJSHeapSize: 1024 }),
+    });
+
+    handle.tick();
+    handle.tick();
+
+    setLogSink(null);
+
+    expect(entries).toHaveLength(2);
+    expect(entries[0]!.context).toBe('Heartbeat');
+    expect(entries[0]!.level).toBe('info');
+    expect(entries[0]!.message).toBe('heartbeat');
+    // args[0] carries the snapshot object, serialized through safeSerializeArg
+    const snap = entries[0]!.args[0] as Record<string, unknown>;
+    expect(snap.tickIndex).toBe(1);
+    expect(snap.bodyChildren).toBe(1);
+    expect(snap.nodeCount).toBe(10);
+
+    handle.stop();
+  });
+});

--- a/src/content/diagnostic-heartbeat.ts
+++ b/src/content/diagnostic-heartbeat.ts
@@ -1,0 +1,116 @@
+import { createLogger } from '@/shared/logger.js';
+
+const log = createLogger('Heartbeat');
+
+export const HEARTBEAT_DEFAULT_INTERVAL_MS = 5_000;
+
+interface HeapMetrics {
+  readonly usedJSHeapSize?: number;
+  readonly totalJSHeapSize?: number;
+  readonly jsHeapSizeLimit?: number;
+}
+
+export interface HeartbeatSnapshot {
+  readonly tickIndex: number;
+  readonly elapsedMs: number;
+  readonly heap: HeapMetrics;
+  readonly bodyChildren: number;
+  readonly nodeCount: number;
+  readonly heapDeltaBytes?: number;
+  readonly nodeDelta?: number;
+}
+
+export interface HeartbeatDeps {
+  readonly intervalMs?: number;
+  readonly setIntervalFn?: (cb: () => void, ms: number) => unknown;
+  readonly clearIntervalFn?: (handle: unknown) => void;
+  readonly nowFn?: () => number;
+  readonly readBodyChildren?: () => number;
+  readonly readNodeCount?: () => number;
+  readonly readHeap?: () => HeapMetrics;
+}
+
+interface PerformanceWithMemory extends Performance {
+  memory?: {
+    readonly usedJSHeapSize?: number;
+    readonly totalJSHeapSize?: number;
+    readonly jsHeapSizeLimit?: number;
+  };
+}
+
+function defaultReadHeap(): HeapMetrics {
+  if (typeof performance === 'undefined') return {};
+  const perf = performance as PerformanceWithMemory;
+  if (perf.memory === undefined) return {};
+  return {
+    usedJSHeapSize: perf.memory.usedJSHeapSize,
+    totalJSHeapSize: perf.memory.totalJSHeapSize,
+    jsHeapSizeLimit: perf.memory.jsHeapSizeLimit,
+  };
+}
+
+function defaultReadBodyChildren(): number {
+  if (typeof document === 'undefined' || document.body === null) return 0;
+  return document.body.children.length;
+}
+
+function defaultReadNodeCount(): number {
+  if (typeof document === 'undefined') return 0;
+  return document.querySelectorAll('*').length;
+}
+
+export interface HeartbeatHandle {
+  stop(): void;
+  tick(): HeartbeatSnapshot;
+}
+
+export function startHeartbeat(deps: HeartbeatDeps = {}): HeartbeatHandle {
+  const intervalMs = deps.intervalMs ?? HEARTBEAT_DEFAULT_INTERVAL_MS;
+  const setIntervalFn = deps.setIntervalFn ?? ((cb, ms) => setInterval(cb, ms));
+  const clearIntervalFn = deps.clearIntervalFn ?? ((h) => clearInterval(h as number));
+  const nowFn = deps.nowFn ?? (() => Date.now());
+  const readBodyChildren = deps.readBodyChildren ?? defaultReadBodyChildren;
+  const readNodeCount = deps.readNodeCount ?? defaultReadNodeCount;
+  const readHeap = deps.readHeap ?? defaultReadHeap;
+
+  const startedMs = nowFn();
+  let tickIndex = 0;
+  let prevHeapBytes: number | undefined;
+  let prevNodeCount: number | undefined;
+
+  function snapshot(): HeartbeatSnapshot {
+    tickIndex += 1;
+    const elapsedMs = nowFn() - startedMs;
+    const heap = readHeap();
+    const bodyChildren = readBodyChildren();
+    const nodeCount = readNodeCount();
+
+    const heapDeltaBytes =
+      prevHeapBytes !== undefined && heap.usedJSHeapSize !== undefined
+        ? heap.usedJSHeapSize - prevHeapBytes
+        : undefined;
+    const nodeDelta = prevNodeCount !== undefined ? nodeCount - prevNodeCount : undefined;
+
+    prevHeapBytes = heap.usedJSHeapSize;
+    prevNodeCount = nodeCount;
+
+    return { tickIndex, elapsedMs, heap, bodyChildren, nodeCount, heapDeltaBytes, nodeDelta };
+  }
+
+  function fire(): HeartbeatSnapshot {
+    const snap = snapshot();
+    log.info('heartbeat', snap);
+    return snap;
+  }
+
+  const handle = setIntervalFn(fire, intervalMs);
+
+  return {
+    stop(): void {
+      clearIntervalFn(handle);
+    },
+    tick(): HeartbeatSnapshot {
+      return fire();
+    },
+  };
+}

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -35,6 +35,7 @@ import {
   installNavigationTeardown,
 } from './signaling/page-stamp-embed.js';
 import { rescanWithForcedMitigation } from './rescan.js';
+import { startHeartbeat, type HeartbeatHandle } from './diagnostic-heartbeat.js';
 
 const log = createLogger('Content');
 
@@ -120,6 +121,23 @@ chrome.runtime.onMessage.addListener((message: HoneyLLMMessage) => {
   }
 });
 
+// Issue #224 — diagnostic heartbeat for the leak hunt (#217). Started
+// after snapshot dispatch so the periodic stats line shows up alongside
+// post-verdict observation. Stopped on pagehide so SPA-style same-tab
+// navigations don't double-up timers across page rebuilds.
+let heartbeatHandle: HeartbeatHandle | null = null;
+
+function startDiagnosticHeartbeat(): void {
+  if (heartbeatHandle !== null) return;
+  heartbeatHandle = startHeartbeat();
+  const stop = (): void => {
+    heartbeatHandle?.stop();
+    heartbeatHandle = null;
+    window.removeEventListener('pagehide', stop);
+  };
+  window.addEventListener('pagehide', stop);
+}
+
 async function run(): Promise<void> {
   startKeepalivePing();
 
@@ -138,6 +156,8 @@ async function run(): Promise<void> {
   chrome.runtime.sendMessage(message).catch((err) => {
     log.error('Failed to send snapshot to service worker', err);
   });
+
+  startDiagnosticHeartbeat();
 }
 
 if (isLocalHarnessHost()) {


### PR DESCRIPTION
## Summary

Closes the post-verdict log gap surfaced by the #217 leak hunt. After verdict-stamp embed, our content script goes silent — but the page's renderer can run wild for minutes. A periodic heartbeat logs heap + DOM stats every 5s so the leak signature is visible directly in logs, no DevTools profile needed for first-pass triage.

## What's in this PR

**New**
- `src/content/diagnostic-heartbeat.ts` — `startHeartbeat()` factory with full dependency injection (setInterval / now / read functions) for testability. Computes per-tick deltas for heap and node count so growth rate is obvious at a glance. Returns a `HeartbeatHandle` with `stop()` + `tick()`.
- `src/content/diagnostic-heartbeat.test.ts` — 4 cases covering snapshot shape, delta computation across ticks, custom intervalMs, setInterval/clearInterval wiring, and logger sink emission.

**Modified**
- `src/content/index.ts` — starts the heartbeat after PAGE_SNAPSHOT dispatch. `pagehide` listener stops it cleanly so SPA same-tab navigations don't double up timers.

## Heartbeat output shape

Every 5s, one log line — `level=info`, `context=Heartbeat`, `message=heartbeat`, with `args[0]` carrying:

```json
{
  "tickIndex": 7,
  "elapsedMs": 30043,
  "heap": {
    "usedJSHeapSize": 2147483648,
    "totalJSHeapSize": 2415919104,
    "jsHeapSizeLimit": 4294967296
  },
  "bodyChildren": 142,
  "nodeCount": 14823,
  "heapDeltaBytes": 268435456,
  "nodeDelta": 1842
}
```

`heapDeltaBytes` and `nodeDelta` are undefined on tick 1.

## Why this matters for #217

A fresh Officeworks-homepage repro will produce ~12 heartbeat lines per minute. If the leak is real you'll see `usedJSHeapSize` climbing (e.g. 50 MB → 800 MB → 1.5 GB → 3 GB) and `nodeCount` climbing (page is materializing endless ad iframes). That's the signature.

If `heapDeltaBytes` stays small but `nodeDelta` keeps growing → DOM-driven leak (lazy load avalanche).
If `heapDeltaBytes` grows but `nodeDelta` stays flat → JS heap leak (closure capture, fetch wrapper buffering, etc.).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 1462 tests pass (4 new)
- [x] `npm run build` — clean
- [ ] Manual smoke: load `dist/`, open log viewer with "Save to disk" enabled, navigate to any page, confirm heartbeat lines appear in `pages/<slug>.jsonl` every ~5s.

## Out of scope (filed as v2)

- Main-world fetch/XHR invocation counters (`postMessage` round-trip).
- Stamp-observer fire counter (instrument `reembedIfMissing`).
- SW + offscreen heartbeats with context-appropriate metrics.

Pairs with #225 (file-writer periodic flush) — together they make heartbeat lines tail-readable with ~2s latency.

Closes #224