### PR TITLE
feat(extension-#236): popup heartbeat-active banner (PR4/4)

### DIFF
--- a/src/popup/heartbeat-banner.test.ts
+++ b/src/popup/heartbeat-banner.test.ts
@@ -1,0 +1,138 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { initHeartbeatBanner, isHeartbeatActiveForTab } from './heartbeat-banner.js';
+
+const STORAGE_KEY = 'honeyllm:logging-state';
+
+interface LoggingState {
+  connected: boolean;
+  heartbeat: { global: boolean; perTab: Record<number, boolean> };
+}
+
+interface ChromeStub {
+  storage: {
+    local: {
+      get: (key: string) => Promise<Record<string, unknown>>;
+      set: (entries: Record<string, unknown>) => Promise<void>;
+    };
+    onChanged: { addListener: (cb: (...args: unknown[]) => void) => void };
+  };
+  tabs: {
+    query: (info: chrome.tabs.QueryInfo) => Promise<chrome.tabs.Tab[]>;
+  };
+}
+
+function stubChrome(initial: Partial<LoggingState> | undefined, currentTabId: number | undefined): {
+  storage: Record<string, unknown>;
+} {
+  const storage: Record<string, unknown> = {};
+  if (initial !== undefined) storage[STORAGE_KEY] = initial;
+  const stub: ChromeStub = {
+    storage: {
+      local: {
+        get: async (key: string) => (key in storage ? { [key]: storage[key] } : {}),
+        set: async (entries: Record<string, unknown>) => {
+          Object.assign(storage, entries);
+        },
+      },
+      onChanged: { addListener: () => undefined },
+    },
+    tabs: {
+      query: async () => (currentTabId !== undefined ? [{ id: currentTabId } as chrome.tabs.Tab] : []),
+    },
+  };
+  vi.stubGlobal('chrome', stub);
+  return { storage };
+}
+
+describe('isHeartbeatActiveForTab (#236)', () => {
+  const STATE = (overrides: Partial<LoggingState> = {}): LoggingState => ({
+    connected: false,
+    heartbeat: { global: false, perTab: {} },
+    ...overrides,
+  });
+
+  it('false when global=false and no perTab override', () => {
+    expect(isHeartbeatActiveForTab(STATE(), 1)).toBe(false);
+  });
+
+  it('true when global=true (regardless of tabId)', () => {
+    expect(isHeartbeatActiveForTab(STATE({ heartbeat: { global: true, perTab: {} } }), 1)).toBe(true);
+    expect(isHeartbeatActiveForTab(STATE({ heartbeat: { global: true, perTab: {} } }), undefined)).toBe(true);
+  });
+
+  it('true when perTab[currentTab]=true (even if global=false)', () => {
+    expect(isHeartbeatActiveForTab(STATE({ heartbeat: { global: false, perTab: { 5: true } } }), 5)).toBe(true);
+  });
+
+  it('false when perTab[currentTab]=false (override defeats global=false)', () => {
+    expect(isHeartbeatActiveForTab(STATE({ heartbeat: { global: false, perTab: { 5: false } } }), 5)).toBe(false);
+  });
+
+  it('false when perTab override is for a DIFFERENT tab', () => {
+    expect(isHeartbeatActiveForTab(STATE({ heartbeat: { global: false, perTab: { 7: true } } }), 5)).toBe(false);
+  });
+});
+
+describe('initHeartbeatBanner — banner rendering (#236)', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    while (document.body.firstChild !== null) document.body.removeChild(document.body.firstChild);
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('does NOT render a visible banner when no heartbeat is active', async () => {
+    stubChrome({ connected: false, heartbeat: { global: false, perTab: {} } }, 1);
+    await initHeartbeatBanner();
+    const banner = document.getElementById('heartbeat-banner') as HTMLDivElement;
+    expect(banner).not.toBeNull();
+    expect(banner.style.display).toBe('none');
+  });
+
+  it('renders the banner when heartbeat.global=true', async () => {
+    stubChrome({ connected: false, heartbeat: { global: true, perTab: {} } }, 1);
+    await initHeartbeatBanner();
+    const banner = document.getElementById('heartbeat-banner') as HTMLDivElement;
+    expect(banner.style.display).toBe('flex');
+    expect(banner.textContent).toContain('Heartbeat active');
+  });
+
+  it('renders the banner when heartbeat.perTab[currentTab]=true (even if global=false)', async () => {
+    stubChrome({ connected: false, heartbeat: { global: false, perTab: { 42: true } } }, 42);
+    await initHeartbeatBanner();
+    const banner = document.getElementById('heartbeat-banner') as HTMLDivElement;
+    expect(banner.style.display).toBe('flex');
+  });
+
+  it('does NOT render when global=false and only OTHER tabs have overrides', async () => {
+    stubChrome({ connected: false, heartbeat: { global: false, perTab: { 99: true } } }, 1);
+    await initHeartbeatBanner();
+    const banner = document.getElementById('heartbeat-banner') as HTMLDivElement;
+    expect(banner.style.display).toBe('none');
+  });
+
+  it('clicking the banner writes global=false AND perTab[currentTab]=false', async () => {
+    const { storage } = stubChrome(
+      { connected: false, heartbeat: { global: true, perTab: {} } },
+      77,
+    );
+    await initHeartbeatBanner();
+    const banner = document.getElementById('heartbeat-banner') as HTMLDivElement;
+    banner.click();
+    // Allow the write to settle.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const persisted = storage[STORAGE_KEY] as LoggingState;
+    expect(persisted.heartbeat.global).toBe(false);
+    expect(persisted.heartbeat.perTab[77]).toBe(false);
+  });
+
+  it('inserts the banner as the first child of the host', async () => {
+    stubChrome({ connected: false, heartbeat: { global: true, perTab: {} } }, 1);
+    const sibling = document.createElement('p');
+    sibling.id = 'sibling';
+    document.body.appendChild(sibling);
+    await initHeartbeatBanner();
+    expect(document.body.firstChild?.nodeType).toBe(Node.ELEMENT_NODE);
+    expect((document.body.firstChild as HTMLElement).id).toBe('heartbeat-banner');
+  });
+});

