### PR TITLE
fix(extension-#233): deactivate mitigations on benign re-verdict; partial-failure → UNKNOWN

### DIFF
--- a/src/content/index.test.ts
+++ b/src/content/index.test.ts
@@ -34,9 +34,15 @@ vi.mock('./signaling/meta-tag.js', () => ({
   setSecurityMetaTag: signalSpies.setSecurityMetaTag,
 }));
 
+const mitigationSpies = vi.hoisted(() => ({
+  deactivateNetworkGuard: vi.fn(),
+  deactivateRedirectBlocker: vi.fn(),
+}));
+
 vi.mock('./mitigation/network-guard.js', () => ({
   injectNetworkGuard: vi.fn(),
   activateNetworkGuard: vi.fn(),
+  deactivateNetworkGuard: mitigationSpies.deactivateNetworkGuard,
 }));
 
 vi.mock('./mitigation/dom-sanitizer.js', () => ({
@@ -45,6 +51,7 @@ vi.mock('./mitigation/dom-sanitizer.js', () => ({
 
 vi.mock('./mitigation/redirect-blocker.js', () => ({
   activateRedirectBlocker: vi.fn(),
+  deactivateRedirectBlocker: mitigationSpies.deactivateRedirectBlocker,
 }));
 
 vi.mock('./rescan.js', () => ({
@@ -210,5 +217,49 @@ describe('content/index.ts onMessage VERDICT handler — duplicate dedup (#230)'
     expect(signalSpies.setWindowGlobals).toHaveBeenCalledTimes(1);
     expect(stampSpies.embedStamp).not.toHaveBeenCalled();
     expect(stampSpies.installStampObservers).not.toHaveBeenCalled();
+  });
+});
+
+describe('content/index.ts onMessage DEACTIVATE_MITIGATIONS handler (#233A)', () => {
+  beforeEach(() => {
+    stampSpies.embedStamp.mockReset();
+    stampSpies.installStampObservers.mockReset();
+    stampSpies.installNavigationTeardown.mockReset();
+    signalSpies.setWindowGlobals.mockReset();
+    signalSpies.setSecurityMetaTag.mockReset();
+    mitigationSpies.deactivateNetworkGuard.mockReset();
+    mitigationSpies.deactivateRedirectBlocker.mockReset();
+
+    stampSpies.embedStamp.mockImplementation(() => ({}));
+    stampSpies.installStampObservers.mockImplementation(() => ({ disconnect: vi.fn() }));
+    stampSpies.installNavigationTeardown.mockImplementation(() => ({ teardown: vi.fn() }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('invokes deactivateNetworkGuard and deactivateRedirectBlocker', async () => {
+    const captured = await loadContentScript();
+    captured.fn!({ type: 'DEACTIVATE_MITIGATIONS' });
+    expect(mitigationSpies.deactivateNetworkGuard).toHaveBeenCalledTimes(1);
+    expect(mitigationSpies.deactivateRedirectBlocker).toHaveBeenCalledTimes(1);
+  });
+
+  it('tears down the active stamp lifecycle from a prior VERDICT', async () => {
+    const captured = await loadContentScript();
+    const teardown = vi.fn();
+    stampSpies.installNavigationTeardown.mockReturnValueOnce({ teardown });
+    captured.fn!({ type: 'VERDICT', verdict: makeVerdict(50, 'COMPROMISED') });
+    expect(teardown).not.toHaveBeenCalled();
+
+    captured.fn!({ type: 'DEACTIVATE_MITIGATIONS' });
+    expect(teardown).toHaveBeenCalledTimes(1);
+  });
+
+  it('is safe when no stamp was previously installed', async () => {
+    const captured = await loadContentScript();
+    expect(() => captured.fn!({ type: 'DEACTIVATE_MITIGATIONS' })).not.toThrow();
+    expect(mitigationSpies.deactivateNetworkGuard).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -24,9 +24,16 @@ setLogSink((entry: LogEntry) => {
   }
 });
 import { extractPageSnapshot } from './ingestion/extractor.js';
-import { injectNetworkGuard, activateNetworkGuard } from './mitigation/network-guard.js';
+import {
+  injectNetworkGuard,
+  activateNetworkGuard,
+  deactivateNetworkGuard,
+} from './mitigation/network-guard.js';
 import { sanitizeSuspiciousNodes } from './mitigation/dom-sanitizer.js';
-import { activateRedirectBlocker } from './mitigation/redirect-blocker.js';
+import {
+  activateRedirectBlocker,
+  deactivateRedirectBlocker,
+} from './mitigation/redirect-blocker.js';
 import { setWindowGlobals } from './signaling/window-globals.js';
 import { setSecurityMetaTag } from './signaling/meta-tag.js';
 import {
@@ -125,6 +132,18 @@ chrome.runtime.onMessage.addListener((message: HoneyLLMMessage) => {
     const updated = applyMitigations(message.verdict);
     setWindowGlobals(updated);
     log.info(`Mitigations applied: ${updated.mitigationsApplied.join(', ')}`);
+  }
+
+  // Issue #233 — symmetric deactivate. Fired by the SW when a CLEAN/UNKNOWN
+  // verdict supersedes a prior COMPROMISED/SUSPICIOUS for this tab. Roll
+  // back the network guard, redirect blocker, and stamp lifecycle so the
+  // page is not left in a half-mitigated state after a transient flip.
+  if (message.type === 'DEACTIVATE_MITIGATIONS') {
+    deactivateNetworkGuard();
+    deactivateRedirectBlocker();
+    activeStamp?.teardown();
+    activeStamp = null;
+    log.info('Mitigations deactivated');
   }
 
   // Issue #113 (N2) — popup-triggered rescan with mitigations forced

--- a/src/policy/engine.test.ts
+++ b/src/policy/engine.test.ts
@@ -149,6 +149,42 @@ describe('evaluatePolicy', () => {
       expect(verdict.status).toBe('CLEAN');
       expect(verdict.analysisError).toBeNull();
     });
+
+    // Issue #233 — partial probe failure where surviving probes do not
+    // produce a positive signal must be UNKNOWN, not CLEAN(1.0). The prior
+    // `[analysisError: partial probe failure] CLEAN(1.0)` verdict was
+    // contradictory and caused the bricklink false-flip.
+    it('returns UNKNOWN when partial probe failure leaves no positive signal (#233B)', () => {
+      const results = [
+        makeResult({ probeName: 'summarization', passed: false, errorMessage: 'evidence_review timeout' }),
+        makeResult({ probeName: 'instruction_detection', passed: true, score: 0 }),
+        makeResult({ probeName: 'adversarial_compliance', passed: true, score: 0 }),
+      ];
+      const verdict = evaluatePolicy(
+        results,
+        CLEAN_FLAGS,
+        'https://partial-clean.com',
+        'partial probe failure: summarization',
+      );
+      expect(verdict.status).toBe('UNKNOWN');
+      expect(verdict.confidence).toBe(0);
+      expect(verdict.analysisError).toBe('partial probe failure: summarization');
+    });
+
+    it('keeps SUSPICIOUS when partial failure has a real positive signal (#233B regression)', () => {
+      const results = [
+        makeResult({ probeName: 'summarization', passed: false, errorMessage: 'engine timeout' }),
+        makeResult({ probeName: 'instruction_detection', passed: false, score: 40 }),
+      ];
+      const verdict = evaluatePolicy(
+        results,
+        CLEAN_FLAGS,
+        'https://partial-suspicious.com',
+        'partial probe failure: summarization',
+      );
+      expect(verdict.status).toBe('SUSPICIOUS');
+      expect(verdict.confidence).toBeGreaterThan(0);
+    });
   });
 
   // Phase 4 Stage 4D.3 — canaryId wiring.

--- a/src/policy/engine.ts
+++ b/src/policy/engine.ts
@@ -24,6 +24,10 @@ function allProbesErrored(probeResults: readonly ProbeResult[]): boolean {
   return probeResults.every((r) => r.errorMessage !== null);
 }
 
+function anyProbeErrored(probeResults: readonly ProbeResult[]): boolean {
+  return probeResults.some((r) => r.errorMessage !== null);
+}
+
 export function evaluatePolicy(
   probeResults: readonly ProbeResult[],
   behavioralFlags: BehavioralFlags,
@@ -79,6 +83,37 @@ export function evaluatePolicy(
   }
 
   const { totalScore } = computeScore(probeResults, behavioralFlags);
+
+  // Issue #233 — partial probe failure where the surviving probes do not
+  // produce a positive signal (score < SUSPICIOUS) must not be reported as
+  // CLEAN. confidenceFromScore(0) is 1.0, which combined with an analysis
+  // error produced a contradictory `CLEAN(1.0) [analysisError: partial probe
+  // failure: ...]` verdict. Mirror the all-errored branch instead so the
+  // popup and downstream consumers see UNKNOWN with confidence=0 — the page
+  // could not be fully assessed. SUSPICIOUS/COMPROMISED scores still win
+  // (a real signal beats a single-probe error).
+  if (anyProbeErrored(probeResults) && statusFromScore(totalScore) === 'CLEAN') {
+    return {
+      status: 'UNKNOWN',
+      confidence: 0,
+      totalScore,
+      probeResults,
+      behavioralFlags,
+      mitigationsApplied: [],
+      timestamp: Date.now(),
+      url,
+      analysisError: aggregateError,
+      canaryId,
+      webgpuAdapterMode,
+      stamp: null,
+      perChunkAnalysis: null,
+      entitySummary: null,
+      responseVerdict: null,
+      thinkingVerdict: null,
+      embeddingsFindings: null,
+    };
+  }
+
   const status = statusFromScore(totalScore);
   const confidence = confidenceFromScore(totalScore);
 

--- a/src/service-worker/dispatch.test.ts
+++ b/src/service-worker/dispatch.test.ts
@@ -258,6 +258,74 @@ describe('dispatchVerdictMessages — duplicate-VERDICT idempotency (#230)', () 
   });
 });
 
+describe('dispatchVerdictMessages — DEACTIVATE_MITIGATIONS path (#233A)', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    __resetDispatchState();
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  function makeVerdictAt(status: SecurityStatus, ts: number): SecurityVerdict {
+    return { ...makeVerdict(status), timestamp: ts };
+  }
+
+  it('emits DEACTIVATE_MITIGATIONS when CLEAN supersedes a prior COMPROMISED', async () => {
+    const { sent } = stubChrome(false);
+    await dispatchVerdictMessages(1, makeVerdictAt('COMPROMISED', 100), false);
+    await dispatchVerdictMessages(1, makeVerdictAt('CLEAN', 101), false);
+    expect(findMessage(sent, 'DEACTIVATE_MITIGATIONS')).toBeDefined();
+  });
+
+  it('emits DEACTIVATE_MITIGATIONS when UNKNOWN supersedes a prior SUSPICIOUS', async () => {
+    const { sent } = stubChrome(false);
+    await dispatchVerdictMessages(1, makeVerdictAt('SUSPICIOUS', 200), false);
+    await dispatchVerdictMessages(1, makeVerdictAt('UNKNOWN', 201), false);
+    expect(findMessage(sent, 'DEACTIVATE_MITIGATIONS')).toBeDefined();
+  });
+
+  it('does not emit DEACTIVATE_MITIGATIONS on the first verdict (no prior state)', async () => {
+    const { sent } = stubChrome(false);
+    await dispatchVerdictMessages(1, makeVerdictAt('CLEAN', 100), false);
+    expect(findMessage(sent, 'DEACTIVATE_MITIGATIONS')).toBeUndefined();
+  });
+
+  it('does not emit DEACTIVATE_MITIGATIONS on CLEAN → CLEAN', async () => {
+    const { sent } = stubChrome(false);
+    await dispatchVerdictMessages(1, makeVerdictAt('CLEAN', 100), false);
+    await dispatchVerdictMessages(1, makeVerdictAt('CLEAN', 101), false);
+    expect(findMessage(sent, 'DEACTIVATE_MITIGATIONS')).toBeUndefined();
+  });
+
+  it('does not emit DEACTIVATE_MITIGATIONS on COMPROMISED → COMPROMISED', async () => {
+    const { sent } = stubChrome(false);
+    await dispatchVerdictMessages(1, makeVerdictAt('COMPROMISED', 100), false);
+    await dispatchVerdictMessages(1, makeVerdictAt('COMPROMISED', 101), false);
+    expect(findMessage(sent, 'DEACTIVATE_MITIGATIONS')).toBeUndefined();
+  });
+
+  it('does not emit DEACTIVATE_MITIGATIONS on COMPROMISED → SUSPICIOUS (still mitigated)', async () => {
+    const { sent } = stubChrome(false);
+    await dispatchVerdictMessages(1, makeVerdictAt('COMPROMISED', 100), false);
+    await dispatchVerdictMessages(1, makeVerdictAt('SUSPICIOUS', 101), false);
+    expect(findMessage(sent, 'DEACTIVATE_MITIGATIONS')).toBeUndefined();
+  });
+
+  it('emits DEACTIVATE_MITIGATIONS even when testing-mode would block APPLY_MITIGATION', async () => {
+    const { sent } = stubChrome(true); // testing-mode on
+    await dispatchVerdictMessages(1, makeVerdictAt('COMPROMISED', 100), true); // forceMitigation
+    await dispatchVerdictMessages(1, makeVerdictAt('CLEAN', 101), false);
+    expect(findMessage(sent, 'DEACTIVATE_MITIGATIONS')).toBeDefined();
+  });
+
+  it('handleTabRemovedForDispatch clears the status so a recycled tab id does not deactivate spuriously', async () => {
+    const { sent } = stubChrome(false);
+    await dispatchVerdictMessages(1, makeVerdictAt('COMPROMISED', 100), false);
+    handleTabRemovedForDispatch(1);
+    await dispatchVerdictMessages(1, makeVerdictAt('CLEAN', 101), false);
+    expect(findMessage(sent, 'DEACTIVATE_MITIGATIONS')).toBeUndefined();
+  });
+});
+
 describe('handleRescanWithMitigation', () => {
   beforeEach(() => vi.unstubAllGlobals());
   afterEach(() => vi.unstubAllGlobals());

--- a/src/service-worker/dispatch.ts
+++ b/src/service-worker/dispatch.ts
@@ -1,6 +1,7 @@
-import type { SecurityVerdict } from '@/types/verdict.js';
+import type { SecurityVerdict, SecurityStatus } from '@/types/verdict.js';
 import type {
   ApplyMitigationMessage,
+  DeactivateMitigationsMessage,
   TriggerRescanMessage,
   VerdictMessage,
 } from '@/types/messages.js';
@@ -16,14 +17,31 @@ const log = createLogger('Dispatch');
 // surfaces the second-call origin if/when one persists in production.
 const lastDispatchedTimestamp = new Map<number, number>();
 
+// Issue #233 — track the last dispatched status per tab so a CLEAN/UNKNOWN
+// verdict superseding a prior COMPROMISED/SUSPICIOUS can fire a symmetric
+// DEACTIVATE_MITIGATIONS message. Without this, the content-script's
+// network guard + redirect blocker stay armed indefinitely after a
+// transient false-positive.
+const lastDispatchedStatus = new Map<number, SecurityStatus>();
+
 /** Test-only: clear all per-tab dedup state. */
 export function __resetDispatchState(): void {
   lastDispatchedTimestamp.clear();
+  lastDispatchedStatus.clear();
 }
 
 /** Tab-removal cleanup hook — wired from `chrome.tabs.onRemoved`. */
 export function handleTabRemovedForDispatch(tabId: number): void {
   lastDispatchedTimestamp.delete(tabId);
+  lastDispatchedStatus.delete(tabId);
+}
+
+function isMitigatedStatus(status: SecurityStatus): boolean {
+  return status === 'COMPROMISED' || status === 'SUSPICIOUS';
+}
+
+function isBenignStatus(status: SecurityStatus): boolean {
+  return status === 'CLEAN' || status === 'UNKNOWN';
 }
 
 /**
@@ -61,6 +79,16 @@ export async function dispatchVerdictMessages(
 
   const verdictMsg: VerdictMessage = { type: 'VERDICT', verdict };
   chrome.tabs.sendMessage(tabId, verdictMsg);
+
+  // Issue #233 — symmetric deactivate path. Fires when a benign verdict
+  // supersedes a prior mitigated verdict on the same tab. Done before the
+  // APPLY_MITIGATION gate so the deactivate isn't suppressed by testing-mode.
+  const priorStatus = lastDispatchedStatus.get(tabId);
+  if (priorStatus !== undefined && isMitigatedStatus(priorStatus) && isBenignStatus(verdict.status)) {
+    const deactivateMsg: DeactivateMitigationsMessage = { type: 'DEACTIVATE_MITIGATIONS' };
+    chrome.tabs.sendMessage(tabId, deactivateMsg);
+  }
+  lastDispatchedStatus.set(tabId, verdict.status);
 
   if (verdict.status !== 'COMPROMISED' && verdict.status !== 'SUSPICIOUS') return;
 

--- a/src/service-worker/orchestrator.test.ts
+++ b/src/service-worker/orchestrator.test.ts
@@ -5,8 +5,12 @@ import {
   buildUnsupportedLanguageVerdict,
   swapInFlightController,
   AnalysisAbortedError,
+  mergeProbeResults,
+  computeAggregateError,
 } from './orchestrator.js';
 import type { PageSnapshot } from '@/types/snapshot.js';
+import type { BehavioralFlags, ProbeResult } from '@/types/verdict.js';
+import { evaluatePolicy } from '@/policy/engine.js';
 
 function snapshotFixture(overrides: Partial<PageSnapshot['metadata']> = {}): PageSnapshot {
   return {
@@ -262,5 +266,48 @@ describe('AnalysisAbortedError (issue #11)', () => {
     expect(err).toBeInstanceOf(AnalysisAbortedError);
     expect(err.name).toBe('AnalysisAbortedError');
     expect(err.message).toBe('superseded');
+  });
+});
+
+// Issue #233B — partial probe failure must not surface as CLEAN(1.0). This
+// integration test exercises the merge + aggregate + evaluate chain that
+// `analyzeSnapshot` runs (orchestrator.ts:622-651) without standing up the
+// full snapshot pipeline.
+describe('partial probe failure → UNKNOWN (#233B integration)', () => {
+  const FLAGS: BehavioralFlags = {
+    roleDrift: false,
+    exfiltrationIntent: false,
+    instructionFollowing: false,
+    hiddenContentAwareness: false,
+  };
+
+  function probe(overrides: Partial<ProbeResult>): ProbeResult {
+    return {
+      probeName: 'evidence_review',
+      passed: true,
+      flags: [],
+      rawOutput: '',
+      score: 0,
+      errorMessage: null,
+      ...overrides,
+    };
+  }
+
+  it('one errored probe + two zero-score survivors aggregates to UNKNOWN, not CLEAN(1.0)', () => {
+    const chunkResults = [
+      [
+        probe({ probeName: 'evidence_review', errorMessage: 'evidence_review timeout', passed: false }),
+        probe({ probeName: 'instruction_detection', score: 0 }),
+        probe({ probeName: 'adversarial_compliance', score: 0 }),
+      ],
+    ];
+    const merged = mergeProbeResults(chunkResults);
+    const aggregateError = computeAggregateError(merged);
+    expect(aggregateError).toMatch(/partial probe failure: evidence_review/);
+
+    const verdict = evaluatePolicy(merged, FLAGS, 'https://partial.example.com', aggregateError);
+    expect(verdict.status).toBe('UNKNOWN');
+    expect(verdict.confidence).toBe(0);
+    expect(verdict.analysisError).toBe(aggregateError);
   });
 });

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -12,6 +12,11 @@ export type MessageType =
   | 'PROBE_RESULTS'
   | 'VERDICT'
   | 'APPLY_MITIGATION'
+  // Issue #233 — symmetric deactivate path. SW → content, dispatched
+  // when a CLEAN/UNKNOWN verdict supersedes a prior COMPROMISED/SUSPICIOUS
+  // for the same tab. Tells the content script to roll back active
+  // mitigations (network guard, redirect blocker) and remove the stamp.
+  | 'DEACTIVATE_MITIGATIONS'
   | 'ENGINE_STATUS'
   | 'ENGINE_READY'
   | 'PING_KEEPALIVE'
@@ -144,6 +149,17 @@ export interface VerdictMessage extends BaseMessage {
 export interface ApplyMitigationMessage extends BaseMessage {
   readonly type: 'APPLY_MITIGATION';
   readonly verdict: SecurityVerdict;
+}
+
+/**
+ * Issue #233 — sent by the SW when a CLEAN or UNKNOWN verdict
+ * supersedes a prior COMPROMISED/SUSPICIOUS for the same tab. The
+ * content script deactivates the network guard, detaches the redirect
+ * blocker, and tears down the page-stamp lifecycle. No payload is
+ * needed — the trigger condition is decided in dispatch.ts.
+ */
+export interface DeactivateMitigationsMessage extends BaseMessage {
+  readonly type: 'DEACTIVATE_MITIGATIONS';
 }
 
 export interface EngineStatusMessage extends BaseMessage {
@@ -430,6 +446,7 @@ export type HoneyLLMMessage =
   | ProbeResultsMessage
   | VerdictMessage
   | ApplyMitigationMessage
+  | DeactivateMitigationsMessage
   | EngineStatusMessage
   | EngineReadyMessage
   | PingKeepaliveMessage


### PR DESCRIPTION
## Summary

Closes #233 — both sub-fixes (mitigation rollback + probe-failure verdict).

### Sub-fix A — mitigation rollback (`dispatch.ts` + `content/index.ts`)

- New message: `DEACTIVATE_MITIGATIONS` (no payload).
- `dispatch.ts` tracks last dispatched status per tab. When CLEAN/UNKNOWN supersedes a prior COMPROMISED/SUSPICIOUS for the same tab, emits `DEACTIVATE_MITIGATIONS` before the existing `APPLY_MITIGATION` gate (so it fires even with testing-mode on).
- Content script handler rolls back the network guard, redirect blocker, and tears down the stamp lifecycle (reusing the `NavigationTeardownHandle.teardown()` from #231). Tab-removal cleanup clears the per-tab status to avoid spurious deactivates on id recycling.

### Sub-fix B — partial probe failure → UNKNOWN (`policy/engine.ts`)

- `evaluatePolicy` previously fell through to score-derived CLEAN with `confidence = 1 - 0/150 = 1.0` whenever some probes errored and survivors scored 0, producing the contradictory `CLEAN(1.0) [analysisError: partial probe failure: ...]` verdict observed on bricklink.com.
- New branch: when **any** probe errored AND `statusFromScore(totalScore) === 'CLEAN'`, return UNKNOWN with confidence=0. SUSPICIOUS/COMPROMISED scores still win — a real positive signal beats a single-probe error (the existing `keeps score-derived status... when partial failure` test still passes).

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 1491/1491 (added 14 new tests across `engine.test.ts`, `dispatch.test.ts`, `content/index.test.ts`, `orchestrator.test.ts`)
- [x] `npm run build` clean
- [ ] Live re-verify on bricklink.com/v2/main.page after merge — second analysis should now surface UNKNOWN, not CLEAN(1.0); after a COMPROMISED→CLEAN flip on any origin, confirm `__HONEYLLM_GUARD_ACTIVE__` flips false in main-world DevTools

## Notes

- Phase 2 byte-locked baseline (`docs/testing/inbrowser-results.json`) is untouched.
- Builds on PR #234 (#230 + #231). The deactivate path reuses the `NavigationTeardownHandle` introduced there.
- #232 (false-positive flag on bricklink) explicitly deferred — needs #226 per-hunter logging coverage to triage which primitive flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)