### PR TITLE
docs(extension-#236): document Port pattern invariant

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,16 @@ The offscreen doc is created on first `PAGE_SNAPSHOT` after a reload, not eagerl
 
 When committing phase test results, commit **full per-probe result directories** as evidence. Gitignore only partial / wiped dumps that were superseded by a summary JSON. Before first `git add`, run `npm audit` + a broad secret grep — AIza keys are 39 chars, so regex must be ≥20 char suffix to catch them.
 
+### Content→SW logging via Port, not sendMessage (issue #236, 2026-05-04)
+
+`src/content/index.ts` log sink uses `chrome.runtime.connect({name: LOG_PORT_NAME})` + `port.postMessage(...)`, NOT `chrome.runtime.sendMessage(...).catch(...)`. Reason: when the SW is asleep, sendMessage's returned Promise + `.catch` arrow + decorated LogEntry pile up in Chrome's internal pending-message queue and never GC. Pre-fix on Officeworks: +266k closures + +160k V8 contexts over 20h, renderer RSS hit 650 MB. Post-fix at 9.5h: -4.49% edges (i.e. went DOWN). 18× reduction in the leak-pattern class.
+
+The sink also no-ops when `viewerConnected = false` (set by SW broadcasting `SET_LOGGING_STATE` on log-viewer Port connect/disconnect). In production the viewer is never opened, so the sink stays inert. State lives in `chrome.storage.local['honeyllm:logging-state']` with shape `{connected, heartbeat: {global, perTab: {[tabId]: bool}}}`.
+
+Heartbeat (`src/content/diagnostic-heartbeat.ts`) is opt-in via the same storage flag — never re-introduce an unconditional `startHeartbeat()` at content-script init. Toggle UI lives in the log viewer; popup banner + toolbar badge surface the active state across Chrome restarts.
+
+Any future content-side periodic timer that ships state to the SW must use this Port pattern. New high-frequency content→SW message types (>1×/sec) must consider whether they belong on the LogBus Port or need their own Port. Never put them on `sendMessage`.
+
 ## Execution-context map (service worker vs offscreen vs content)
 
 When debugging, know which context a log line came from:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -67,6 +67,14 @@ Applied when the verdict is SUSPICIOUS or COMPROMISED:
 
 Runs in the page's main JavaScript realm (not isolated). Overrides `fetch()` and `XMLHttpRequest.open()` to block requests to exfiltration endpoints before any page script can execute.
 
+### Content→SW logging (`src/content/index.ts` setLogSink, issue #236)
+
+Log entries from content scripts ship to the SW LogBus via a long-lived `chrome.runtime.connect({name: LOG_PORT_NAME})` Port — **not** via `chrome.runtime.sendMessage`. Reason: `sendMessage` returns a Promise; when the SW is asleep its resolver/rejector closures + the LogEntry + the `.catch` arrow accumulate in Chrome's internal pending-message queue and never GC, causing a closure leak observed at 18× scale on long-running tabs (issue #236, +266k closures over 20h on Officeworks). The Port is fire-and-forget — no Promise return, no per-tick allocation.
+
+The sink also no-ops when no log viewer is connected (`viewerConnected = false`, set by SW broadcasting `SET_LOGGING_STATE` on viewer Port connect/disconnect). Steady-state production allocation is zero per log line. The diagnostic heartbeat (`src/content/diagnostic-heartbeat.ts`) is similarly opt-in via the same storage-flag toggle and only fires when the viewer-side master/per-tab UI enables it.
+
+This pattern is mandatory for any future content-side periodic telemetry. See CLAUDE.md "Content→SW logging via Port" invariant.
+
 ## Service Worker
 
 **Entry:** `src/service-worker/index.ts`


### PR DESCRIPTION
## Summary

Refs #236.

Documents the architectural invariant from PRs #237-#240 (content→SW logging via Port + viewer-gate, closure-leak fix) so a future agent can't regress by reaching for \`chrome.runtime.sendMessage\` in a hot path.

- **\`CLAUDE.md\`** — new entry under "Domain-specific invariants (easy to trip on)" with the rule, the why (heap-snapshot evidence), and the storage shape.
- **\`docs/ARCHITECTURE.md\`** — new "Content→SW logging" subsection under "Content Script" describing the Port pattern, viewer-gate, and the heartbeat opt-in.

Verification evidence (18× closure-delta reduction at 9.5h vs 20h pre-fix) was also posted as a comment on the closed #236 issue so the loop is closed publicly.

## Test plan

Docs-only PR — no code changes. Typecheck/test/build are no-ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)