--- a/src/popup/heartbeat-banner.ts
+++ b/src/popup/heartbeat-banner.ts
@@ -1,0 +1,108 @@
+// Issue #236 — popup heartbeat-active banner. Surfaces when heartbeat
+// is on (globally or for the current tab) so the user notices on every
+// popup open after Chrome restart. One-click disable writes both
+// global=false AND clears the per-tab override; SW broadcast (PR1)
+// then propagates SET_LOGGING_STATE to every content script.
+
+const STORAGE_KEY_LOGGING_STATE = 'honeyllm:logging-state';
+
+interface LoggingState {
+  connected: boolean;
+  heartbeat: { global: boolean; perTab: Record<number, boolean> };
+}
+
+async function readLoggingState(): Promise<LoggingState> {
+  const res = await chrome.storage.local.get(STORAGE_KEY_LOGGING_STATE);
+  const stored = res[STORAGE_KEY_LOGGING_STATE] as Partial<LoggingState> | undefined;
+  return {
+    connected: stored?.connected ?? false,
+    heartbeat: {
+      global: stored?.heartbeat?.global ?? false,
+      perTab: stored?.heartbeat?.perTab ?? {},
+    },
+  };
+}
+
+async function writeLoggingState(next: LoggingState): Promise<void> {
+  await chrome.storage.local.set({ [STORAGE_KEY_LOGGING_STATE]: next });
+}
+
+export function isHeartbeatActiveForTab(state: LoggingState, tabId: number | undefined): boolean {
+  if (state.heartbeat.global) return true;
+  if (tabId !== undefined && state.heartbeat.perTab[tabId] === true) return true;
+  return false;
+}
+
+async function disableHeartbeatForCurrentTab(tabId: number | undefined): Promise<void> {
+  const current = await readLoggingState();
+  const nextPerTab: Record<number, boolean> = { ...current.heartbeat.perTab };
+  if (tabId !== undefined) {
+    nextPerTab[tabId] = false;
+  }
+  await writeLoggingState({
+    connected: current.connected,
+    heartbeat: { global: false, perTab: nextPerTab },
+  });
+}
+
+function ensureBanner(host: HTMLElement): HTMLDivElement {
+  let banner = document.getElementById('heartbeat-banner') as HTMLDivElement | null;
+  if (banner !== null) return banner;
+  banner = document.createElement('div');
+  banner.id = 'heartbeat-banner';
+  banner.style.background = '#3a2f15';
+  banner.style.border = '1px solid #7a5d20';
+  banner.style.color = '#facc15';
+  banner.style.padding = '8px 12px';
+  banner.style.borderRadius = '6px';
+  banner.style.fontSize = '12px';
+  banner.style.marginBottom = '12px';
+  banner.style.cursor = 'pointer';
+  banner.style.display = 'flex';
+  banner.style.gap = '8px';
+  banner.style.alignItems = 'center';
+  banner.title = 'Click to disable heartbeat for the current tab and globally';
+  host.insertBefore(banner, host.firstChild);
+  return banner;
+}
+
+function renderBanner(banner: HTMLDivElement, active: boolean): void {
+  if (!active) {
+    banner.style.display = 'none';
+    while (banner.firstChild !== null) banner.removeChild(banner.firstChild);
+    return;
+  }
+  banner.style.display = 'flex';
+  while (banner.firstChild !== null) banner.removeChild(banner.firstChild);
+  const dot = document.createElement('span');
+  dot.textContent = '\u{1F7E1}';
+  banner.appendChild(dot);
+  const text = document.createElement('span');
+  text.textContent = 'Heartbeat active — click to disable';
+  text.style.flex = '1';
+  banner.appendChild(text);
+}
+
+export async function initHeartbeatBanner(host: HTMLElement = document.body): Promise<void> {
+  const banner = ensureBanner(host);
+
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  const tabId = tab?.id;
+
+  async function refresh(): Promise<void> {
+    const state = await readLoggingState();
+    renderBanner(banner, isHeartbeatActiveForTab(state, tabId));
+  }
+
+  banner.addEventListener('click', () => {
+    void disableHeartbeatForCurrentTab(tabId).then(refresh);
+  });
+
+  chrome.storage.onChanged.addListener((changes, area) => {
+    if (area !== 'local') return;
+    if (changes[STORAGE_KEY_LOGGING_STATE] === undefined) return;
+    void refresh();
+  });
+
+  await refresh();
+}

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -33,6 +33,7 @@ import { getCacheStats, clearCache } from '@/service-worker/scan-cache.js';
 import { getRegistryStats, resetRegistryTelemetry } from '@/registry/telemetry.js';
 import { renderRegistryStats } from './registry-stats.js';
 import { initPendingInterceptPanel } from './pending-intercept.js';
