### PR TITLE
feat(log-viewer-#225): periodic flush so .jsonl files are tail-readable

### DIFF
--- a/src/log-viewer/file-writer.test.ts
+++ b/src/log-viewer/file-writer.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { reopenAtEnd } from './file-writer.js';
+
+interface MockWritable {
+  seekCalls: number[];
+  closed: boolean;
+  closedFlush: boolean;
+  seek(pos: number): Promise<void>;
+  write(data: BufferSource): Promise<void>;
+  close(): Promise<void>;
+}
+
+interface MockFile {
+  size: number;
+}
+
+interface MockFileHandle {
+  file: MockFile;
+  createWritableCalls: number;
+  getFileCalls: number;
+  getFile(): Promise<MockFile>;
+  createWritable(opts: { keepExistingData: boolean }): Promise<MockWritable>;
+  lastWritable: MockWritable | null;
+}
+
+function makeMockHandle(initialSize: number): MockFileHandle {
+  const handle: MockFileHandle = {
+    file: { size: initialSize },
+    createWritableCalls: 0,
+    getFileCalls: 0,
+    lastWritable: null,
+    async getFile() {
+      this.getFileCalls += 1;
+      return this.file;
+    },
+    async createWritable(_opts) {
+      this.createWritableCalls += 1;
+      const w: MockWritable = {
+        seekCalls: [],
+        closed: false,
+        closedFlush: false,
+        async seek(pos) {
+          w.seekCalls.push(pos);
+        },
+        async write(_data) {
+          // no-op
+        },
+        async close() {
+          w.closed = true;
+        },
+      };
+      this.lastWritable = w;
+      return w;
+    },
+  };
+  return handle;
+}
+
+describe('reopenAtEnd', () => {
+  it('does not seek when the file is empty (position 0 is already end)', async () => {
+    const handle = makeMockHandle(0);
+    const stream = (await reopenAtEnd(
+      handle as unknown as FileSystemFileHandle,
+    )) as unknown as MockWritable;
+    expect(handle.getFileCalls).toBe(1);
+    expect(handle.createWritableCalls).toBe(1);
+    expect(stream.seekCalls).toEqual([]);
+  });
+
+  it('seeks to file size when there is existing data so writes append', async () => {
+    const handle = makeMockHandle(4321);
+    const stream = (await reopenAtEnd(
+      handle as unknown as FileSystemFileHandle,
+    )) as unknown as MockWritable;
+    expect(stream.seekCalls).toEqual([4321]);
+  });
+
+  it('returns a fresh writable on each call', async () => {
+    const handle = makeMockHandle(100);
+    const a = await reopenAtEnd(handle as unknown as FileSystemFileHandle);
+    const b = await reopenAtEnd(handle as unknown as FileSystemFileHandle);
+    expect(a).not.toBe(b);
+    expect(handle.createWritableCalls).toBe(2);
+  });
+});

--- a/src/log-viewer/file-writer.ts
+++ b/src/log-viewer/file-writer.ts
@@ -8,7 +8,8 @@ const IDB_KEY = 'rootDirectory';
 interface SessionState {
   readonly sessionDir: FileSystemDirectoryHandle;
   readonly pagesDir: FileSystemDirectoryHandle;
-  readonly fullStream: FileSystemWritableFileStream;
+  readonly fullHandle: FileSystemFileHandle;
+  fullStream: FileSystemWritableFileStream;
   readonly streams: Map<string, FileSystemWritableFileStream>;
   readonly pageOrder: Map<string, number>;
   readonly indexHandle: FileSystemFileHandle;
@@ -172,6 +173,19 @@ function scheduleIndexFlush(): void {
   }, 5000);
 }
 
