### PR TITLE
feat(extension-#236): logging-state broadcast scaffolding (SW side, PR1/4)

### DIFF
--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -20,6 +20,15 @@ import {
   handleRescanPage,
   handleTabRemovedForDispatch,
 } from './dispatch.js';
+import {
+  STORAGE_KEY_LOGGING_STATE,
+  broadcastLoggingState,
+  sendLoggingStateToTab,
+  dropTabFromLoggingState,
+  markViewerConnected,
+  markViewerDisconnected,
+  refreshHeartbeatBadge,
+} from './logging-broadcast.js';
 import { scanUrl } from './url-scanner.js';
 import { loadRegistryOnce } from '@/registry/lookup.js';
 import { bootstrapEmbeddingsHunter } from './embeddings-bootstrap.js';
@@ -39,7 +48,32 @@ const log = createLogger('ServiceWorker');
 chrome.runtime.onConnect.addListener((port) => {
   if (port.name === LOG_PORT_NAME) {
     logBus.connect(port);
+    // Issue #236 — flip viewer-connected, broadcast to content scripts so
+    // they enable their log sink. The viewer's own onDisconnect is wired
+    // by LogBus.connect; we add a sibling listener here to flip back +
+    // re-broadcast so content stops shipping logs once the viewer closes.
+    void markViewerConnected().then(broadcastLoggingState);
+    port.onDisconnect.addListener(() => {
+      void markViewerDisconnected().then(broadcastLoggingState);
+    });
   }
+});
+
+// Issue #236 — re-broadcast logging state whenever it changes (e.g. via
+// log-viewer toggle write or popup banner click). Single write site
+// (chrome.storage), single broadcast site (this listener).
+chrome.storage.onChanged.addListener((changes, area) => {
+  if (area !== 'local') return;
+  if (changes[STORAGE_KEY_LOGGING_STATE] === undefined) return;
+  void broadcastLoggingState();
+  void refreshHeartbeatBadge();
+});
+
+// Issue #236 — fresh content-script init catches the resolved state
+// without waiting for the next state change.
+chrome.tabs.onUpdated.addListener((tabId, info) => {
+  if (info.status !== 'complete') return;
+  void sendLoggingStateToTab(tabId);
 });
 
 // Issue #117 (N13) — bootstrap the per-install HMAC secret on every
@@ -85,6 +119,7 @@ chrome.runtime.onInstalled.addListener(() => {
   bootstrapInstallSecret();
   bootstrapRegistry();
   bootstrapEmbeddings();
+  void refreshHeartbeatBadge();
 });
 
 chrome.runtime.onStartup.addListener(() => {
@@ -93,6 +128,7 @@ chrome.runtime.onStartup.addListener(() => {
   bootstrapInstallSecret();
   bootstrapRegistry();
   bootstrapEmbeddings();
+  void refreshHeartbeatBadge();
 });
 
 // Phase 4 Stage 4D.4 — per-tab icon state lifecycle hooks.
@@ -102,6 +138,9 @@ chrome.tabs.onRemoved.addListener((tabId) => {
   // Issue #230 — drop the per-tab dedup entry so a future tab reusing the same
   // numeric id (Chrome recycles ids over the SW lifetime) starts fresh.
   handleTabRemovedForDispatch(tabId);
+  // Issue #236 — strip the per-tab heartbeat override so a recycled
+  // tab id starts fresh from the global default.
+  void dropTabFromLoggingState(tabId);
 });
 
 chrome.runtime.onMessage.addListener((message: HoneyLLMMessage, sender, sendResponse) => {

--- a/src/service-worker/logging-broadcast.test.ts
+++ b/src/service-worker/logging-broadcast.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  STORAGE_KEY_LOGGING_STATE,
+  type LoggingState,
+  getLoggingState,
+  setLoggingState,
+  effectiveHeartbeat,
+  anyHeartbeatActive,
+  broadcastLoggingState,
+  sendLoggingStateToTab,
+  dropTabFromLoggingState,
+  refreshHeartbeatBadge,
+} from './logging-broadcast.js';
+
+interface ChromeStub {
+  storage: {
+    local: {
+      get: (key: string) => Promise<Record<string, unknown>>;
+      set: (entries: Record<string, unknown>) => Promise<void>;
+    };
+  };
+  tabs: {
+    query: (info: chrome.tabs.QueryInfo) => Promise<chrome.tabs.Tab[]>;
+    sendMessage: (tabId: number, msg: unknown) => Promise<unknown>;
+  };
+  action: {
+    setBadgeText: (details: { text: string }) => Promise<void>;
+    setTitle: (details: { title: string }) => Promise<void>;
+  };
+}
+
+interface SentMessage {
+  readonly tabId: number;
+  readonly msg: unknown;
+}
+
+interface BadgeCalls {
+  readonly text: string[];
+  readonly title: string[];
+}
+
+function stubChrome(initial: Partial<LoggingState> | undefined, tabs: { id: number | undefined }[]): {
+  sent: SentMessage[];
+  badge: BadgeCalls;
+  storage: Record<string, unknown>;
+} {
+  const sent: SentMessage[] = [];
+  const badge: BadgeCalls = { text: [], title: [] };
+  const storage: Record<string, unknown> = {};
+  if (initial !== undefined) {
+    storage[STORAGE_KEY_LOGGING_STATE] = initial;
+  }
+  const stub: ChromeStub = {
+    storage: {
+      local: {
+        get: async (key: string) => (key in storage ? { [key]: storage[key] } : {}),
+        set: async (entries: Record<string, unknown>) => {
+          Object.assign(storage, entries);
+        },
+      },
+    },
+    tabs: {
+      query: async () => tabs as chrome.tabs.Tab[],
+      sendMessage: async (tabId: number, msg: unknown) => {
+        sent.push({ tabId, msg });
+      },
+    },
+    action: {
+      setBadgeText: async ({ text }) => {
+        badge.text.push(text);
+      },
+      setTitle: async ({ title }) => {
+        badge.title.push(title);
+      },
+    },
+  };
+  vi.stubGlobal('chrome', stub);
+  return { sent, badge, storage };
+}
+
+const FULL_STATE = (overrides: Partial<LoggingState> = {}): LoggingState => ({
+  connected: false,
+  heartbeat: { global: false, perTab: {} },
+  ...overrides,
+});
+
+describe('effectiveHeartbeat', () => {
+  it('returns perTab[id] when defined (true)', () => {
+    expect(effectiveHeartbeat(FULL_STATE({ heartbeat: { global: false, perTab: { 7: true } } }), 7)).toBe(true);
+  });
+
+  it('returns perTab[id] when defined (false) — overrides global=true', () => {
+    expect(effectiveHeartbeat(FULL_STATE({ heartbeat: { global: true, perTab: { 7: false } } }), 7)).toBe(false);
+  });
+
+  it('falls back to global when perTab[id] is undefined', () => {
+    expect(effectiveHeartbeat(FULL_STATE({ heartbeat: { global: true, perTab: {} } }), 7)).toBe(true);
+    expect(effectiveHeartbeat(FULL_STATE({ heartbeat: { global: false, perTab: {} } }), 7)).toBe(false);
+  });
+});
+
+describe('anyHeartbeatActive', () => {
+  it('false when global=false and no perTab entries', () => {
+    expect(anyHeartbeatActive(FULL_STATE())).toBe(false);
+  });
+
+  it('true when global=true', () => {
+    expect(anyHeartbeatActive(FULL_STATE({ heartbeat: { global: true, perTab: {} } }))).toBe(true);
+  });
+
+  it('true when any perTab entry is true (even if global=false)', () => {
+    expect(anyHeartbeatActive(FULL_STATE({ heartbeat: { global: false, perTab: { 1: true } } }))).toBe(true);
+  });
+
+  it('false when all perTab entries are false and global=false', () => {
+    expect(anyHeartbeatActive(FULL_STATE({ heartbeat: { global: false, perTab: { 1: false, 2: false } } }))).toBe(false);
+  });
+});
+
+describe('getLoggingState', () => {
+  beforeEach(() => vi.unstubAllGlobals());
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('returns the default state when storage is empty', async () => {
+    stubChrome(undefined, []);
+    const s = await getLoggingState();
+    expect(s.connected).toBe(false);
+    expect(s.heartbeat.global).toBe(false);
+    expect(Object.keys(s.heartbeat.perTab)).toHaveLength(0);
+  });
+
+  it('returns the persisted state', async () => {
+    stubChrome({ connected: true, heartbeat: { global: true, perTab: { 5: false } } }, []);
+    const s = await getLoggingState();
+    expect(s.connected).toBe(true);
+    expect(s.heartbeat.global).toBe(true);
+    expect(s.heartbeat.perTab[5]).toBe(false);
+  });
+});
+
+describe('setLoggingState', () => {
+  beforeEach(() => vi.unstubAllGlobals());
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('partial patch merges with existing state', async () => {
+    const { storage } = stubChrome({ connected: false, heartbeat: { global: true, perTab: { 1: true } } }, []);
+    await setLoggingState({ connected: true });
+    const persisted = storage[STORAGE_KEY_LOGGING_STATE] as LoggingState;
+    expect(persisted.connected).toBe(true);
+    expect(persisted.heartbeat.global).toBe(true);
+    expect(persisted.heartbeat.perTab[1]).toBe(true);
+  });
+});
+
+describe('broadcastLoggingState', () => {
+  beforeEach(() => vi.unstubAllGlobals());
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('sends per-tab resolved state to each active tab', async () => {
+    const { sent } = stubChrome(
+      { connected: true, heartbeat: { global: false, perTab: { 2: true } } },
+      [{ id: 1 }, { id: 2 }],
+    );
+    await broadcastLoggingState();
+    expect(sent).toHaveLength(2);
+    const tab1 = sent.find((s) => s.tabId === 1);
+    const tab2 = sent.find((s) => s.tabId === 2);
+    expect((tab1!.msg as { type: string; connected: boolean; heartbeat: boolean })).toEqual({
+      type: 'SET_LOGGING_STATE',
+      connected: true,
+      heartbeat: false, // global=false, no perTab[1]
+    });
+    expect((tab2!.msg as { type: string; connected: boolean; heartbeat: boolean })).toEqual({
+      type: 'SET_LOGGING_STATE',
+      connected: true,
+      heartbeat: true, // perTab[2]=true
+    });
+  });
+
+  it('skips tabs without an id', async () => {
+    const { sent } = stubChrome({ connected: false, heartbeat: { global: true, perTab: {} } }, [
+      { id: undefined },
+      { id: 5 },
+    ]);
+    await broadcastLoggingState();
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.tabId).toBe(5);
+  });
+});
+
+describe('sendLoggingStateToTab', () => {
+  beforeEach(() => vi.unstubAllGlobals());
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('sends the resolved state for the given tab id', async () => {
+    const { sent } = stubChrome({ connected: true, heartbeat: { global: false, perTab: { 9: true } } }, []);
+    await sendLoggingStateToTab(9);
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.tabId).toBe(9);
+    expect((sent[0]!.msg as { heartbeat: boolean }).heartbeat).toBe(true);
+  });
+});
+
+describe('dropTabFromLoggingState', () => {
+  beforeEach(() => vi.unstubAllGlobals());
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('strips the per-tab override', async () => {
+    const { storage } = stubChrome(
+      { connected: false, heartbeat: { global: false, perTab: { 1: true, 2: false } } },
+      [],
+    );
+    await dropTabFromLoggingState(1);
+    const persisted = storage[STORAGE_KEY_LOGGING_STATE] as LoggingState;
+    expect(persisted.heartbeat.perTab[1]).toBeUndefined();
+    expect(persisted.heartbeat.perTab[2]).toBe(false);
+  });
+
+  it('is a no-op when the tab has no override', async () => {
+    const { storage } = stubChrome({ connected: false, heartbeat: { global: false, perTab: {} } }, []);
+    const before = JSON.stringify(storage);
+    await dropTabFromLoggingState(99);
+    expect(JSON.stringify(storage)).toBe(before);
+  });
+});
+
+describe('refreshHeartbeatBadge', () => {
+  beforeEach(() => vi.unstubAllGlobals());
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('sets badge when heartbeat is active globally', async () => {
+    const { badge } = stubChrome({ connected: false, heartbeat: { global: true, perTab: {} } }, []);
+    await refreshHeartbeatBadge();
+    expect(badge.text[0]).toBe('\u{1F7E1}');
+    expect(badge.title[0]).toContain('Heartbeat active');
+  });
+
+  it('sets badge when heartbeat is active for any tab', async () => {
+    const { badge } = stubChrome({ connected: false, heartbeat: { global: false, perTab: { 3: true } } }, []);
+    await refreshHeartbeatBadge();
+    expect(badge.text[0]).toBe('\u{1F7E1}');
+  });
+
+  it('clears badge when no heartbeat is active', async () => {
+    const { badge } = stubChrome({ connected: false, heartbeat: { global: false, perTab: { 1: false } } }, []);
+    await refreshHeartbeatBadge();
+    expect(badge.text[0]).toBe('');
+    expect(badge.title[0]).toBe('HoneyLLM');
+  });
+});

--- a/src/service-worker/logging-broadcast.ts
+++ b/src/service-worker/logging-broadcast.ts
@@ -1,0 +1,144 @@
+import type { SetLoggingStateMessage } from '@/types/messages.js';
+import { createLogger } from '@/shared/logger.js';
+
+const log = createLogger('LoggingBroadcast');
+
+/**
+ * Issue #236 — single source of truth for content→SW logging state. The
+ * `connected` flag flips on log-viewer Port open/close. Heartbeat
+ * preference persists across SW + Chrome restarts (per-tab overrides
+ * are wiped on `chrome.tabs.onRemoved`).
+ */
+export const STORAGE_KEY_LOGGING_STATE = 'honeyllm:logging-state';
+
+export interface LoggingState {
+  readonly connected: boolean;
+  readonly heartbeat: {
+    readonly global: boolean;
+    readonly perTab: Readonly<Record<number, boolean>>;
+  };
+}
+
+const DEFAULT_STATE: LoggingState = {
+  connected: false,
+  heartbeat: { global: false, perTab: {} },
+};
+
+export async function getLoggingState(): Promise<LoggingState> {
+  const res = await chrome.storage.local.get(STORAGE_KEY_LOGGING_STATE);
+  const stored = res[STORAGE_KEY_LOGGING_STATE] as Partial<LoggingState> | undefined;
+  if (stored === undefined || stored === null) return DEFAULT_STATE;
+  return {
+    connected: stored.connected ?? false,
+    heartbeat: {
+      global: stored.heartbeat?.global ?? false,
+      perTab: stored.heartbeat?.perTab ?? {},
+    },
+  };
+}
+
+export async function setLoggingState(patch: Partial<LoggingState>): Promise<void> {
+  const current = await getLoggingState();
+  const next: LoggingState = {
+    connected: patch.connected ?? current.connected,
+    heartbeat: {
+      global: patch.heartbeat?.global ?? current.heartbeat.global,
+      perTab: patch.heartbeat?.perTab ?? current.heartbeat.perTab,
+    },
+  };
+  await chrome.storage.local.set({ [STORAGE_KEY_LOGGING_STATE]: next });
+}
+
+export function effectiveHeartbeat(state: LoggingState, tabId: number): boolean {
+  const override = state.heartbeat.perTab[tabId];
+  return override !== undefined ? override : state.heartbeat.global;
+}
+
+export function anyHeartbeatActive(state: LoggingState): boolean {
+  if (state.heartbeat.global) return true;
+  for (const tabId of Object.keys(state.heartbeat.perTab)) {
+    if (state.heartbeat.perTab[Number(tabId)]) return true;
+  }
+  return false;
+}
+
+/**
+ * Send the resolved per-tab logging state to every active tab. Failures
+ * (no content script in tab, tab closed mid-flight) are swallowed —
+ * dispatch is best-effort observability.
+ */
+export async function broadcastLoggingState(): Promise<void> {
+  const state = await getLoggingState();
+  const tabs = await chrome.tabs.query({});
+  for (const tab of tabs) {
+    if (tab.id === undefined) continue;
+    const msg: SetLoggingStateMessage = {
+      type: 'SET_LOGGING_STATE',
+      connected: state.connected,
+      heartbeat: effectiveHeartbeat(state, tab.id),
+    };
+    chrome.tabs.sendMessage(tab.id, msg).catch(() => {
+      // Tab may have no content script (chrome:// pages, file:// excluded
+      // by manifest, etc.) or may have closed mid-flight.
+    });
+  }
+}
+
+/**
+ * Send the resolved state to a single tab — used on `chrome.tabs.onUpdated`
+ * status='complete' so a freshly-mounted content script gets the current
+ * state without waiting for the next state change.
+ */
+export async function sendLoggingStateToTab(tabId: number): Promise<void> {
+  const state = await getLoggingState();
+  const msg: SetLoggingStateMessage = {
+    type: 'SET_LOGGING_STATE',
+    connected: state.connected,
+    heartbeat: effectiveHeartbeat(state, tabId),
+  };
+  chrome.tabs.sendMessage(tabId, msg).catch(() => undefined);
+}
+
+/**
+ * Strip a per-tab heartbeat override from storage. Called from
+ * `chrome.tabs.onRemoved` so a recycled tab id starts fresh from the
+ * global default. Mirrors the dedup-cleanup pattern from #234.
+ */
+export async function dropTabFromLoggingState(tabId: number): Promise<void> {
+  const current = await getLoggingState();
+  if (current.heartbeat.perTab[tabId] === undefined) return;
+  const nextPerTab: Record<number, boolean> = { ...current.heartbeat.perTab };
+  delete nextPerTab[tabId];
+  await setLoggingState({
+    heartbeat: { global: current.heartbeat.global, perTab: nextPerTab },
+  });
+}
+
+/**
+ * Reflect heartbeat-active state on the toolbar badge. Amber dot when
+ * any heartbeat (global or per-tab) is on, cleared otherwise. Lets a
+ * user who closed the log viewer with heartbeat still on notice on the
+ * next Chrome session.
+ */
+export async function refreshHeartbeatBadge(): Promise<void> {
+  const state = await getLoggingState();
+  if (anyHeartbeatActive(state)) {
+    await chrome.action.setBadgeText({ text: '\u{1F7E1}' });
+    await chrome.action.setTitle({ title: 'HoneyLLM — Heartbeat active (click to disable)' });
+  } else {
+    await chrome.action.setBadgeText({ text: '' });
+    await chrome.action.setTitle({ title: 'HoneyLLM' });
+  }
+}
+
+/** Internal: called on log-viewer Port connect. */
+export async function markViewerConnected(): Promise<void> {
+  await setLoggingState({ connected: true });
+  log.info('viewer connected');
+}
+
+/** Internal: called on log-viewer Port disconnect. */
+export async function markViewerDisconnected(): Promise<void> {
+  await setLoggingState({ connected: false });
+  log.info('viewer disconnected');
+}

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -17,6 +17,12 @@ export type MessageType =
   // for the same tab. Tells the content script to roll back active
   // mitigations (network guard, redirect blocker) and remove the stamp.
   | 'DEACTIVATE_MITIGATIONS'
+  // Issue #236 — SW broadcasts the current logging state to each
+  // content script: whether the log viewer is connected and whether the
+  // heartbeat should be running for THIS tab (already-resolved
+  // perTab[id] ?? global). Content uses it to gate its log sink and
+  // start/stop the heartbeat.
+  | 'SET_LOGGING_STATE'
   | 'ENGINE_STATUS'
   | 'ENGINE_READY'
   | 'PING_KEEPALIVE'
@@ -160,6 +166,26 @@ export interface ApplyMitigationMessage extends BaseMessage {
  */
 export interface DeactivateMitigationsMessage extends BaseMessage {
   readonly type: 'DEACTIVATE_MITIGATIONS';
+}
+
+/**
+ * Issue #236 — broadcast by the SW to every content script when the log
+ * viewer connects/disconnects or when the heartbeat preference changes.
+ *
+ * `connected` — true while a viewer Port is open on the SW. Content
+ *   uses this to gate its log sink: when false, log lines drop without
+ *   touching `chrome.runtime` (eliminating the closure-leak class
+ *   identified in #236 root-cause analysis).
+ *
+ * `heartbeat` — already-resolved per-tab value
+ *   (`perTab[tabId] ?? global`). Content starts/stops its heartbeat in
+ *   response. The SW resolves per-tab so content doesn't need to know
+ *   its own tabId.
+ */
+export interface SetLoggingStateMessage extends BaseMessage {
+  readonly type: 'SET_LOGGING_STATE';
+  readonly connected: boolean;
+  readonly heartbeat: boolean;
 }
 
 export interface EngineStatusMessage extends BaseMessage {
@@ -447,6 +473,7 @@ export type HoneyLLMMessage =
   | VerdictMessage
   | ApplyMitigationMessage
   | DeactivateMitigationsMessage
+  | SetLoggingStateMessage
   | EngineStatusMessage
   | EngineReadyMessage
   | PingKeepaliveMessage


### PR DESCRIPTION
## Summary

Refs #236 (PR1 of 4).

SW-side scaffolding for the content→SW logging Port migration. Adds the `SET_LOGGING_STATE` message type, a single source of truth in `chrome.storage.local['honeyllm:logging-state']`, broadcast helpers that fire on viewer Port connect/disconnect / storage change / tab updated / tab removed, and a toolbar badge that surfaces "🟡 Heartbeat active" when any heartbeat is on (so a heartbeat left on across Chrome restarts is never invisible).

**No-op in production for this PR.** Content scripts and the log viewer don't consume the new state yet — PR2 and PR3 wire those.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 1509/1509 (added 18 new tests in `src/service-worker/logging-broadcast.test.ts`)
- [x] `npm run build` clean

## Notes

- Storage shape: `{ connected: bool, heartbeat: { global: bool, perTab: { [id]: bool } } }`
- `effectiveHeartbeat(state, tabId)` resolves `perTab[id] ?? global` so content scripts don't need to know their own tabId.
- Per-tab override is wiped on `chrome.tabs.onRemoved` so a recycled tab id starts fresh from global default (mirror of #234's dispatch-dedup cleanup).
- Phase 2 byte-locked baseline + classifier files untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)