+import { initHeartbeatBanner } from './heartbeat-banner.js';
 
 interface StoredVerdict {
   status: string;
@@ -712,5 +713,12 @@ void (async () => {
     await initPendingInterceptPanel(panelRoot);
   } catch (err) {
     console.error('pending-intercept init failed', err);
+  }
+  try {
+    // Issue #236 — surface a heartbeat-active warning banner so a
+    // heartbeat left on across Chrome restarts is never invisible.
+    await initHeartbeatBanner();
+  } catch (err) {
+    console.error('heartbeat banner init failed', err);
   }
 })();


### PR DESCRIPTION
## Summary

Closes #236 (PR4 of 4 — final).

Adds an amber banner to the popup that surfaces when heartbeat is on either globally or for the current tab. Click disables both \`global=false\` AND \`perTab[currentTab]=false\` (so a one-click "kill heartbeat for this session" works). The toolbar badge from PR1 provides the passive amber dot; this PR completes the feedback loop so the user notices on every popup open after Chrome restart and can disable in one click.

The banner subscribes to \`chrome.storage.onChanged\` so it appears / disappears live if the log viewer or another popup toggles state.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 1535/1535 (added 11 new tests in \`src/popup/heartbeat-banner.test.ts\`)
- [x] \`npm run build\` clean

## Final-PR live verification (post-merge)

- [ ] Build + reload extension. Open Officeworks tab. Confirm content does not call \`chrome.runtime.sendMessage\` for log lines (SW DevTools network panel idle for log traffic).
- [ ] Open log viewer. Heartbeat checkbox initially OFF. Toolbar badge clears.
- [ ] Toggle heartbeat ON globally. Heartbeat lines appear in viewer for all tabs. Toolbar badge shows 🟡.
- [ ] Add a per-tab override OFF for Officeworks. Verify Officeworks stops heartbeating but other tabs continue.
- [ ] Close log viewer. Open popup. Banner appears: "🟡 Heartbeat active — click to disable". Click banner → state clears → badge clears.
- [ ] Restart Chrome. Confirm popup banner appears on first open if heartbeat was left on.
- [ ] **Heap-snapshot regression test**: 4h Officeworks tab with viewer closed + heartbeat global=ON. Take heap snapshot, diff against fresh-load snapshot. Expected closure delta < 1k (was +266k pre-fix).

## Notes

- Final PR for #236. With PR1+PR2+PR3+PR4 all merged: content scripts ship logs only when the viewer is connected, via a long-lived Port (no per-call Promise retention), with the heartbeat as a separately-toggleable producer.
- Phase 2 byte-locked baseline + classifier files untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)