+// Issue #225 — open / re-open a writable at end-of-file so subsequent
+// writes append. createWritable({keepExistingData}) defaults to position
+// 0, which is correct for a freshly-created empty file but overwrites
+// existing content after a flush+reopen cycle.
+export async function reopenAtEnd(
+  fh: FileSystemFileHandle,
+): Promise<FileSystemWritableFileStream> {
+  const file = await fh.getFile();
+  const stream = await fh.createWritable({ keepExistingData: true });
+  if (file.size > 0) await stream.seek(file.size);
+  return stream;
+}
+
 export async function startSession(root: FileSystemDirectoryHandle): Promise<{
   sessionPath: string;
 }> {
@@ -180,14 +194,13 @@ export async function startSession(root: FileSystemDirectoryHandle): Promise<{
   const sessionDir = await root.getDirectoryHandle(sessionId, { create: true });
   const pagesDir = await sessionDir.getDirectoryHandle('pages', { create: true });
   const fullHandle = await sessionDir.getFileHandle('full.jsonl', { create: true });
-  const fullStream = await fullHandle.createWritable({ keepExistingData: true });
-  // Position writer at end. Existing data is empty for a freshly-created file.
-  await fullStream.seek(0);
+  const fullStream = await reopenAtEnd(fullHandle);
   const indexHandle = await sessionDir.getFileHandle('index.json', { create: true });
 
   session = {
     sessionDir,
     pagesDir,
+    fullHandle,
     fullStream,
     streams: new Map(),
     pageOrder: new Map(),
@@ -214,8 +227,9 @@ async function getOrCreateBucketStream(filename: string): Promise<FileSystemWrit
   const isPageFile = !filename.startsWith('_');
   const dir = isPageFile ? session.pagesDir : session.sessionDir;
   const fh = await dir.getFileHandle(filename, { create: true });
-  const stream = await fh.createWritable({ keepExistingData: true });
-  await stream.seek(0);
+  // reopenAtEnd seeks to current file size so writes after a flush+reopen
+  // cycle (issue #225) append rather than overwrite from position 0.
+  const stream = await reopenAtEnd(fh);
   session.streams.set(filename, stream);
   return stream;
 }
@@ -263,6 +277,40 @@ export async function writeEntry(entry: LogEntry): Promise<void> {
   session.bytesWritten += bytes.byteLength;
 
   scheduleIndexFlush();
+}
+
+// Issue #225 — periodic flush. Closes every cached writable so Chrome
+// renames the .crswap swap files to their .jsonl targets, making logs
+// tail-readable with bounded latency. Subsequent writes lazily reopen
+// streams via getOrCreateBucketStream / reopenAtEnd.
+//
+// The viewer drives the cadence: it serialises flush() through the same
+// pendingWrites tail-promise as writeEntry(), so flushes never race
+// in-flight writes.
+export async function flush(): Promise<void> {
+  if (session === null) return;
+  try {
+    await session.fullStream.close();
+  } catch (err) {
+    console.error('[file-writer] full close during flush', err);
+  }
+  session.fullStream = await reopenAtEnd(session.fullHandle);
+
+  const oldStreams = Array.from(session.streams.values());
+  session.streams.clear();
+  for (const stream of oldStreams) {
+    try {
+      await stream.close();
+    } catch (err) {
+      console.error('[file-writer] bucket close during flush', err);
+    }
+  }
+
+  try {
+    await writeIndex();
+  } catch (err) {
+    console.error('[file-writer] index flush during flush', err);
+  }
 }
 
 export async function stopSession(): Promise<void> {

--- a/src/log-viewer/log-viewer.ts
+++ b/src/log-viewer/log-viewer.ts
@@ -2,6 +2,7 @@ import { LOG_PORT_NAME, type LogPortMessage } from '@/shared/log-bus.js';
 import type { LogEntry, LogLevel, LogSource } from '@/shared/logger.js';
 import {
   ensurePermission,
+  flush as flushWriter,
   getSavedHandle,
   pickDirectory,
   startSession,
@@ -9,6 +10,8 @@ import {
   writeEntry,
   stats as writerStats,
 } from './file-writer.js';
+
+const FLUSH_INTERVAL_MS = 2000;
 
 interface FilterState {
   readonly levels: ReadonlySet<LogLevel>;
@@ -54,6 +57,7 @@ const els = {
 const writerState = {
   active: false,
   pendingWrites: Promise.resolve(),
+  flushTimer: null as ReturnType<typeof setInterval> | null,
 };
 
 function updateDiskStat(): void {
@@ -400,6 +404,18 @@ async function activateWriter(): Promise<void> {
     // Backfill: write everything currently in the buffer so the disk
     // record opens with the same context the user is looking at.
     for (const entry of state.buffer) maybePersistEntry(entry);
+    // Issue #225 — periodic flush so the .jsonl files become tail-readable
+    // with bounded latency. Serialised through pendingWrites so flushes
+    // never race in-flight writes.
+    writerState.flushTimer = setInterval(() => {
+      if (!writerState.active) return;
+      writerState.pendingWrites = writerState.pendingWrites
+        .then(() => flushWriter())
+        .then(() => updateDiskStat())
+        .catch((err) => {
+          console.error('[log-viewer] periodic flush failed', err);
+        });
+    }, FLUSH_INTERVAL_MS);
   } catch (err) {
     console.error('[log-viewer] activate writer failed', err);
     const msg = err instanceof Error ? err.message : 'unknown error';
@@ -416,6 +432,10 @@ async function deactivateWriter(): Promise<void> {
   els.btnSave.disabled = true;
   els.btnSave.textContent = 'Stopping…';
   writerState.active = false;
+  if (writerState.flushTimer !== null) {
+    clearInterval(writerState.flushTimer);
+    writerState.flushTimer = null;
+  }
   try {
     await writerState.pendingWrites;
     await stopSession();


### PR DESCRIPTION
## Summary

Fixes the `.crswap` annoyance surfaced tonight: while a session is active, Chrome buffers writes in `<file>.jsonl.crswap` and only renames to `<file>.jsonl` on `.close()`. The named files were 0 bytes during a session, so `tail -f full.jsonl` showed nothing. External tooling had to read `.crswap` directly — non-obvious and Chrome-implementation-specific.

After this PR, every 2 seconds the viewer closes + reopens streams. Chrome renames `.crswap` → `.jsonl`, content lands on disk with bounded latency, and `tail -f` works.

## What's in this PR

**Modified `src/log-viewer/file-writer.ts`**
- `SessionState` now carries `fullHandle` (the `FileSystemFileHandle`) so post-flush reopen can recreate the `full.jsonl` writable.
- New exported helper `reopenAtEnd(fileHandle)` — `getFile().size` + `createWritable({keepExistingData: true})` + `seek(size)`. Used by both `startSession` and `getOrCreateBucketStream` so post-flush writes append rather than overwrite from position 0.
- New exported `flush()`: closes `fullStream` + every cached bucket stream (Chrome renames `.crswap` → `.jsonl` on close), clears the cache so subsequent writes lazily reopen at end, re-writes `index.json`.

**Modified `src/log-viewer/log-viewer.ts`**
- `activateWriter` starts a 2-second `setInterval` that posts `flush()` onto the existing `writerState.pendingWrites` tail-promise. Serialisation through the same queue as `writeEntry` guarantees flush never races an in-flight write.
- `deactivateWriter` clears the timer before awaiting `pendingWrites` + `stopSession`.

**New `src/log-viewer/file-writer.test.ts`**
- 3 cases covering `reopenAtEnd` empty-file (no seek), `reopenAtEnd` existing-data (seeks to size), and fresh-writable-per-call invariant.

## Why viewer-driven, not file-writer-driven

`writeEntry` and `flush` both mutate stream state and must not race. The viewer already serialises `writeEntry` calls through `writerState.pendingWrites`. Adding flush as another `.then()` on the same chain is the cheapest way to guarantee correct ordering without introducing a second internal queue inside `file-writer.ts`. File-writer stays mostly stateless w.r.t. timing; the viewer owns cadence.

## Latency / overhead

- Tail latency: ~2 seconds.
- Overhead: 2 syscalls per stream per 2s (close + reopen). At our log volume (≤100 entries/s peak during scan, typically ≤1/s steady), negligible.
- No data loss — `pendingWrites` ensures all in-flight writes complete before flush proceeds.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — all pass (3 new for `reopenAtEnd`)
- [x] `npm run build` — clean
- [ ] Manual smoke: load `dist/`, open viewer with "Save to disk" enabled, watch a session subdirectory — `full.jsonl` and per-page files grow visibly within 2-3 seconds rather than appearing as 0-byte files with `.crswap` siblings.

## Relationship to other in-flight work

- Pairs with #224 (heartbeat) — together they make the leak hunt loggable+tail-readable.
- Unblocks `tail -f`-based diagnostic workflows for #217 and any future incident.

Closes #225