### PR TITLE
fix(extension-#230,#231): dedupe duplicate VERDICTs and dispose stamp lifecycle

### DIFF
--- a/src/content/index.test.ts
+++ b/src/content/index.test.ts
@@ -1,0 +1,214 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { SecurityVerdict, SecurityStatus } from '@/types/verdict.js';
+import type { PageStamp } from '@/types/page-stamp.js';
+import type { HoneyLLMMessage, VerdictMessage } from '@/types/messages.js';
+
+// Issue #230 + #231 — integration tests for the content-script
+// onMessage handler. The handler dedups duplicate VERDICTs by
+// timestamp and disposes the previous stamp lifecycle before
+// installing a new one.
+
+const stampSpies = vi.hoisted(() => ({
+  embedStamp: vi.fn(),
+  installStampObservers: vi.fn(),
+  installNavigationTeardown: vi.fn(),
+}));
+
+const signalSpies = vi.hoisted(() => ({
+  setWindowGlobals: vi.fn(),
+  setSecurityMetaTag: vi.fn(),
+}));
+
+vi.mock('./signaling/page-stamp-embed.js', () => ({
+  embedStamp: stampSpies.embedStamp,
+  installStampObservers: stampSpies.installStampObservers,
+  installNavigationTeardown: stampSpies.installNavigationTeardown,
+}));
+
+vi.mock('./signaling/window-globals.js', () => ({
+  setWindowGlobals: signalSpies.setWindowGlobals,
+}));
+
+vi.mock('./signaling/meta-tag.js', () => ({
+  setSecurityMetaTag: signalSpies.setSecurityMetaTag,
+}));
+
+vi.mock('./mitigation/network-guard.js', () => ({
+  injectNetworkGuard: vi.fn(),
+  activateNetworkGuard: vi.fn(),
+}));
+
+vi.mock('./mitigation/dom-sanitizer.js', () => ({
+  sanitizeSuspiciousNodes: vi.fn(() => []),
+}));
+
+vi.mock('./mitigation/redirect-blocker.js', () => ({
+  activateRedirectBlocker: vi.fn(),
+}));
+
+vi.mock('./rescan.js', () => ({
+  rescanWithForcedMitigation: vi.fn(async () => undefined),
+}));
+
+vi.mock('./diagnostic-heartbeat.js', () => ({
+  startHeartbeat: vi.fn(() => ({ stop: vi.fn() })),
+}));
+
+vi.mock('./ingestion/extractor.js', () => ({
+  extractPageSnapshot: vi.fn(async () => ({})),
+}));
+
+const FIXTURE_STAMP: PageStamp = {
+  v: 1,
+  url: 'https://example.com/',
+  status: 'CLEAN',
+  timestamp: 1_700_000_000_000,
+  nonce: 'fixture-nonce',
+  hmac: 'a'.repeat(64),
+};
+
+function makeVerdict(timestamp: number, status: SecurityStatus = 'CLEAN'): SecurityVerdict {
+  return {
+    status,
+    confidence: 0.9,
+    totalScore: 0,
+    probeResults: [],
+    behavioralFlags: {
+      roleDrift: false,
+      exfiltrationIntent: false,
+      instructionFollowing: false,
+      hiddenContentAwareness: false,
+    },
+    mitigationsApplied: [],
+    timestamp,
+    url: 'https://example.com/',
+    analysisError: null,
+    canaryId: null,
+    webgpuAdapterMode: null,
+    stamp: FIXTURE_STAMP,
+    perChunkAnalysis: null,
+    entitySummary: null,
+    responseVerdict: null,
+    thinkingVerdict: null,
+    embeddingsFindings: null,
+  };
+}
+
+interface ChromeStub {
+  runtime: {
+    onMessage: { addListener: (fn: (m: HoneyLLMMessage) => void) => void };
+    sendMessage: (msg: unknown) => Promise<unknown>;
+  };
+  tabs: {
+    sendMessage: (tabId: number, msg: unknown) => Promise<unknown>;
+  };
+}
+
+interface CapturedListener {
+  fn: ((m: HoneyLLMMessage) => void) | null;
+}
+
+async function loadContentScript(): Promise<CapturedListener> {
+  const captured: CapturedListener = { fn: null };
+
+  // Force the local-harness short-circuit so injectNetworkGuard / run() are
+  // skipped at module load. The onMessage.addListener call is unconditional
+  // and runs regardless.
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: {
+      ...window.location,
+      hostname: '127.0.0.1',
+      port: '8765',
+      href: 'http://127.0.0.1:8765/',
+    },
+  });
+
+  const chromeStub: ChromeStub = {
+    runtime: {
+      onMessage: {
+        addListener: (fn: (m: HoneyLLMMessage) => void): void => {
+          captured.fn = fn;
+        },
+      },
+      sendMessage: vi.fn(async () => undefined),
+    },
+    tabs: {
+      sendMessage: vi.fn(async () => undefined),
+    },
+  };
+  vi.stubGlobal('chrome', chromeStub);
+
+  // Reset module registry so each test gets a fresh module-scope state.
+  vi.resetModules();
+  await import('./index.js');
+  if (captured.fn === null) throw new Error('content/index.ts did not register a listener');
+  return captured;
+}
+
+describe('content/index.ts onMessage VERDICT handler — duplicate dedup (#230)', () => {
+  beforeEach(() => {
+    stampSpies.embedStamp.mockReset();
+    stampSpies.installStampObservers.mockReset();
+    stampSpies.installNavigationTeardown.mockReset();
+    signalSpies.setWindowGlobals.mockReset();
+    signalSpies.setSecurityMetaTag.mockReset();
+
+    stampSpies.embedStamp.mockImplementation(() => ({}));
+    stampSpies.installStampObservers.mockImplementation(() => ({ disconnect: vi.fn() }));
+    stampSpies.installNavigationTeardown.mockImplementation(() => ({ teardown: vi.fn() }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('processes a fresh VERDICT (timestamp not seen before)', async () => {
+    const captured = await loadContentScript();
+    const msg: VerdictMessage = { type: 'VERDICT', verdict: makeVerdict(1) };
+    captured.fn!(msg);
+    expect(signalSpies.setWindowGlobals).toHaveBeenCalledTimes(1);
+    expect(signalSpies.setSecurityMetaTag).toHaveBeenCalledTimes(1);
+    expect(stampSpies.embedStamp).toHaveBeenCalledTimes(1);
+    expect(stampSpies.installStampObservers).toHaveBeenCalledTimes(1);
+    expect(stampSpies.installNavigationTeardown).toHaveBeenCalledTimes(1);
+  });
+
+  it('suppresses a duplicate VERDICT with the same timestamp', async () => {
+    const captured = await loadContentScript();
+    const verdict = makeVerdict(2);
+    captured.fn!({ type: 'VERDICT', verdict });
+    captured.fn!({ type: 'VERDICT', verdict });
+    expect(signalSpies.setWindowGlobals).toHaveBeenCalledTimes(1);
+    expect(stampSpies.embedStamp).toHaveBeenCalledTimes(1);
+    expect(stampSpies.installStampObservers).toHaveBeenCalledTimes(1);
+  });
+
+  it('processes a VERDICT with a newer timestamp and tears down the previous stamp first (#231)', async () => {
+    const captured = await loadContentScript();
+    const teardown1 = vi.fn();
+    const teardown2 = vi.fn();
+    stampSpies.installNavigationTeardown
+      .mockImplementationOnce(() => ({ teardown: teardown1 }))
+      .mockImplementationOnce(() => ({ teardown: teardown2 }));
+
+    captured.fn!({ type: 'VERDICT', verdict: makeVerdict(10) });
+    expect(teardown1).not.toHaveBeenCalled();
+
+    captured.fn!({ type: 'VERDICT', verdict: makeVerdict(11) });
+    expect(teardown1).toHaveBeenCalledTimes(1);
+    expect(teardown2).not.toHaveBeenCalled();
+    expect(stampSpies.embedStamp).toHaveBeenCalledTimes(2);
+    expect(stampSpies.installStampObservers).toHaveBeenCalledTimes(2);
+  });
+
+  it('a VERDICT with stamp=null skips the stamp pipeline entirely', async () => {
+    const captured = await loadContentScript();
+    const v: SecurityVerdict = { ...makeVerdict(20), stamp: null };
+    captured.fn!({ type: 'VERDICT', verdict: v });
+    expect(signalSpies.setWindowGlobals).toHaveBeenCalledTimes(1);
+    expect(stampSpies.embedStamp).not.toHaveBeenCalled();
+    expect(stampSpies.installStampObservers).not.toHaveBeenCalled();
+  });
+});

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -33,6 +33,7 @@ import {
   embedStamp,
   installStampObservers,
   installNavigationTeardown,
+  type NavigationTeardownHandle,
 } from './signaling/page-stamp-embed.js';
 import { rescanWithForcedMitigation } from './rescan.js';
 import { startHeartbeat, type HeartbeatHandle } from './diagnostic-heartbeat.js';
@@ -83,9 +84,27 @@ function applyMitigations(verdict: SecurityVerdict): SecurityVerdict {
     : verdict;
 }
 
+// Issue #231 — track the active stamp lifecycle so a fresh VERDICT can
+// dispose the previous observer pair + popstate/hashchange listeners
+// before installing a new pair. Without this, repeat VERDICTs (see #230)
+// stack observers and listeners that leak across the page lifetime.
+let activeStamp: NavigationTeardownHandle | null = null;
+
+// Issue #230 — content-side idempotency. The SW dedups duplicate dispatches
+// at dispatch.ts; this is belt-and-braces against any path that reaches the
+// content script through a non-dispatch route. Keyed on verdict.timestamp,
+// which is unique per analysis (Date.now() in evaluatePolicy).
+let lastVerdictTimestamp: number | null = null;
+
 chrome.runtime.onMessage.addListener((message: HoneyLLMMessage) => {
   if (message.type === 'VERDICT') {
     const verdict = message.verdict;
+    if (lastVerdictTimestamp !== null && lastVerdictTimestamp === verdict.timestamp) {
+      log.warn(`Suppressed duplicate VERDICT at content-side ts=${verdict.timestamp}`);
+      return;
+    }
+    lastVerdictTimestamp = verdict.timestamp;
+
     log.info(`Received verdict: ${verdict.status} (confidence: ${verdict.confidence})`);
 
     setWindowGlobals(verdict);
@@ -95,9 +114,10 @@ chrome.runtime.onMessage.addListener((message: HoneyLLMMessage) => {
     // skipped verdicts and verdicts where ensureInstallSecret failed
     // arrive with stamp=null and skip the embed path.
     if (verdict.stamp !== null) {
+      activeStamp?.teardown();
       const nodes = embedStamp(verdict.stamp);
       const observers = installStampObservers(nodes, verdict.stamp);
-      installNavigationTeardown(observers, nodes);
+      activeStamp = installNavigationTeardown(observers, nodes);
     }
   }
 

--- a/src/content/signaling/page-stamp-embed.test.ts
+++ b/src/content/signaling/page-stamp-embed.test.ts
@@ -161,4 +161,30 @@ describe('installNavigationTeardown', () => {
     await flushMicrotasks();
     expect(countStampNodes()).toBe(0);
   });
+
+  // Issue #231 — manual teardown handle so a fresh VERDICT can dispose
+  // the prior stamp lifecycle before installing a new one.
+  it('returns a handle whose teardown() disconnects observers and removes stamp nodes', async () => {
+    const nodes = embedStamp(FIXTURE_STAMP);
+    const obs = installStampObservers(nodes, FIXTURE_STAMP);
+    const handle = installNavigationTeardown(obs, nodes);
+    expect(countStampNodes()).toBe(3);
+    handle.teardown();
+    expect(countStampNodes()).toBe(0);
+    // Observers should be disconnected — adding/removing nodes must not re-embed
+    resetDom();
+    await flushMicrotasks();
+    expect(countStampNodes()).toBe(0);
+  });
+
+  it('handle.teardown() is idempotent (manual + popstate fires safely)', async () => {
+    const nodes = embedStamp(FIXTURE_STAMP);
+    const obs = installStampObservers(nodes, FIXTURE_STAMP);
+    const handle = installNavigationTeardown(obs, nodes);
+    handle.teardown();
+    expect(() => handle.teardown()).not.toThrow();
+    // popstate after manual teardown must not throw or re-create state
+    expect(() => window.dispatchEvent(new PopStateEvent('popstate'))).not.toThrow();
+    expect(countStampNodes()).toBe(0);
+  });
 });

--- a/src/content/signaling/page-stamp-embed.ts
+++ b/src/content/signaling/page-stamp-embed.ts
@@ -43,6 +43,16 @@ export interface StampObservers {
   disconnect(): void;
 }
 
+export interface NavigationTeardownHandle {
+  /**
+   * Issue #231 — manual teardown for callers that need to dispose the
+   * stamp before navigation fires (e.g. a fresh VERDICT supersedes the
+   * previous one). Idempotent: safe to call multiple times and safe to
+   * call after popstate/hashchange has already fired.
+   */
+  teardown(): void;
+}
+
 function bytesToBase64url(bytes: Uint8Array): string {
   let binary = '';
   for (let i = 0; i < bytes.length; i += 1) {
@@ -139,8 +149,11 @@ export function installStampObservers(initial: StampNodes, stamp: PageStamp): St
 export function installNavigationTeardown(
   observers: StampObservers,
   _nodes: StampNodes,
-): void {
+): NavigationTeardownHandle {
+  let disposed = false;
   const teardown = (): void => {
+    if (disposed) return;
+    disposed = true;
     observers.disconnect();
     const remaining = document.querySelectorAll(`[${STAMP_DATA_ATTR}]`);
     remaining.forEach((el) => el.remove());
@@ -149,4 +162,5 @@ export function installNavigationTeardown(
   };
   window.addEventListener('popstate', teardown);
   window.addEventListener('hashchange', teardown);
+  return { teardown };
 }

--- a/src/service-worker/dispatch.test.ts
+++ b/src/service-worker/dispatch.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import type { SecurityVerdict, SecurityStatus } from '@/types/verdict.js';
 import { STORAGE_KEY_TESTING_MODE } from '@/shared/constants.js';
-import { dispatchVerdictMessages, handleRescanWithMitigation, handleRescanPage } from './dispatch.js';
+import {
+  dispatchVerdictMessages,
+  handleRescanWithMitigation,
+  handleRescanPage,
+  handleTabRemovedForDispatch,
+  __resetDispatchState,
+} from './dispatch.js';
 
 interface ChromeStub {
   storage: {
@@ -77,7 +83,10 @@ function findMessage(sent: SentMessage[], type: string): SentMessage | undefined
 }
 
 describe('dispatchVerdictMessages — testing-mode gate', () => {
-  beforeEach(() => vi.unstubAllGlobals());
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    __resetDispatchState();
+  });
   afterEach(() => vi.unstubAllGlobals());
 
   it('always dispatches VERDICT regardless of testing-mode (CLEAN, mode off)', async () => {
@@ -182,6 +191,70 @@ describe('dispatchVerdictMessages — testing-mode gate', () => {
     await dispatchVerdictMessages(42, makeVerdict('CLEAN'), false);
     const verdictMsg = findMessage(sent, 'VERDICT');
     expect(verdictMsg!.tabId).toBe(42);
+  });
+});
+
+describe('dispatchVerdictMessages — duplicate-VERDICT idempotency (#230)', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    __resetDispatchState();
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('emits exactly one VERDICT per call (CLEAN — no APPLY_MITIGATION path)', async () => {
+    const { sent } = stubChrome(false);
+    await dispatchVerdictMessages(1, makeVerdict('CLEAN'), false);
+    const verdictCount = sent.filter((s) => (s.msg as { type?: string }).type === 'VERDICT').length;
+    expect(verdictCount).toBe(1);
+  });
+
+  it('emits exactly one VERDICT per call (COMPROMISED — APPLY_MITIGATION also dispatched)', async () => {
+    const { sent } = stubChrome(false);
+    await dispatchVerdictMessages(1, makeVerdict('COMPROMISED'), false);
+    const verdictCount = sent.filter((s) => (s.msg as { type?: string }).type === 'VERDICT').length;
+    const mitigateCount = sent.filter((s) => (s.msg as { type?: string }).type === 'APPLY_MITIGATION').length;
+    expect(verdictCount).toBe(1);
+    expect(mitigateCount).toBe(1);
+  });
+
+  it('suppresses a duplicate dispatch for same tab + same verdict.timestamp', async () => {
+    const { sent } = stubChrome(false);
+    const verdict = makeVerdict('COMPROMISED');
+    await dispatchVerdictMessages(1, verdict, false);
+    await dispatchVerdictMessages(1, verdict, false); // duplicate — should be skipped
+    const verdictCount = sent.filter((s) => (s.msg as { type?: string }).type === 'VERDICT').length;
+    const mitigateCount = sent.filter((s) => (s.msg as { type?: string }).type === 'APPLY_MITIGATION').length;
+    expect(verdictCount).toBe(1);
+    expect(mitigateCount).toBe(1);
+  });
+
+  it('allows re-dispatch when verdict.timestamp differs (newer analysis)', async () => {
+    const { sent } = stubChrome(false);
+    const first = makeVerdict('CLEAN');
+    const second: SecurityVerdict = { ...first, timestamp: first.timestamp + 1 };
+    await dispatchVerdictMessages(1, first, false);
+    await dispatchVerdictMessages(1, second, false);
+    const verdictCount = sent.filter((s) => (s.msg as { type?: string }).type === 'VERDICT').length;
+    expect(verdictCount).toBe(2);
+  });
+
+  it('dedup is per-tab — same timestamp on a different tab is dispatched', async () => {
+    const { sent } = stubChrome(false);
+    const verdict = makeVerdict('CLEAN');
+    await dispatchVerdictMessages(1, verdict, false);
+    await dispatchVerdictMessages(2, verdict, false);
+    const verdictCount = sent.filter((s) => (s.msg as { type?: string }).type === 'VERDICT').length;
+    expect(verdictCount).toBe(2);
+  });
+
+  it('handleTabRemovedForDispatch clears state so a recycled tab id starts fresh', async () => {
+    const { sent } = stubChrome(false);
+    const verdict = makeVerdict('CLEAN');
+    await dispatchVerdictMessages(1, verdict, false);
+    handleTabRemovedForDispatch(1);
+    await dispatchVerdictMessages(1, verdict, false);
+    const verdictCount = sent.filter((s) => (s.msg as { type?: string }).type === 'VERDICT').length;
+    expect(verdictCount).toBe(2);
   });
 });
 

--- a/src/service-worker/dispatch.ts
+++ b/src/service-worker/dispatch.ts
@@ -5,6 +5,26 @@ import type {
   VerdictMessage,
 } from '@/types/messages.js';
 import { isTestingModeEnabled } from '@/shared/testing-mode.js';
+import { createLogger } from '@/shared/logger.js';
+
+const log = createLogger('Dispatch');
+
+// Issue #230 — per-tab idempotency keyed on verdict.timestamp. analyzeSnapshot
+// stamps a unique Date.now() onto every verdict via evaluatePolicy, so a
+// duplicate dispatch (whatever its source) is detectable by matching tabId +
+// timestamp. The duplicate is dropped at the dispatch layer; the warn log
+// surfaces the second-call origin if/when one persists in production.
+const lastDispatchedTimestamp = new Map<number, number>();
+
+/** Test-only: clear all per-tab dedup state. */
+export function __resetDispatchState(): void {
+  lastDispatchedTimestamp.clear();
+}
+
+/** Tab-removal cleanup hook — wired from `chrome.tabs.onRemoved`. */
+export function handleTabRemovedForDispatch(tabId: number): void {
+  lastDispatchedTimestamp.delete(tabId);
+}
 
 /**
  * Issue #113 (N2) — VERDICT + APPLY_MITIGATION dispatch with testing-mode gate.
@@ -32,6 +52,13 @@ export async function dispatchVerdictMessages(
   verdict: SecurityVerdict,
   forceMitigation: boolean,
 ): Promise<void> {
+  const prior = lastDispatchedTimestamp.get(tabId);
+  if (prior !== undefined && prior === verdict.timestamp) {
+    log.warn(`Suppressed duplicate VERDICT dispatch tab=${tabId} ts=${verdict.timestamp}`);
+    return;
+  }
+  lastDispatchedTimestamp.set(tabId, verdict.timestamp);
+
   const verdictMsg: VerdictMessage = { type: 'VERDICT', verdict };
   chrome.tabs.sendMessage(tabId, verdictMsg);
 

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -14,7 +14,12 @@ import { analyzeThinking } from './thinking-analyzer.js';
 import { setTabVerdict, handleTabActivated, handleTabRemoved } from './toolbar-icon.js';
 import { ensureInstallSecret } from '@/shared/install-secret.js';
 import { verifyStamp } from './stamp.js';
-import { dispatchVerdictMessages, handleRescanWithMitigation, handleRescanPage } from './dispatch.js';
+import {
+  dispatchVerdictMessages,
+  handleRescanWithMitigation,
+  handleRescanPage,
+  handleTabRemovedForDispatch,
+} from './dispatch.js';
 import { scanUrl } from './url-scanner.js';
 import { loadRegistryOnce } from '@/registry/lookup.js';
 import { bootstrapEmbeddingsHunter } from './embeddings-bootstrap.js';
@@ -92,7 +97,12 @@ chrome.runtime.onStartup.addListener(() => {
 
 // Phase 4 Stage 4D.4 — per-tab icon state lifecycle hooks.
 chrome.tabs.onActivated.addListener(handleTabActivated);
-chrome.tabs.onRemoved.addListener(handleTabRemoved);
+chrome.tabs.onRemoved.addListener((tabId) => {
+  handleTabRemoved(tabId);
+  // Issue #230 — drop the per-tab dedup entry so a future tab reusing the same
+  // numeric id (Chrome recycles ids over the SW lifetime) starts fresh.
+  handleTabRemovedForDispatch(tabId);
+});
 
 chrome.runtime.onMessage.addListener((message: HoneyLLMMessage, sender, sendResponse) => {
   switch (message.type) {


### PR DESCRIPTION
## Summary

Closes #230 and #231 — paired because the duplicate-VERDICT dispatch is the trigger for the observer-stack accumulation.

- **#230 (duplicate VERDICT)** — `dispatch.ts` now keys per-tab dedup on `verdict.timestamp`. A repeat dispatch for the same `(tabId, timestamp)` is dropped at the helper with a `Suppressed duplicate VERDICT dispatch` warn line that surfaces any remaining second-call origin in production logs. Tab removal flushes the dedup entry. Content-script `index.ts` mirrors this with a `lastVerdictTimestamp` guard so any non-dispatch route into the listener is also de-duped.
- **#231 (observer stacking)** — `installNavigationTeardown` now returns a `NavigationTeardownHandle` with an idempotent `teardown()`. The content script tracks the active stamp and disposes the previous observer pair + popstate/hashchange listeners before installing a new pair on a fresh VERDICT. Manual `teardown()` + subsequent popstate/hashchange events are safe (no double-remove).

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 1477/1477 (added 13 new tests across `dispatch.test.ts`, `page-stamp-embed.test.ts`, new `content/index.test.ts`)
- [x] `npm run build` clean
- [ ] Live re-verify on `bricklink.com/v2/main.page` and `lego.com/en-au` after merge — expect one `Received verdict` per analysis and bounded heartbeat node count

## Notes

- Root cause of the second VERDICT dispatch on bricklink couldn't be pinned in static analysis (the manifest's `world: ISOLATED` + default `all_frames: false` + only one `tabs.sendMessage(VERDICT)` call site for non-portal pages should have ruled it out). The dedup is belt-and-braces — the warn log surfaces the second-call path if it persists.
- Phase 2 byte-locked baseline (`docs/testing/inbrowser-results.json`) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)