### PR TITLE
docs(sprints-#249): per-sprint kickoff files + project setup script

### DIFF
--- a/docs/plans/sprints/README.md
+++ b/docs/plans/sprints/README.md
@@ -1,0 +1,52 @@
+# Per-sprint kickoff files
+
+Sequential 3-day sprints to ship the v0.1 → v1.0 completion plan. Each file is a **playbook** for one sprint: read the pre-flight checklist once at sprint start, then per work item paste one kickoff prompt block per Claude session.
+
+Source-of-truth spec: [`../v0.1-completion.md`](../v0.1-completion.md). The plan doc holds the architecture / dependencies / scope-cut rules; the sprint files hold the paste-ready commands.
+
+## How to run a work item
+
+The discipline is **one Claude session per work item**, regardless of model / effort / thinking choices (memory rule: `feedback_session_per_item_discipline.md`). Compression and context degradation hit every model past a threshold; fresh sessions per item keep cache warm and avoid debugging-by-degradation.
+
+For each item:
+
+1. Read the sprint file's pre-flight checklist. Confirm or set: model, effort, plugins, MCP servers, repo state.
+2. Open Claude in repo root with the recommended model:
+   ```bash
+   cd /Users/node3/Documents/projects/HoneyLLM && claude --model <model>
+   ```
+   Or use the slash command (see below).
+3. Paste the item's kickoff prompt block into Claude. Wait for it to complete.
+4. Run the validation commands from the file. If they pass, exit (`Ctrl+D`). If they fail, paste the closeout prompt or escalate.
+5. Next item → next fresh session.
+
+## Slash command
+
+`~/.claude/commands/sprint.md` provides `/sprint <N.M>` (e.g. `/sprint 1.2`). It reads the matching sprint file, finds the item block, and presents the kickoff prompt + validation + any human-test steps in-conversation. See the slash command's source for exact behaviour.
+
+## Sprint files
+
+| File | Sprint theme | Tag at end | Recommended model |
+|---|---|---|---|
+| [`sprint-1-stability.md`](sprint-1-stability.md) | Bugs + observability | — | haiku 4.5 / medium |
+| [`sprint-2-phase3-closure.md`](sprint-2-phase3-closure.md) | Phase 3 closure + smokes | — | haiku 4.5 / medium |
+| [`sprint-3-tag-v0.2.md`](sprint-3-tag-v0.2.md) | §4.2 + telemetry + ProtectAI | v0.2.0-internal | opus 4.7 / high |
+| [`sprint-4-determillm-bridge.md`](sprint-4-determillm-bridge.md) | DM-A/E/F/G + Wolf design | — | haiku 4.5 / medium |
+| [`sprint-5-wolf-nano.md`](sprint-5-wolf-nano.md) | Wolf canary + Nano + #119 | — | sonnet 4.6 / medium |
+| [`sprint-6-tag-v0.3.md`](sprint-6-tag-v0.3.md) | Wolf finish + #227 + tag | v0.3.0-internal | sonnet 4.6 / medium |
+| [`sprint-7-isolate-mode.md`](sprint-7-isolate-mode.md) | Isolate mode (#132) | — | opus 4.7 / high |
+| [`sprint-8-local-proxy.md`](sprint-8-local-proxy.md) | Local Proxy w/ root CA (#133) | v0.4.0-internal | opus 4.7 / high |
+| [`sprint-9-byok.md`](sprint-9-byok.md) | BYOK (#19) | — | sonnet 4.6 / medium |
+| [`sprint-10-local-chat.md`](sprint-10-local-chat.md) | Local LLM chat (#4) | v0.5.0-internal | sonnet 4.6 / medium |
+| [`sprint-11-agentic-design.md`](sprint-11-agentic-design.md) | Scheduled/agentic security model | — | opus 4.7 / high |
+| [`sprint-12-tag-v1.md`](sprint-12-tag-v1.md) | Scheduled/agentic finish + ship | v1.0.0 | sonnet 4.6 / medium |
+
+## Workflow rules (universal across sprints)
+
+- Issue → branch `<type>/issue-<N>-<slug>` → PR → `Closes #N` → CI green → squash-merge.
+- **Never** `Closes #2` or `Closes #248` from a PR (long-running tracker issues).
+- **Spillover**: when closing item X partially completes planned item Y, comment on Y with what landed + what remains, set Y's project Status = `Partially Done`, append to the epic issue's spillover log.
+- Auto-merge once CI green. Pre-push runs typecheck + test + build; never `--no-verify`.
+- `npm audit` + AIza-≥20 grep before first `git add`.
+- TypeScript strict; files <400 lines (cap 800); no `any` in app code.
+- Don't touch `docs/testing/inbrowser-results.json` (Phase 2 byte-locked baseline).

--- a/docs/plans/sprints/sprint-1-stability.md
+++ b/docs/plans/sprints/sprint-1-stability.md
@@ -1,0 +1,160 @@
+# Sprint 1 — Stability (Days 1-3)
+
+**Theme:** Bug fixes + observability primary. **Tag at end:** none. **Recommended model:** `claude-haiku-4-5-20251001`, effort medium.
+
+Master plan section: [`../v0.1-completion.md` Sprint 1](../v0.1-completion.md#sprint-1-days-13-stability--bugs--observability).
+Tracking: epic #248. Project board: <https://github.com/users/JimmyCapps/projects/1>.
+
+---
+
+## Pre-flight checklist (run once at sprint start)
+
+- [ ] **Model:** `claude-haiku-4-5-20251001` (medium effort). Bug fixes + plumbing — well-specified TDD-first work.
+- [ ] **Plugins (recommended state):** keep superpowers, feature-dev, code-simplifier, commit-commands, code-review, security-guidance, typescript-lsp, chrome-devtools-mcp, playwright, context7, hookify. Disable cloudflare, huggingface-skills, agent-sdk-dev, playground, skill-creator, claude-code-setup if still on.
+- [ ] **MCP servers needed:** chrome-devtools-mcp (for #217 profiling), playwright (for E2E tests). Others not load-bearing for this sprint.
+- [ ] **Repo state:** `cd /Users/node3/Documents/projects/HoneyLLM && git checkout main && git pull --ff-only && npm test` → all pass.
+- [ ] **Confirm scope:** read [Sprint 1 spec](../v0.1-completion.md#sprint-1-days-13-stability--bugs--observability) — bricklink fix expects #226 logs to identify primitive; Officeworks 4-step diagnostic in #217 body.
+
+**Start Claude in repo root:**
+```bash
+cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-haiku-4-5-20251001
+```
+
+---
+
+## Item 1.1 — Rebase + merge PR #221 (closes #220)
+
+**What:** PR #221 deactivates network-guard + redirect-blocker on benign re-verdict; CI green but mergeable=CONFLICTING vs main. Rebase onto main, resolve the expected `src/content/index.ts` conflict near `applyMitigations` extraction, push, auto-merge.
+
+**Kickoff prompt:**
+```
+Execute Sprint 1 item 1.1 (PR #221 rebase + merge — closes #220) per docs/plans/v0.1-completion.md Sprint 1 §1.1. Conflict expected in src/content/index.ts near applyMitigations extraction; keep PR #221's extraction shape, replay newer changes inside the new module. Push --force-with-lease, wait for CI, squash-merge, delete branch.
+```
+
+**Validation:**
+- `gh pr view 221 --json state -q '.state'` → `MERGED`
+- `gh issue view 220 --json state -q '.state'` → `CLOSED`
+- `git log -1 --oneline main` shows the merge commit
+
+**Closeout:** none — #220 closes via the PR.
+
+---
+
+## Item 1.2 — #226 logging coverage
+
+**What:** Adds chunk + hunter + probe-selection log entries to the existing LogBus jsonl pipeline. Unblocks #232 triage by exposing per-hunter scores.
+
+**Kickoff prompt:**
+```
+Execute Sprint 1 item 1.2 (#226 logging coverage) per docs/plans/v0.1-completion.md Sprint 1 §1.2. TDD-first: write src/tests/observability/pipeline-trace.test.ts asserting jsonl emits {chunk_created, hunter_run:spider, hunter_run:hawk, hunter_run:embeddings, probe_selected, probe_run, verdict_emitted} for a synthetic PageSnapshot. Touch src/service-worker/orchestrator.ts, src/hunters/{spider,hawk,embeddings}/, src/service-worker/dispatch.ts. Reuse src/log-viewer/file-writer.ts (#222/#223/#225 infra) — do NOT introduce a parallel sink. Extend LogEvent union in src/types/messages.ts. Phase 2 byte-locked baseline must stay byte-identical (logging is display-only). Spillover note: #236 already shipped the LogBus Port pattern (commit e56996a) — write into that infra. Branch feat/issue-226-pipeline-logging.
+```
+
+**Validation:**
+- `npm test -- --run pipeline-trace` passes
+- `gh pr view <N> --json state -q '.state'` → `MERGED` (auto-merge after CI)
+- `gh issue view 226 --json state -q '.state'` → `CLOSED`
+- Manual: `npm run build`, load `dist/` unpacked, scan a Wikipedia page, confirm new entries appear in `docs/logs/<latest>/`.
+- Phase 2 baseline unchanged: `git diff HEAD~1 -- docs/testing/inbrowser-results.json` shows no diff.
+
+**Closeout:** none — #226 closes via the PR.
+
+---
+
+## Item 1.3 — #232 bricklink false-positive fix (depends on 1.2)
+
+**What:** Use the new #226 jsonl to identify which primitive flagged bricklink.com. Likely embeddings hunter (J.Burrows precedent). Fix the calibration; lock with a regression test.
+
+**Kickoff prompt:**
+```
+Execute Sprint 1 item 1.3 (#232 bricklink false-positive fix) per docs/plans/v0.1-completion.md Sprint 1 §1.3. Pre-req: #226 must be merged. Workflow: re-run a bricklink scan with the new jsonl; identify flagging primitive from per-hunter scores. If embeddings: add commerce/promotional-copy negative examples to data/injection-corpus.json + npm run embed:corpus + lock with "Buy now! Click here! Limited offer!" unit test below EMBEDDING_COSINE_THRESHOLD = 0.85. If Hawk or Spider: tune that primitive + add bricklink homepage to test-pages/clean/ as a regression fixture. Acceptance: 3 consecutive CLEAN scans of bricklink.com/v2/main.page. Branch fix/issue-232-bricklink-fp.
+```
+
+**Validation:**
+- `gh pr view <N> --json state -q '.state'` → `MERGED`
+- `gh issue view 232 --json state -q '.state'` → `CLOSED`
+- Manual: load `dist/`, visit `https://www.bricklink.com/v2/main.page` 3 times, all CLEAN.
+
+**Closeout:** none.
+
+---
+
+## Item 1.4 — #217 Officeworks renderer leak (independent)
+
+**What:** Issue body has 4-step diagnostic (network delta → outerHTML test → fetch toString test → heap profile). Cheapest-first; ship a fix or a documented known-issue note.
+
+**Kickoff prompt:**
+```
+Execute Sprint 1 item 1.4 (#217 Officeworks renderer leak) per docs/plans/v0.1-completion.md Sprint 1 §1.4. Execute the 4-step diagnostic from issue #217's body cheapest-first: (1) network-panel delta enabled vs disabled, (2) `outerHTML = ''` test in src/content/ingestion/extractor.ts:64, (3) Function.prototype.toString mask in src/content/main-world-inject.ts, (4) heap profile only if 1-3 don't localise. Decision tree per issue body. If localised: ship fix on fix/issue-217-<root-cause> with regression test. If not: write known-issue paragraph for the eventual docs/RELEASE_NOTES_v0.2.0-internal.md and file a v0.2.0.x patch issue with the captured profile.
+```
+
+**Validation:**
+- Either: `gh pr view <N> --json state -q '.state'` → `MERGED` AND Officeworks homepage idle 5 min stays bounded (<1 GB renderer)
+- Or: `gh issue view 217` shows known-issue triage comment with profile attachment
+
+**Human testing for the diagnostic:**
+1. Open Chrome with HoneyLLM unpacked (use the test profile, not your daily profile — the leak escalates fast).
+2. Open Chrome Task Manager (`Window` → `Task Manager`) and macOS Activity Monitor (sort by Memory).
+3. Visit `https://www.officeworks.com.au/` (homepage, NOT a product detail page).
+4. Note the tab renderer's PID; record memory baseline at T=0.
+5. Leave the tab idle 5 minutes — do not interact.
+6. Record memory at T=5min. Compare against memory at the same time with HoneyLLM disabled on the site (popup → "Never scan on officeworks.com.au").
+7. After each fix attempt (steps 2 and 3 in the diagnostic), repeat 1-6 and record the delta.
+8. Comment results on #217 per attempt.
+
+**Closeout:** none if fix lands; else manual issue update with known-issue posture.
+
+---
+
+## Item 1.5 — #157 strict-LLM-bypass gate-check + ship-or-close
+
+**What:** Telemetry gate: read `honeyllm:cache-telemetry` for `ner_exfil_fast_path` hit-rate over the last 7+ days. ≥10% AND reasonable LLM-disagreement → ship Option A (skip LLM call on fast-path hits). Else close as won't-fix with the rate documented.
+
+**Kickoff prompt:**
+```
+Execute Sprint 1 item 1.5 (#157 strict-LLM-bypass gate-check) per docs/plans/v0.1-completion.md Sprint 1 §1.5. Read honeyllm:cache-telemetry storage from a recent SW console dump or harness query (#227 isn't shipped yet, so use chrome.storage.local DevTools panel). Compute 7-day ner_exfil_fast_path hit-rate + LLM-disagreement rate. If hit-rate ≥10% AND disagreement reasonable → implement Option A in src/probes/orchestrator: skip LLM call when ner_exfil_fast_path flag set, branch feat/issue-157-strict-llm-bypass. Else close #157 as won't-fix with measurements documented in close comment.
+```
+
+**Validation:**
+- `gh issue view 157 --json state -q '.state'` → `CLOSED` (either via PR merge or won't-fix)
+- If shipped: `npm test` includes new orchestrator skip-path test that passes
+- Close comment cites measured hit-rate + disagreement-rate
+
+**Closeout:** if ship path → none (PR closes). If won't-fix path → ensure close comment has the measurement table (don't close silently).
+
+---
+
+## Item 1.6 [USER] — #14 Nano replicate-sampling
+
+**What:** Run the already-patched harness through the 162 affected-baseline rows × 5 replicates each. ~1 hour. Output JSON sidecar that informs Sprint 2's #2 B7 regression report.
+
+**Human steps (no Claude session needed):**
+
+1. Open EPP-enrolled Chrome profile (the one with Gemini Nano available).
+2. Confirm Nano is downloaded: visit `chrome://on-device-internals/` → "Optimization Guide" tab → "Available" for Gemini Nano.
+3. From repo root: `npm run build && npm run harness:nano` — opens the harness in a new tab.
+4. Click "Run Replicates Sweep" (button added by PR #82); wait ~10 minutes.
+5. Sidecar JSON writes to browser downloads as `nano-replicates-2026-05-XX.json`. Move into `docs/testing/phase4/`.
+6. Branch + commit:
+   ```bash
+   git checkout -b test/issue-14-nano-replicates
+   git add docs/testing/phase4/nano-replicates-2026-05-*.json
+   git commit -m "test(harness-#14): Nano replicate-sampling on affected baseline"
+   git push -u origin test/issue-14-nano-replicates
+   gh pr create --base main --title "test(harness-#14): Nano replicate-sampling on affected baseline" --body "Closes #14"
+   ```
+7. Auto-merge after CI green.
+
+**Validation:**
+- `gh issue view 14 --json state -q '.state'` → `CLOSED`
+- File `docs/testing/phase4/nano-replicates-2026-05-XX.json` exists on main with 162 rows × 5 replicates
+
+---
+
+## Sprint 1 close-out
+
+When all 6 items above show `CLOSED` (or shipped), update epic #248:
+
+1. Edit issue #248; mark Sprint 1 ✅ DONE in the sprint summary block.
+2. If any spillover happened (e.g. #226's logging unexpectedly closed #157's measurement need), append to the spillover log section.
+3. No tag this sprint — v0.2.0-internal lands at end of Sprint 3.
+4. Open Sprint 2 by reading [`sprint-2-phase3-closure.md`](sprint-2-phase3-closure.md).

--- a/docs/plans/sprints/sprint-10-local-chat.md
+++ b/docs/plans/sprints/sprint-10-local-chat.md
@@ -1,0 +1,88 @@
+# Sprint 10 — Local LLM chat #4 + tag v0.5.0-internal (Days 28-30)
+
+**Theme:** In-popup chat surface reusing existing canaries (Gemma WebGPU + Nano). **Tag at end:** `v0.5.0-internal`. **Recommended model:** `claude-sonnet-4-6`, effort medium.
+
+Master plan: [`../v0.1-completion.md` Sprint 10](../v0.1-completion.md#sprint-10-days-2830-local-llm-chat-4--tag-v130). Tracking: epic #248.
+
+---
+
+## Pre-flight checklist
+
+- [ ] Model: `claude-sonnet-4-6` (medium).
+- [ ] Plugins baseline.
+- [ ] Repo state: v0.4.0-internal tag exists; BYOK shipped (Sprint 9).
+
+```bash
+cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-sonnet-4-6
+```
+
+---
+
+## Item 10.1 — #4 Stage 1: chat UI design
+
+**Kickoff prompt:**
+```
+Execute Sprint 10 item 10.1 (#4 Stage 1: chat UI design) per docs/plans/v0.1-completion.md Sprint 10 §10.1. Design RFC at docs/proposals/local-chat.md covering: (1) where chat lives — new tab in popup vs separate options page, (2) canary selector — Gemma-2-2b WebGPU vs Gemini Nano vs (if Sprint 9 BYOK enabled) BYOK provider, (3) conversation history storage shape (chrome.storage.local keyed by conversation id), (4) privacy: no remote sync, history wiped on extension uninstall, (5) UX: streaming responses, cancel button, copy-to-clipboard, regenerate. Branch docs/issue-XXX-local-chat-rfc.
+```
+
+---
+
+## Item 10.2 — #4 Stage 2: implementation
+
+**Kickoff prompt:**
+```
+Execute Sprint 10 item 10.2 (#4 Stage 2: chat impl) per docs/plans/v0.1-completion.md Sprint 10 §10.2. Pre-req: §10.1 RFC. New src/chat/ surface: ui.ts (chat surface component), engine-router.ts (routes to existing canary engines via reused offscreen-doc message types — DO NOT load a second engine), history-store.ts. Mount in popup as a Chat tab. Reuse the streaming pattern from existing canary dispatch. TDD: engine-router routes to Gemma when Gemma loaded, to Nano when Nano loaded, surfaces canary-not-loaded error otherwise. Branch feat/issue-4-stage-2-chat-impl.
+```
+
+---
+
+## Item 10.3 — #4 Stage 3: conversation history + storage
+
+**Kickoff prompt:**
+```
+Execute Sprint 10 item 10.3 (#4 Stage 3: chat history) per docs/plans/v0.1-completion.md Sprint 10 §10.3. Implement history-store.ts: chrome.storage.local key honeyllm:chat:<conversation-id>, schema v1 = {id, title, messages: [{role, content, ts}], createdAt, updatedAt}. Cap N=50 conversations; oldest-pruned when over cap. Bulk delete for "Clear all chats". TDD: persist round-trip, cap enforcement, defensive against storage quota errors. Branch feat/issue-4-stage-3-chat-history.
+```
+
+---
+
+## Item 10.4 — #4 Stage 4: testing
+
+**Kickoff prompt:**
+```
+Execute Sprint 10 item 10.4 (#4 Stage 4: chat testing) per docs/plans/v0.1-completion.md Sprint 10 §10.4. Cover: streaming response rendering, cancel mid-stream, conversation persistence across popup close/open, switching canary mid-conversation, BYOK selection if Sprint 9 shipped. Branch test/issue-4-stage-4-chat-tests.
+```
+
+---
+
+## Item 10.5 [USER] — Smoke chat with WebGPU + Nano
+
+**Manual playbook:** [`../v0.1-completion.md` §M-11](../v0.1-completion.md#m-11--local-llm-chat-smoke-sprint-10). Summary: load `dist/`, open Chat tab, ask Gemma a question, confirm streamed response, switch to Nano, repeat. Comment + close.
+
+**Validation:**
+- `gh issue view 4 --json state -q '.state'` → `CLOSED`
+- Comment on #4 has screenshot of streamed response
+
+---
+
+## Item 10.6 — Refresh ROADMAP + RAG_STATUS + RELEASE_NOTES_v0.5.0-internal.md
+
+**Kickoff prompt:**
+```
+Execute Sprint 10 item 10.6 (release-cut prep for v0.5.0-internal). Update ROADMAP + clone RAG_STATUS. Write RELEASE_NOTES_v0.5.0-internal.md headlining: BYOK (#19) + Local LLM chat (#4). Branch docs/issue-XXX-release-prep-v0.5.
+```
+
+---
+
+## Item 10.7 — Tag v0.5.0-internal
+
+**Kickoff prompt:**
+```
+Execute Sprint 10 item 10.7 (tag v0.5.0-internal) per docs/plans/v0.1-completion.md Sprint 10 §10.7. Tests + build clean. Bump 0.4.0-internal → 0.5.0-internal. release/v0.5.0-internal branch + PR + tag + gh release create --prerelease.
+```
+
+---
+
+## Sprint 10 close-out
+
+1. Epic #248: Sprint 10 ✅ DONE.
+2. Open Sprint 11: [`sprint-11-agentic-design.md`](sprint-11-agentic-design.md).

--- a/docs/plans/sprints/sprint-11-agentic-design.md
+++ b/docs/plans/sprints/sprint-11-agentic-design.md
@@ -1,0 +1,55 @@
+# Sprint 11 — Scheduled/agentic security model (Days 31-33)
+
+**Theme:** Design + foundation for #5 scheduled/agentic tasks. Heavy on security RFC; implementation finishes in Sprint 12. **Tag:** none. **Recommended model:** `claude-opus-4-7`, effort high (security model must be right first time).
+
+Master plan: [`../v0.1-completion.md` Sprint 11](../v0.1-completion.md#sprint-11-days-3133-scheduled--agentic-tasks-5--security-first-design). Tracking: epic #248.
+
+---
+
+## Pre-flight checklist
+
+- [ ] Model: **`claude-opus-4-7`** (high effort). Agentic actions with verdict-gating must be airtight.
+- [ ] Plugins: baseline + `security-guidance`.
+- [ ] Repo state: v0.5.0-internal tag exists; isolate mode (#132) on main.
+
+```bash
+cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-opus-4-7
+```
+
+---
+
+## Item 11.1 — #5 Stage 1: security model RFC
+
+**Kickoff prompt:**
+```
+Execute Sprint 11 item 11.1 (#5 Stage 1: agentic security RFC) per docs/plans/v0.1-completion.md Sprint 11 §11.1. Write docs/proposals/agentic-security.md covering invariants: (1) NO network call without a CLEAN verdict on the source page (verdict-gate.ts checker on every outbound action), (2) isolate-mode mandatory for any agentic browsing (#132 enforced), (3) per-task allow-lists for origins / actions, (4) user must approve any cross-origin action (one-time consent UI), (5) telemetry: every gated action logged to honeyllm:agentic-telemetry with {taskId, action, origin, verdict, decision, ts}, (6) failure modes — silent skip on soft violation, hard abort + notification on hard violation, (7) tasks resumable across browser restart via chrome.alarms. Open chore issue first. Branch docs/issue-XXX-agentic-security-rfc.
+```
+
+**Validation:**
+- `docs/proposals/agentic-security.md` exists on main with explicit answers to all 7 invariants
+
+---
+
+## Item 11.2 — #5 Stage 2: chrome.alarms integration + task storage
+
+**Kickoff prompt:**
+```
+Execute Sprint 11 item 11.2 (#5 Stage 2: alarms + storage) per docs/plans/v0.1-completion.md Sprint 11 §11.2. Pre-req: §11.1 RFC merged. Implement: (1) src/agentic/task-store.ts — task definitions in chrome.storage.local keyed by task id; schema {id, title, schedule, urlPattern, actions, allowList, createdAt}, (2) src/agentic/alarms-bridge.ts — chrome.alarms.create / onAlarm.addListener wired to task-store, (3) tasks resumable across browser restart (alarms persist; task definitions in storage). TDD: 8 cases — task CRUD, alarm fires correct task, restart resilience, malformed-task defensive. Branch feat/issue-5-stage-2-alarms-storage.
+```
+
+---
+
+## Item 11.3 — #5 Stage 3: verdict-gate (security constraints)
+
+**Kickoff prompt:**
+```
+Execute Sprint 11 item 11.3 (#5 Stage 3: verdict-gate) per docs/plans/v0.1-completion.md Sprint 11 §11.3. Pre-req: §11.2. Implement src/agentic/verdict-gate.ts: every agentic action passes through gate(action, currentVerdict, taskAllowList). Returns {allow: true} | {allow: false, reason: 'verdict_unclean' | 'origin_not_in_allowlist' | 'cross_origin_no_consent' | 'isolate_mode_required'}. Wire to honeyllm:agentic-telemetry. Hard violations → task aborts; soft violations → silent skip with telemetry. TDD: 12 cases covering each refusal class + allow path + edge cases. Branch feat/issue-5-stage-3-verdict-gate.
+```
+
+---
+
+## Sprint 11 close-out
+
+1. Epic #248: Sprint 11 ✅ DONE.
+2. No tag this sprint — v1.0.0 lands at end of Sprint 12.
+3. Open Sprint 12: [`sprint-12-tag-v1.md`](sprint-12-tag-v1.md).

--- a/docs/plans/sprints/sprint-12-tag-v1.md
+++ b/docs/plans/sprints/sprint-12-tag-v1.md
@@ -1,0 +1,83 @@
+# Sprint 12 — Scheduled/agentic finish + tag v1.0.0 (Days 34-36)
+
+**Theme:** Implement the agentic loop against the Sprint 11 RFC, smoke it, and cut the first publicly releasable tag. **Tag at end:** `v1.0.0`. **Recommended model:** `claude-sonnet-4-6`, effort medium (implementation against locked design).
+
+Master plan: [`../v0.1-completion.md` Sprint 12](../v0.1-completion.md#sprint-12-days-3436-scheduledagentic-finish--tag-v200). Tracking: epic #248.
+
+---
+
+## Pre-flight checklist
+
+- [ ] Model: `claude-sonnet-4-6` (medium). RFC + foundation done in Sprint 11; Sprint 12 is implementation.
+- [ ] Plugins baseline.
+- [ ] Repo state: Sprint 11 deliverables on main (RFC + alarms-bridge + task-store + verdict-gate).
+
+```bash
+cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-sonnet-4-6
+```
+
+---
+
+## Item 12.1 — #5 Stage 4: agentic loop
+
+**Kickoff prompt:**
+```
+Execute Sprint 12 item 12.1 (#5 Stage 4: agentic loop) per docs/plans/v0.1-completion.md Sprint 12 §12.1. Pre-req: Sprint 11 §11.3 verdict-gate on main. Implement src/agentic/loop.ts: when an alarm fires, (1) load task from task-store, (2) open URL in isolate window per #132 if task isolate-required (always true per RFC), (3) wait for verdict on the loaded page, (4) for each action in task definition: gate(action) → execute or skip per gate decision, (5) emit telemetry, (6) close isolate window when done. Surface a "Run now" button in popup for manual trigger of any scheduled task. TDD: 10 cases — alarm-fires-loads-task, isolate-window-spawns, verdict-gates-block-violations, telemetry-emits, cleanup-on-error, manual-trigger-bypasses-schedule. Branch feat/issue-5-stage-4-agentic-loop.
+```
+
+---
+
+## Item 12.2 — #5 Stage 5: testing
+
+**Kickoff prompt:**
+```
+Execute Sprint 12 item 12.2 (#5 Stage 5: agentic testing) per docs/plans/v0.1-completion.md Sprint 12 §12.2. Add: (1) integration test stubbing chrome.alarms + chrome.windows + verdict-router (DI seams), (2) end-to-end scenario: task fires → isolate spawn → CLEAN verdict → action executes → telemetry recorded, (3) negative scenario: task fires → COMPROMISED verdict → all actions blocked → task aborts with hard-violation log. Branch test/issue-5-stage-5-agentic-tests.
+```
+
+---
+
+## Item 12.3 [USER] — Smoke agentic task with simulated injection
+
+**Manual playbook:** [`../v0.1-completion.md` §M-12](../v0.1-completion.md#m-12--scheduled--agentic-task-smoke-sprint-12). Summary: build, load `dist/`, create a daily task pointing at a clean fixture; force-trigger; confirm runs in isolate mode + summary returned. Edit task to point at injection fixture; force-trigger; confirm aborts with verdict-gate violation. Comment + close.
+
+**Validation:**
+- `gh issue view 5 --json state -q '.state'` → `CLOSED`
+- Comment on #5 has logs showing both clean execution + violation abort
+
+---
+
+## Item 12.4 — Refresh ROADMAP + RAG_STATUS + RELEASE_NOTES_v1.0.0.md
+
+**Kickoff prompt:**
+```
+Execute Sprint 12 item 12.4 (release-cut prep for v1.0.0) per docs/plans/v0.1-completion.md Sprint 12 §12.4. Update docs/ROADMAP.md: every closed v1.0 issue actually closed; v1.0 row → 100%. Clone RAG_STATUS to a new dated file capturing the v1.0.0 state. Write docs/RELEASE_NOTES_v1.0.0.md as the FIRST PUBLICLY RELEASABLE release notes. Headline capabilities: 4 hunters (Spider/Hawk/embeddings/DetermiLLM-stub), 3 canaries (Gemma-2-2b WebGPU / Gemini Nano / Wolf Llama-3.2-1B), image-injection probe (multimodal Nano), classifier v3, dual-path mitigations w/ deactivation lifecycle, signed registry, isolate mode, local proxy w/ root CA, BYOK (Anthropic/OpenAI/Google), local LLM chat, scheduled/agentic tasks w/ verdict-gating. Known issues remaining: #76 npm publish (deferred), DetermiLLM core packs (DM-B/C/D + #75 in DetermiLLM phase), any deferred per scope-cuts. Branch docs/issue-XXX-release-prep-v1.0.
+```
+
+---
+
+## Item 12.5 — Tag v1.0.0
+
+**Kickoff prompt:**
+```
+Execute Sprint 12 item 12.5 (TAG v1.0.0 — first publicly releasable) per docs/plans/v0.1-completion.md Sprint 12 §12.5. Run npm ci && npm run typecheck && npm test && npm run build:release && npm run test:e2e — ALL must pass. Bump manifest.json + package.json from 0.5.0-internal → 1.0.0 (NOTE: drops the -internal suffix). Branch release/v1.0.0; PR with --body-file docs/RELEASE_NOTES_v1.0.0.md; squash-merge after CI green. git checkout main && git pull && git tag v1.0.0 && git push origin v1.0.0 && gh release create v1.0.0 -F docs/RELEASE_NOTES_v1.0.0.md (NO --prerelease flag — this is the first public release).
+```
+
+**Validation:**
+- `git tag` lists `v1.0.0` (no -internal suffix)
+- `gh release view v1.0.0` shows it as a non-prerelease
+- All test suites green
+- `manifest.json` and `package.json` show version `1.0.0`
+
+---
+
+## Project close-out
+
+When `v1.0.0` ships:
+
+1. Edit epic #248: mark Sprint 12 ✅ DONE; mark the entire epic complete; close manually (per the never-close-from-PR rule).
+2. Archive the plan doc: `git mv docs/plans/v0.1-completion.md docs/plans/archive/v0.1-completion-COMPLETE-2026-XX-XX.md`. Optionally archive the sprint files alongside.
+3. Open a fresh plan for what comes next:
+   - DetermiLLM phase (DM-B/C/D + #75 dialect packs) is the only remaining concentrated work
+   - #76 npm publish if the user signals readiness
+   - Anything new that surfaced during the 12 sprints
+4. Comment on the GitHub Project board indicating it's now closed for new items.

--- a/docs/plans/sprints/sprint-2-phase3-closure.md
+++ b/docs/plans/sprints/sprint-2-phase3-closure.md
@@ -1,0 +1,154 @@
+# Sprint 2 — Phase 3 closure + image probe + maintainer smokes (Days 4-6)
+
+**Theme:** Close Phase 3 Track B + ship image-injection popup + run maintainer smokes. **Tag:** none. **Recommended model:** `claude-haiku-4-5-20251001`, effort medium.
+
+Master plan: [`../v0.1-completion.md` Sprint 2](../v0.1-completion.md#sprint-2-days-46-phase-3-closure--image-probe--maintainer-smokes). Tracking: epic #248.
+
+---
+
+## Pre-flight checklist
+
+- [ ] Model: `claude-haiku-4-5-20251001` (medium effort).
+- [ ] Plugins: same baseline as Sprint 1.
+- [ ] MCP: claude-in-chrome (for #124 smoke), playwright. Disable chrome-devtools-mcp if Sprint 1's Officeworks work is done.
+- [ ] Repo state: `git checkout main && git pull --ff-only && npm test` → all pass.
+- [ ] Confirm: PR #221, #226 fix, #232 fix all on main from Sprint 1.
+
+```bash
+cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-haiku-4-5-20251001
+```
+
+---
+
+## Item 2.1 — #2 reframe doc to N10 methodology
+
+**What:** Rewrite issue #2's body to reflect the N10 methodology (`docs/testing/phase5/methodology.md`) instead of the deprecated synthetic-fixture sweep plan. Doc-only, no code.
+
+**Kickoff prompt:**
+```
+Execute Sprint 2 item 2.1 (#2 reframe doc) per docs/plans/v0.1-completion.md Sprint 2 §2.1. Read docs/testing/phase5/methodology.md (N10), then rewrite #2's body to consume N10 instead of the deprecated Track B sweep plan. Branch docs/issue-2-reframe. PR body MUST say "Refs #2" — NEVER "Closes #2" (memory rule feedback_issue_2_never_closes.md).
+```
+
+**Validation:**
+- `gh pr view <N> --json state -q '.state'` → `MERGED`
+- `gh issue view 2` body shows N10-aligned plan
+- `gh issue view 2 --json state -q '.state'` → still `OPEN` (#2 stays open by rule)
+
+**Closeout:** none — but verify the PR did NOT auto-close #2.
+
+---
+
+## Item 2.2 [USER] — #2 Track B B5 manual leg
+
+**Manual playbook:** [`../v0.1-completion.md` §M-2](../v0.1-completion.md#m-2--2-track-b-b5-manual-leg-sprint-2). Summary: ~2 hours. For each of 23 fixtures × 3 agents (Claude.ai, ChatGPT, Gemini), record verdict + emitted URLs. Commit on `docs/issue-2-b5-manual-leg`; PR body `Refs #2`.
+
+**Pre-req:** confirm fixture host: `curl -I https://fixtures.host-things.online/test-pages/manifest.json` returns 200.
+
+**Validation:**
+- New section "Real-wrapper run 2026-05-XX" exists in `docs/testing/phase3/STAGE_B5_RESULTS.md`
+- 23 × 3 grid populated
+- PR merged with `Refs #2`; #2 stays open
+
+---
+
+## Item 2.3 — #9 4G.6a popup multimodal column
+
+**What:** Add a popup accordion that renders image-injection probe findings (the `image_injection` flag from PR #205). Mirrors `embeddings-findings.ts` + `registry-stats.ts` patterns. UI-only; no probe-runner change.
+
+**Kickoff prompt:**
+```
+Execute Sprint 2 item 2.3 (#9 4G.6a popup multimodal column) per docs/plans/v0.1-completion.md Sprint 2 §2.3. Mirror src/popup/embeddings-findings.ts + src/popup/registry-stats.ts patterns: lazy DOM query, three render branches (no probe data / probe ran no images / probe with findings), idempotent re-render. Reads from SecurityVerdict.imageInjectionFindings (add the optional field if not yet on the type, defaulting null). No probe-runner / orchestrator change. Branch feat/issue-9-4g6a-popup-multimodal.
+```
+
+**Validation:**
+- `npm test` includes new popup-render tests; all pass
+- `gh pr view <N> --json state -q '.state'` → `MERGED`
+- Manual: load `dist/`, visit a `test-pages/injected-images/` fixture, popup shows the new accordion
+
+**Closeout:** #9 stays open (4G.5 + 4G.6b still pending). Verify PR body says `Refs #9` not `Closes #9`.
+
+---
+
+## Item 2.4 [USER] — #9 4G.5 Nano image smoke sweep
+
+**Pre-req:** fix the Chrome extension-load error blocking 4G.5 first (see `chrome://extensions/` → HoneyLLM → "Errors" button if any present).
+
+**Manual playbook:** [`../v0.1-completion.md` §M-3](../v0.1-completion.md#m-3--9-4g5-nano-image-smoke-sweep-sprint-2). Summary: EPP-enrolled Chrome, walk 5 injected-image fixtures + 1 clean control, commit JSON sidecar.
+
+**Validation:**
+- File `docs/testing/phase4/4G5-nano-image-sweep-2026-05-XX.json` exists with 6 entries
+- PR merged with `Refs #9`
+
+---
+
+## Item 2.5 — #9 4G.6b NANO_BASELINE_ADDENDUM (depends on 2.4)
+
+**What:** Append a multimodal-coverage section to `docs/testing/phase3/NANO_BASELINE_ADDENDUM.md` from the Day 5 sweep output.
+
+**Kickoff prompt:**
+```
+Execute Sprint 2 item 2.5 (#9 4G.6b NANO_BASELINE_ADDENDUM) per docs/plans/v0.1-completion.md Sprint 2 §2.5. Pre-req: 2.4 sweep JSON is on main at docs/testing/phase4/4G5-nano-image-sweep-2026-05-XX.json. Append a "Multimodal coverage" section to docs/testing/phase3/NANO_BASELINE_ADDENDUM.md with: per-fixture verdict table, per-technique flag-emission rate, comparison vs text-mode-only Nano baseline. Closes #9 since this is the final 4G stage. Branch docs/issue-9-4g6b-addendum.
+```
+
+**Validation:**
+- `gh issue view 9 --json state -q '.state'` → `CLOSED`
+- `docs/testing/phase3/NANO_BASELINE_ADDENDUM.md` shows the new section
+
+---
+
+## Item 2.6 [USER] — #124 Browse MCP smoke
+
+**Manual playbook:** [`../v0.1-completion.md` §M-4](../v0.1-completion.md#m-4--124-browse-mcp-smoke-sprint-2). Summary: configure Claude Desktop, run `browse` tool against Wikipedia + injection fixture, comment + close.
+
+**Validation:**
+- `gh issue view 124 --json state -q '.state'` → `CLOSED`
+- Comment on #124 has screenshots showing CLEAN + COMPROMISED dispatches
+
+---
+
+## Item 2.7 [USER] — #129 embeddings smoke
+
+**Manual playbook:** [`../v0.1-completion.md` §M-5](../v0.1-completion.md#m-5--129-embeddings-smoke-sprint-2). Summary: load extension unpacked, hit a known-injection honeypot, confirm embeddings accordion renders.
+
+**Validation:**
+- `gh issue view 129 --json state -q '.state'` → `CLOSED`
+- Comment on #129 has screenshot of the accordion row with cosine ≥ 0.85
+
+---
+
+## Item 2.8 [USER] — #8 Chromium-family compat audit
+
+**Manual playbook:** [`../v0.1-completion.md` §M-6](../v0.1-completion.md#m-6--8-chromium-family-compat-audit-sprint-2). Summary: 6 browsers × 2 test pages, fill `docs/testing/phase4/COMPAT_AUDIT.md` rows.
+
+**Pre-req before user runs:** ask Claude in a quick session to scaffold the empty `docs/testing/phase4/COMPAT_AUDIT.md` template with one row per browser.
+
+**Validation:**
+- `gh issue view 8 --json state -q '.state'` → `CLOSED`
+- File exists with 6 rows populated
+
+---
+
+## Item 2.9 — #2 B7 regression report (depends on 2.2)
+
+**What:** Populate `docs/testing/phase3/PHASE3_REGRESSION_REPORT.md` §4 + §8 from the B5 + #14 outputs. Cross-reference 2026-04-20 baseline.
+
+**Kickoff prompt:**
+```
+Execute Sprint 2 item 2.9 (#2 B7 regression report) per docs/plans/v0.1-completion.md Sprint 2 §2.9. Pre-req: B5 results on main from item 2.2 + #14 sidecar from Sprint 1 item 1.6. Populate docs/testing/phase3/PHASE3_REGRESSION_REPORT.md §4 (real-wrapper findings) and §8 (efficacy verdict). Cross-reference 2026-04-20 direct-API baseline (PR #82) and classifier v2/v3 deltas. PR body MUST say "Refs #2" — NEVER "Closes #2".
+```
+
+**Validation:**
+- `gh pr view <N> --json state -q '.state'` → `MERGED`
+- §4 + §8 populated; #2 stays open
+
+**Closeout:** verify PR did NOT auto-close #2.
+
+---
+
+## Sprint 2 close-out
+
+When all 9 items show CLOSED/MERGED (except #2 which stays open by rule):
+
+1. Edit epic #248; mark Sprint 2 ✅ DONE.
+2. Spillover log: append any cross-issue progress (likely none this sprint).
+3. Open Sprint 3: [`sprint-3-tag-v0.2.md`](sprint-3-tag-v0.2.md).

--- a/docs/plans/sprints/sprint-3-tag-v0.2.md
+++ b/docs/plans/sprints/sprint-3-tag-v0.2.md
@@ -1,0 +1,124 @@
+# Sprint 3 — §4.2 + telemetry review + ProtectAI + tag v0.2.0-internal (Days 7-9)
+
+**Theme:** Heavy reasoning sprint — measure pedagogical FPR, review Phase 6 telemetry, validate ProtectAI, then tag the first internal milestone. **Tag at end:** `v0.2.0-internal`. **Recommended model:** `claude-opus-4-7`, effort high.
+
+Master plan: [`../v0.1-completion.md` Sprint 3](../v0.1-completion.md#sprint-3-days-79-pedagogical-42--telemetry-review--protectai--tag-v100). Tracking: epic #248.
+
+---
+
+## Pre-flight checklist
+
+- [ ] Model: **`claude-opus-4-7`** (high effort). Validation + telemetry analysis are reasoning-heavy; not the place to save tokens.
+- [ ] Plugins: same as Sprint 1.
+- [ ] MCP: context7 useful for mlc-llm docs lookup.
+- [ ] **User pre-req:** complete §M-7 `mlc_llm serve` setup ([`../v0.1-completion.md` §M-7](../v0.1-completion.md#m-7--mlc_llm-serve-setup-sprint-3)) before item 3.2.
+- [ ] **Date check:** item 3.3's telemetry window opens ~2026-05-14. If today < 2026-05-14, swap 3.3 with a Sprint 4 item (DM-A) and slip 3.3 to Sprint 4. The tag still cuts at end of Sprint 3 with whatever 3.3 was able to land.
+- [ ] Repo state: `npm test` passes; all Sprint 1+2 PRs on main.
+
+```bash
+cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-opus-4-7
+```
+
+---
+
+## Item 3.1 [USER] — `mlc_llm serve` setup
+
+**Manual playbook:** [`../v0.1-completion.md` §M-7](../v0.1-completion.md#m-7--mlc_llm-serve-setup-sprint-3). End-state: `mlc_llm serve` running at `http://127.0.0.1:8000/v1` with `gemma-2-2b-it-q4f16_1-MLC` model.
+
+**Validation:** `curl http://127.0.0.1:8000/v1/models` returns the model id JSON. Tell Claude in next session: "mlc_llm serve is up at http://127.0.0.1:8000/v1 with model gemma-2-2b-it-q4f16_1-MLC".
+
+---
+
+## Item 3.2 — #120 §4.2 LLM-layer pedagogical FPR (depends on 3.1)
+
+**What:** Run the 50-entry pedagogical corpus through `mlc_llm serve`; populate the §4.2 cells in `docs/testing/phase5/PEDAGOGICAL_BASELINE.md`.
+
+**Kickoff prompt:**
+```
+Execute Sprint 3 item 3.2 (#120 §4.2 LLM-layer pedagogical FPR) per docs/plans/v0.1-completion.md Sprint 3 §3.2. Pre-req: mlc_llm serve up at http://127.0.0.1:8000/v1 with model gemma-2-2b-it-q4f16_1-MLC (per §M-7). Set HONEYLLM_LLM_BASE_URL + HONEYLLM_LLM_MODEL env vars; run scripts/run-pedagogical-fpr.ts; populate docs/testing/phase5/PEDAGOGICAL_BASELINE.md §4.2 cells. If FPR > 0.10 on any path, file a follow-up tuning issue (label phase-5) AND ship the documented result; do NOT block tag. Branch test/issue-120-llm-layer-fpr.
+```
+
+**Validation:**
+- `docs/testing/phase5/PEDAGOGICAL_BASELINE.md` §4.2 cells populated
+- `gh issue view 120 --json state -q '.state'` → `CLOSED`
+- If FPR > 0.10 on any path: follow-up issue exists with measurement + label `phase-5`
+
+**Closeout:** none.
+
+---
+
+## Item 3.3 — Phase 6 combined telemetry review
+
+**What:** Read all 4 Phase 6 telemetry storage keys; output a review doc.
+
+**Date gate:** the telemetry review needs ≥14 days of accumulated signal. Window opens ~2026-05-14. If today < 2026-05-14, defer this item to Sprint 4 and bring DM-A forward.
+
+**Kickoff prompt:**
+```
+Execute Sprint 3 item 3.3 (Phase 6 combined telemetry review) per docs/plans/v0.1-completion.md Sprint 3 §3.3. Pre-req: ≥14 days of telemetry across honeyllm:{cache,response,intercept,thinking}-telemetry storage keys (telemetry started accumulating 2026-04-30). Output docs/testing/phase6/TELEMETRY_REVIEW_2026-05-XX.md with: per-portal capture/analysed/suspicious/compromised rates; cache hit + 404 rate; intercept override-window crossings; cross-portal divergence stat (responseVerdict.status vs thinkingVerdict.status on same origin); selector regression signals (any portal with zero captures over the window). Open follow-up issues for any tuning gaps surfaced. Branch docs/issue-XXX-phase6-telemetry-review (open chore issue first).
+```
+
+**Validation:**
+- `docs/testing/phase6/TELEMETRY_REVIEW_2026-05-XX.md` exists on main
+- Any tuning gaps have open issues with `phase-6+` label
+
+---
+
+## Item 3.4 — #128 ProtectAI validation
+
+**What:** Head-to-head Path A (Hawk → ProtectAI deberta-v3 → LLM) vs Path B (Hawk → LLM direct) on the 50-entry pedagogical corpus. Measure TPR/FPR/F1/latency. Decide ship or won't-fix.
+
+**Kickoff prompt:**
+```
+Execute Sprint 3 item 3.4 (#128 ProtectAI validation) per docs/plans/v0.1-completion.md Sprint 3 §3.4. Set up the head-to-head: Path A = Hawk-FLAGGED → ProtectAI deberta-v3 → LLM-if-confirmed; Path B = Hawk-FLAGGED → LLM direct. Run on the English-only Hawk-FLAGGED chunks from the 50-entry pedagogical corpus (#120). Measure TPR / FPR / F1 / latency for both paths. Decision: if Path A measurably wins (significant latency saving without F1 loss) → implement on branch feat/issue-128-protectai-pathway. Else close #128 as won't-fix with measurements documented. Pre-req: pedagogical corpus available at docs/testing/phase5/pedagogical-corpus.jsonl.
+```
+
+**Validation:**
+- `gh issue view 128 --json state -q '.state'` → `CLOSED`
+- Decision documented (PR body if shipped; close comment if won't-fix) with TPR/FPR/F1/latency table
+
+---
+
+## Item 3.5 — ROADMAP refresh + RAG_STATUS clone
+
+**Kickoff prompt:**
+```
+Execute Sprint 3 item 3.5 (ROADMAP refresh + RAG_STATUS clone) per docs/plans/v0.1-completion.md Sprint 3 §3.5. Update docs/ROADMAP.md: mark Sprint 1-3 closed issues actually closed in §v1.0 (recompute %s; the doc is currently stale showing #83/#44/#45/#48/#60/#118/#119/#145 as v1.0-critical when all were closed 2026-04-30). Add 2026-05-XX decision-log entry summarising v0.2.0-internal cut. Clone docs/RAG_STATUS_2026-04-21.md → docs/RAG_STATUS_2026-05-XX.md with delta of all closed work since. Branch docs/issue-XXX-roadmap-refresh-v0.2 (open chore issue first).
+```
+
+**Validation:**
+- `docs/ROADMAP.md` v1.0 row reflects current closed-issue count
+- `docs/RAG_STATUS_2026-05-XX.md` exists
+
+---
+
+## Item 3.6 — Write `docs/RELEASE_NOTES_v0.2.0-internal.md`
+
+**Kickoff prompt:**
+```
+Execute Sprint 3 item 3.6 (RELEASE_NOTES_v0.2.0-internal.md) per docs/plans/v0.1-completion.md Sprint 3 §3.6. Headline: stability fixes (#220/#221 mitigation lifecycle, #226 logging coverage, #232 bricklink FP, #217 Officeworks posture), Phase 3 closure (#2 B7 report, #14 replicates), maintainer smokes done (#124, #129), image probe popup (#9 4G.6a/b), Phase 5 §4.2 LLM-layer FPR baseline, ProtectAI validation result (#128). Known issues: any items deferred from this sprint per scope-cuts. Branch docs/issue-XXX-release-notes-v0.2 (open chore issue first).
+```
+
+**Validation:** `docs/RELEASE_NOTES_v0.2.0-internal.md` exists with all Sprint 1-3 closures cited.
+
+---
+
+## Item 3.7 — Tag v0.2.0-internal
+
+**Kickoff prompt:**
+```
+Execute Sprint 3 item 3.7 (tag v0.2.0-internal) per docs/plans/v0.1-completion.md Sprint 3 §3.7. Run: npm ci && npm run typecheck && npm test && npm run build:release && npm run test:e2e — all must pass. Bump manifest.json + package.json from 0.1.0 → 0.2.0-internal. Branch release/v0.2.0-internal; PR with --body-file docs/RELEASE_NOTES_v0.2.0-internal.md; squash-merge after CI green. Then: git checkout main && git pull && git tag v0.2.0-internal && git push origin v0.2.0-internal && gh release create v0.2.0-internal -F docs/RELEASE_NOTES_v0.2.0-internal.md --prerelease.
+```
+
+**Validation:**
+- `git tag` lists `v0.2.0-internal`
+- `gh release view v0.2.0-internal` returns the release
+- `manifest.json` and `package.json` show version `0.2.0-internal`
+
+---
+
+## Sprint 3 close-out
+
+1. Edit epic #248: mark Sprint 3 ✅ DONE; tag link in summary block.
+2. Spillover log: append any from Sprint 1-3.
+3. Open Sprint 4: [`sprint-4-determillm-bridge.md`](sprint-4-determillm-bridge.md).

--- a/docs/plans/sprints/sprint-4-determillm-bridge.md
+++ b/docs/plans/sprints/sprint-4-determillm-bridge.md
@@ -1,0 +1,113 @@
+# Sprint 4 — DetermiLLM bridge (DM-A/E/F/G) + Wolf design (Days 10-12)
+
+**Theme:** Wire DetermiLLM as 3rd Hunter (stub) + telemetry + benchmark refactor + seed-issue triage; start Wolf canary design. **Tag:** none. **Recommended model:** `claude-haiku-4-5-20251001`, effort medium (mechanical wiring + triage).
+
+Master plan: [`../v0.1-completion.md` Sprint 4](../v0.1-completion.md#sprint-4-days-1012-determillm-bridge--wolf-design). Tracking: epic #248. Cross-pollination: closes DM-A/E/F/G on the DetermiLLM phase side.
+
+---
+
+## Pre-flight checklist
+
+- [ ] Model: `claude-haiku-4-5-20251001` (medium). Bridge work is mechanical.
+- [ ] Plugins baseline.
+- [ ] MCP: minimum.
+- [ ] Repo state: `npm test` passes; v0.2.0-internal tag exists.
+- [ ] Read [`docs/determillm/ARCHITECTURE.md`](../../determillm/ARCHITECTURE.md) before items 4.1-4.4 — that's the design contract.
+
+```bash
+cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-haiku-4-5-20251001
+```
+
+---
+
+## Item 4.1 — #244 DM-A pack runtime + en pack v0 stub
+
+**What:** Wire DetermiLLM as 3rd Hunter in `runHunt`. Empty `dialect-en` pack stub; gates on Phase 2 baseline byte-identical.
+
+**Kickoff prompt:**
+```
+Execute Sprint 4 item 4.1 (#244 DM-A pack runtime + en pack v0 stub) per docs/plans/v0.1-completion.md Sprint 4 §4.1. Read docs/determillm/ARCHITECTURE.md (PR #166) before starting. Create src/hunters/determillm/{index.ts, pack-runtime.ts}, packs/dialect-en.json (stub: {patterns:[], version:1}), packs/schema.json. Register as 3rd Hunter in runHunt (so total = Spider + Hawk + embeddings + DetermiLLM = 4 hunters). Verify k-of-N voting at tier-router.ts:27 picks it up. **HARD GATE: 0 changed verdicts on Phase 2 byte-locked baseline (162 rows in docs/testing/inbrowser-results.json).** Anchors: tier-router.ts:22-35, src/hunters/spider/index.ts (Hunter shape exemplar). Branch feat/issue-244-determillm-pack-runtime.
+```
+
+**Validation:**
+- `gh issue view 244 --json state -q '.state'` → `CLOSED`
+- `npm test` passes; new tests cover empty-pack returns no findings
+- `git diff main~1 -- docs/testing/inbrowser-results.json` shows zero diff
+
+**Closeout:** comment on the architecture doc PR #166 marking DM-A ✅ COMPLETE on the DetermiLLM side.
+
+---
+
+## Item 4.2 — #245 DM-E pack-match telemetry surface
+
+**Kickoff prompt:**
+```
+Execute Sprint 4 item 4.2 (#245 DM-E pack-match telemetry) per docs/plans/v0.1-completion.md Sprint 4 §4.2. Add STORAGE_KEY_PACK_MATCH_TELEMETRY = 'honeyllm:pack-match-telemetry'. Persist {patternId, chunkId, language, score, ts} per match from orchestrator.ts:191 analyzeSnapshot. **Privacy contract: IDs only, NO excerpt text** (per memory feedback rule). Cap at N=1000 most-recent; rolling drop. Mirror src/registry/telemetry.ts (SR-G) trio: record/reset/getStats. TDD: 8 cases covering persist/no-persist/cap/defensive null. Branch feat/issue-245-pack-match-telemetry.
+```
+
+**Validation:**
+- `gh issue view 245 --json state -q '.state'` → `CLOSED`
+- Manual: visit any page with the post-DM-A extension; SW console `chrome.storage.local.get('honeyllm:pack-match-telemetry')` returns the bounded array
+
+**Closeout:** mark DM-E ✅ on architecture doc.
+
+---
+
+## Item 4.3 — #246 DM-F benchmark-dialect.ts parameterise classifier
+
+**Kickoff prompt:**
+```
+Execute Sprint 4 item 4.3 (#246 DM-F benchmark parameterise) per docs/plans/v0.1-completion.md Sprint 4 §4.3. Refactor scripts/benchmark-dialect.ts:20-21 to accept --classifier flag with values spider+hawk / spider+hawk+determillm / determillm-alone. Output JSON header includes classifier set. Default (no flag) = spider+hawk to preserve existing scripts. TDD: flag parsing + each classifier set runs + output schema invariant. Branch refactor/issue-246-benchmark-classifier-flag.
+```
+
+**Validation:**
+- `gh issue view 246 --json state -q '.state'` → `CLOSED`
+- `tsx scripts/benchmark-dialect.ts --classifier determillm-alone --dry-run` exits 0
+
+**Closeout:** mark DM-F ✅ on architecture doc.
+
+---
+
+## Item 4.4 — #247 DM-G seed-issue triage
+
+**Pre-req:** DM-A/E/F all merged.
+
+**Kickoff prompt:**
+```
+Execute Sprint 4 item 4.4 (#247 DM-G seed-issue triage) per docs/plans/v0.1-completion.md Sprint 4 §4.4. Pre-req: #244, #245, #246 all merged. Re-read each of #66, #67, #68, #69, #70, #71, #72, #73, #74, #77, #78, #79 against docs/determillm/ARCHITECTURE.md. Close issues whose intent is satisfied with comment citing superseder PR / arch-doc section. Reframe #66 / #67 / #69 (broader contract-enforcement layer) to phase-8-candidate label; update issue body to reflect Phase 8+ deferral. Each retained / reframed issue gets a comment pointing at the arch-doc section keeping it open. Triage summary commented on #247 with closed/retained/reframed counts. Then close #247.
+```
+
+**Validation:**
+- `gh issue view 247 --json state -q '.state'` → `CLOSED`
+- Triage summary comment on #247 lists all 12 seed issues with disposition
+- `gh issue list --label phase-8-candidate --search '#66 OR #67 OR #69'` shows #66/#67/#69 reframed
+
+**Closeout:** mark DM-G ✅ on architecture doc.
+
+---
+
+## Item 4.5 — #3 Wolf canary stage 1: design + Llama-3.2-1B integration scaffold
+
+**What:** RFC + scaffold the third canary engine (Llama-3.2-1B). No production wiring yet; stage 2-4 ship in Sprints 5-6.
+
+**Kickoff prompt:**
+```
+Execute Sprint 4 item 4.5 (#3 Wolf canary stage 1) per docs/plans/v0.1-completion.md Sprint 4 §4.5. Write design RFC at docs/proposals/wolf-canary.md covering: (1) why Llama-3.2-1B as third canary (refusal-as-detection per Phase 3 Track A §4: 9/9 refusals on clean inputs), (2) scoring contribution SCORE_WOLF_REFUSAL = 30 (between SUSPICIOUS and COMPROMISED), (3) tier-router integration plan, (4) capability declaration ['text_input']. Add 'llama-3.2-1b-mlc' to src/shared/constants.ts CANARY_CATALOG. Scaffold src/offscreen/canaries/wolf-canary.ts mirroring the Gemma adapter pattern (engine init, generateCompletion, Promise singleton). NO refusal-detection logic yet (Stage 2 in Sprint 5). NO tier-router integration yet (Stage 3 in Sprint 5). Branch feat/issue-3-wolf-canary-stage-1.
+```
+
+**Validation:**
+- `gh pr view <N> --json state -q '.state'` → `MERGED`
+- `docs/proposals/wolf-canary.md` exists
+- `npm test` passes (scaffold tests; no behaviour-change tests yet)
+- #3 stays open (stages 2-4 in Sprints 5-6)
+
+**Closeout:** none.
+
+---
+
+## Sprint 4 close-out
+
+1. Epic #248: Sprint 4 ✅ DONE.
+2. Comment on the DetermiLLM architecture doc / its tracking issue: DM-A/E/F/G all complete via HoneyLLM Sprint 4; DetermiLLM phase can now focus on DM-B/C/D pack curation + #75 with the runtime + telemetry + benchmark already shipped.
+3. Spillover log: nothing expected this sprint unless Wolf design surfaces a hidden constraint.
+4. Open Sprint 5: [`sprint-5-wolf-nano.md`](sprint-5-wolf-nano.md).

--- a/docs/plans/sprints/sprint-5-wolf-nano.md
+++ b/docs/plans/sprints/sprint-5-wolf-nano.md
@@ -1,0 +1,82 @@
+# Sprint 5 — Wolf canary + Nano refinements + #119 (Days 13-15)
+
+**Theme:** Implement Wolf canary's refusal-as-detection pipeline, wire into tier-router, ship #60 + #119. **Tag:** none. **Recommended model:** `claude-sonnet-4-6`, effort medium.
+
+Master plan: [`../v0.1-completion.md` Sprint 5](../v0.1-completion.md#sprint-5-days-1315-wolf-canary--nano-refinements--119). Tracking: epic #248.
+
+---
+
+## Pre-flight checklist
+
+- [ ] Model: `claude-sonnet-4-6` (medium effort). Wolf needs solid reasoning on refusal patterns but not Opus.
+- [ ] Plugins: baseline + `chrome-devtools-mcp` for Llama-3.2-1B WebGPU debugging if needed.
+- [ ] Repo state: Wolf scaffold from Sprint 4 on main; DM-A/E/F/G all merged.
+
+```bash
+cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-sonnet-4-6
+```
+
+---
+
+## Item 5.1 — #3 Wolf stage 2: refusal-as-detection pipeline
+
+**Kickoff prompt:**
+```
+Execute Sprint 5 item 5.1 (#3 Wolf stage 2) per docs/plans/v0.1-completion.md Sprint 5 §5.1. Pre-req: Wolf scaffold on main from Sprint 4 §4.5. Build src/analysis/wolf-refusal-analyzer.ts: when Wolf returns text containing "I can't / I won't / I'm sorry / I cannot / This appears to be / I don't think I should" (refusal markers) IN RESPONSE TO a chunk that does NOT have explicit suspicious markers (per the existing instruction-detection probe), treat as a Wolf detection signal. TDD: 12 cases — refusal-on-clean (signal), refusal-on-injection (signal), compliance-on-clean (no signal), compliance-on-injection (no signal — Wolf doesn't catch this case; that's other hunters' job), edge cases (refusal language inside a code block, multi-language refusals, partial refusals). Branch feat/issue-3-wolf-stage-2.
+```
+
+**Validation:**
+- `npm test` includes 12 wolf-refusal-analyzer tests; all pass
+- `gh pr view <N> --json state -q '.state'` → `MERGED`
+- #3 stays open (stages 3-4 still pending)
+
+---
+
+## Item 5.2 — #3 Wolf stage 3: tier-router integration + scoring
+
+**Kickoff prompt:**
+```
+Execute Sprint 5 item 5.2 (#3 Wolf stage 3) per docs/plans/v0.1-completion.md Sprint 5 §5.2. Pre-req: §5.1 merged. Wire Wolf into tier-router as third-canary path. SCORE_WOLF_REFUSAL = 30 added to src/shared/constants.ts. Wolf signal stacks with Spider/Hawk/embeddings/DetermiLLM. **HARD GATE: Phase 2 byte-locked baseline byte-identical when Wolf is NOT the selected canary** (default canary stays Gemma; Wolf only fires when explicitly selected via the canary chooser). TDD: 8 cases — Wolf-selected dispatches Wolf, Gemma-selected does not, scoring delta in tier-router when Wolf flags, no scoring delta when Wolf is silent, regression on the existing 162-row baseline under Gemma. Branch feat/issue-3-wolf-stage-3.
+```
+
+**Validation:**
+- `npm test` passes including baseline regression tests
+- `git diff main~1 -- docs/testing/inbrowser-results.json` shows zero diff
+- #3 stays open (stage 4 in Sprint 6)
+
+---
+
+## Item 5.3 — #60 Nano in-chunk abort signal
+
+**Kickoff prompt:**
+```
+Execute Sprint 5 item 5.3 (#60 Nano in-chunk abort) per docs/plans/v0.1-completion.md Sprint 5 §5.3. Thread AbortSignal into LanguageModel.session.prompt({signal}) in src/offscreen/canaries/nano-canary.ts. Allows in-chunk abort when the chunk-cap from #210 is exceeded mid-flight. TDD: 6 cases — signal-not-set (passes through), signal-aborted-before (rejects fast), signal-aborted-during (cancels), multiple-aborts-idempotent, abort-error-classification (don't surface as analysisError; surface as 'aborted' status), survival of fast cancellations on the next-chunk path. Branch feat/issue-60-nano-abort-signal.
+```
+
+**Validation:**
+- `gh issue view 60 --json state -q '.state'` → `CLOSED`
+- 6 new tests pass
+
+---
+
+## Item 5.4 — #119 xlm-roberta language-detection fallback (full impl)
+
+**What:** Replace the graceful-fallback stub at `src/hunters/hawk/language-router.ts:33` with full xlm-roberta language detection via transformers.js. Sprint 2's #124 maintainer smoke confirmed Browse MCP Stage 5 ships, so the consumer exists.
+
+**Kickoff prompt:**
+```
+Execute Sprint 5 item 5.4 (#119 xlm-roberta full impl) per docs/plans/v0.1-completion.md Sprint 5 §5.4. Pre-req: #124 Browse MCP smoke complete (Sprint 2). Replace the graceful-fallback stub at src/hunters/hawk/language-router.ts:33 with full xlm-roberta language detection via transformers.js. Reuse the bundling pattern from #156 (NER engine) and #129 (embeddings) — copy prebuilt browser bundle + chrome.runtime.getURL; do NOT bundle via Vite (per project memory rule transformersjs_bundling). Anchors: src/offscreen/ner-engine.ts (singleton + factory DI seam pattern), src/offscreen/embedding-engine.ts. TDD: 10 cases — en/es/zh-CN/de/fr detection accuracy, multilingual page handling, empty-string defensive, model-load-failure graceful fallback to existing stub behaviour. Branch feat/issue-119-xlm-roberta-full.
+```
+
+**Validation:**
+- `gh issue view 119 --json state -q '.state'` → `CLOSED`
+- `npm test` includes 10 new language-router tests
+- `npm run build`; `dist/` size delta < 50 MB (xlm-roberta is ~280 MB unquantised; q8 should land near 70 MB; verify acceptable)
+
+---
+
+## Sprint 5 close-out
+
+1. Epic #248: Sprint 5 ✅ DONE.
+2. Spillover: if Wolf integration surfaced bugs in Spider/Hawk hunter wiring, document on those issues.
+3. Open Sprint 6: [`sprint-6-tag-v0.3.md`](sprint-6-tag-v0.3.md).

--- a/docs/plans/sprints/sprint-6-tag-v0.3.md
+++ b/docs/plans/sprints/sprint-6-tag-v0.3.md
@@ -1,0 +1,92 @@
+# Sprint 6 — Wolf finish + #227 + tag v0.3.0-internal (Days 16-18)
+
+**Theme:** Finish Wolf, ship harness state-query API, optionally run #15 mini-sweep, tag the second internal milestone. **Tag at end:** `v0.3.0-internal`. **Recommended model:** `claude-sonnet-4-6`, effort medium.
+
+Master plan: [`../v0.1-completion.md` Sprint 6](../v0.1-completion.md#sprint-6-days-1618-wolf-finish--227--tag-v110). Tracking: epic #248.
+
+---
+
+## Pre-flight checklist
+
+- [ ] Model: `claude-sonnet-4-6` (medium).
+- [ ] Plugins baseline.
+- [ ] Repo state: Wolf stages 1-3 on main; #60 + #119 on main.
+
+```bash
+cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-sonnet-4-6
+```
+
+---
+
+## Item 6.1 — #3 Wolf stage 4: testing + benchmark + popup integration
+
+**Kickoff prompt:**
+```
+Execute Sprint 6 item 6.1 (#3 Wolf stage 4) per docs/plans/v0.1-completion.md Sprint 6 §6.1. Run scripts/benchmark-dialect.ts --classifier spider+hawk+wolf against the 23-page test-pages/ corpus (NOT the 1250-corpus per memory rule project_hunter_corpus_split). Add Wolf row to popup hunter-findings UI mirroring the existing Spider/Hawk/embeddings rows. Validate Phase 2 byte-locked baseline byte-identical when Wolf is NOT the selected canary. CLOSES #3 if all stages 1-4 are green. Branch feat/issue-3-wolf-stage-4.
+```
+
+**Validation:**
+- `gh issue view 3 --json state -q '.state'` → `CLOSED`
+- Benchmark output JSON committed under `docs/testing/phase5/wolf-benchmark-2026-05-XX.json`
+- `git diff main~1 -- docs/testing/inbrowser-results.json` shows zero diff
+- Manual: load `dist/`, switch canary to Wolf in popup, visit injected fixture, confirm Wolf row appears in popup
+
+---
+
+## Item 6.2 — #227 harness-mediated live state query API
+
+**Kickoff prompt:**
+```
+Execute Sprint 6 item 6.2 (#227 harness state-query API) per docs/plans/v0.1-completion.md Sprint 6 §6.2. Build a chrome.runtime.sendMessage({type: 'STATE_QUERY'}) handler in src/service-worker/index.ts that returns {loadedCanary, activeMitigations, lastVerdict, telemetryCounters: {cache, response, intercept, thinking, packMatch, registry}}. Used by harness for non-disruptive state introspection (no UI side effects). TDD: 8 cases — each return field present, missing-state defaults (e.g. no canary loaded → loadedCanary: null), unknown-message-type rejection, defensive against runtime.lastError. Branch feat/issue-227-state-query-api.
+```
+
+**Validation:**
+- `gh issue view 227 --json state -q '.state'` → `CLOSED`
+- `npm test` includes 8 new state-query tests
+- Manual: `chrome.runtime.sendMessage({type: 'STATE_QUERY'})` from harness or DevTools console returns the expected shape
+
+---
+
+## Item 6.3 — #15 Phase 8 mini-sweep (CONDITIONAL)
+
+**Run only if Sprint 3's Phase 6 telemetry review (item 3.3) flagged Stage-6 deltas.** Otherwise skip; close #15 in Sprint 12 with a "no signal in telemetry" note.
+
+**Kickoff prompt (only if conditional fires):**
+```
+Execute Sprint 6 item 6.3 (#15 Phase 8 mini-sweep) per docs/plans/v0.1-completion.md Sprint 6 §6.3. Pre-req: Sprint 3's TELEMETRY_REVIEW doc flagged Stage-6 deltas needing re-sample. Run the mini-sweep on the 3 un-re-sampled Stage 6 deltas. Output JSON sidecar; commit on test/issue-15-mini-sweep.
+```
+
+**Validation if run:**
+- `gh issue view 15 --json state -q '.state'` → `CLOSED`
+- Sidecar JSON committed
+
+---
+
+## Item 6.4 — Refresh ROADMAP + RAG_STATUS + RELEASE_NOTES_v0.3.0-internal.md
+
+**Kickoff prompt:**
+```
+Execute Sprint 6 item 6.4 (release-cut prep for v0.3.0-internal) per docs/plans/v0.1-completion.md Sprint 6 §6.4. Update docs/ROADMAP.md with Sprint 4-6 closures. Clone docs/RAG_STATUS_<prev>.md → docs/RAG_STATUS_2026-05-XX.md. Write docs/RELEASE_NOTES_v0.3.0-internal.md headlining: Wolf canary shipped (third canary engine), DetermiLLM bridge complete (DM-A/E/F/G), Nano in-chunk abort (#60), xlm-roberta language detection (#119), harness state-query API (#227). Branch docs/issue-XXX-release-prep-v0.3 (open chore issue first).
+```
+
+**Validation:** doc files exist on main.
+
+---
+
+## Item 6.5 — Tag v0.3.0-internal
+
+**Kickoff prompt:**
+```
+Execute Sprint 6 item 6.5 (tag v0.3.0-internal) per docs/plans/v0.1-completion.md Sprint 6 §6.5. Run npm ci && npm run typecheck && npm test && npm run build:release && npm run test:e2e — all must pass. Bump manifest.json + package.json from 0.2.0-internal → 0.3.0-internal. Branch release/v0.3.0-internal; PR with --body-file docs/RELEASE_NOTES_v0.3.0-internal.md; squash-merge after CI green. git tag v0.3.0-internal && git push origin v0.3.0-internal && gh release create v0.3.0-internal -F docs/RELEASE_NOTES_v0.3.0-internal.md --prerelease.
+```
+
+**Validation:**
+- `git tag` lists `v0.3.0-internal`
+- `gh release view v0.3.0-internal` returns the release
+
+---
+
+## Sprint 6 close-out
+
+1. Epic #248: Sprint 6 ✅ DONE; tag link in summary block.
+2. Open Sprint 7: [`sprint-7-isolate-mode.md`](sprint-7-isolate-mode.md).

--- a/docs/plans/sprints/sprint-7-isolate-mode.md
+++ b/docs/plans/sprints/sprint-7-isolate-mode.md
@@ -1,0 +1,73 @@
+# Sprint 7 — Isolate mode #132 (Days 19-21)
+
+**Theme:** Phase 7+ Stage 1: managed sandbox tab/profile so a flagged page can't reach the user's real session. **Tag:** none. **Recommended model:** `claude-opus-4-7`, effort high (security-critical design).
+
+Master plan: [`../v0.1-completion.md` Sprint 7](../v0.1-completion.md#sprint-7-days-1921-isolate-mode-132--phase-7-stage-1). Tracking: epic #248.
+
+---
+
+## Pre-flight checklist
+
+- [ ] Model: **`claude-opus-4-7`** (high effort). Security-critical; cookie/storage isolation must be exact.
+- [ ] Plugins: baseline + `chrome-devtools-mcp` for incognito-window debugging.
+- [ ] Repo state: v0.3.0-internal tag exists on main.
+
+```bash
+cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-opus-4-7
+```
+
+---
+
+## Item 7.1 — #132 Stage 1: design + sandbox tab/profile RFC
+
+**Kickoff prompt:**
+```
+Execute Sprint 7 item 7.1 (#132 Stage 1: isolate mode RFC) per docs/plans/v0.1-completion.md Sprint 7 §7.1. Write design RFC at docs/proposals/isolate-mode.md covering: (1) trigger UX — "Isolate" button in popup + per-origin "always isolate" preference, (2) isolation primitive — chrome.windows.create({incognito: true, focused: true, ...}) OR a managed Chrome profile via chrome.identity API; pick one with rationale, (3) cookie / storage / cache containment guarantees, (4) escape paths to consider (window.opener, postMessage cross-window, drag-drop, copy/paste via clipboard), (5) UX for the user when an isolate happens (notification? automatic close on tab navigate-away?), (6) interaction with existing mitigations (network-guard, redirect-blocker still apply inside isolate window). Open chore issue first. Branch docs/issue-XXX-isolate-mode-rfc.
+```
+
+**Validation:**
+- `docs/proposals/isolate-mode.md` exists on main
+- RFC PR merged with explicit answers to all 6 design questions
+
+---
+
+## Item 7.2 — #132 Stage 2: implementation
+
+**Kickoff prompt:**
+```
+Execute Sprint 7 item 7.2 (#132 Stage 2: isolate implementation) per docs/plans/v0.1-completion.md Sprint 7 §7.2. Pre-req: §7.1 RFC merged. Implement per RFC: (1) "Isolate this page" button in popup → SW message ISOLATE_PAGE, (2) SW handler creates incognito window via chrome.windows.create, opens the URL, returns success/failure to popup, (3) per-origin "always isolate" preference stored at honeyllm:isolate-preferences in chrome.storage.sync (or local — match RFC decision), (4) auto-isolate when verdict on a configured origin returns COMPROMISED, (5) preserve existing mitigations (network-guard, redirect-blocker) inside isolate window. Branch feat/issue-132-isolate-mode-impl.
+```
+
+**Validation:**
+- `npm test` passes; new tests cover SW handler + popup wiring + preferences storage
+- `gh pr view <N> --json state -q '.state'` → `MERGED`
+
+---
+
+## Item 7.3 — #132 Stage 3: testing
+
+**Kickoff prompt:**
+```
+Execute Sprint 7 item 7.3 (#132 Stage 3: isolate testing) per docs/plans/v0.1-completion.md Sprint 7 §7.3. Add: (1) unit tests for SW message handler (DI seam for chrome.windows; jsdom doesn't cover it), (2) preference storage round-trip tests, (3) integration test scenario — popup click → message → handler → window.create stub assertion, (4) E2E if feasible via Playwright (incognito window control is limited but at least confirm popup button presence + click handler wires up). Branch test/issue-132-isolate-mode-tests.
+```
+
+**Validation:**
+- `npm test` passes with isolate-mode tests
+- `npm run test:e2e` passes if E2E added
+
+---
+
+## Item 7.4 [USER] — Smoke isolate mode
+
+**Manual playbook:** [`../v0.1-completion.md` §M-8](../v0.1-completion.md#m-8--isolate-mode-smoke-sprint-7). Summary: load `dist/`, click "Isolate this page", confirm new incognito window opens; in incognito DevTools confirm cookies sandboxed; comment outcome on #132; close issue.
+
+**Validation:**
+- `gh issue view 132 --json state -q '.state'` → `CLOSED`
+- Comment on #132 has screenshot of incognito DevTools showing empty cookie set
+
+---
+
+## Sprint 7 close-out
+
+1. Epic #248: Sprint 7 ✅ DONE.
+2. Open Sprint 8: [`sprint-8-local-proxy.md`](sprint-8-local-proxy.md).

--- a/docs/plans/sprints/sprint-8-local-proxy.md
+++ b/docs/plans/sprints/sprint-8-local-proxy.md
@@ -1,0 +1,93 @@
+# Sprint 8 — Local Proxy w/ root CA #133 + tag v0.4.0-internal (Days 22-24)
+
+**Theme:** Phase 7+ Stage 2: enterprise-deployable local MITM proxy w/ self-signed root CA. **Tag at end:** `v0.4.0-internal`. **Recommended model:** `claude-opus-4-7`, effort high.
+
+Master plan: [`../v0.1-completion.md` Sprint 8](../v0.1-completion.md#sprint-8-days-2224-local-proxy-w-root-ca-133--tag-v120). Tracking: epic #248.
+
+---
+
+## Pre-flight checklist
+
+- [ ] Model: **`claude-opus-4-7`** (high effort). Cert handling + MITM are security-critical and easy to get wrong.
+- [ ] Plugins baseline.
+- [ ] Repo state: v0.3.0-internal tag exists; #132 closed.
+
+```bash
+cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-opus-4-7
+```
+
+---
+
+## Item 8.1 — #133 Stage 1: root CA generation + cert install procedure
+
+**Kickoff prompt:**
+```
+Execute Sprint 8 item 8.1 (#133 Stage 1: root CA + install) per docs/plans/v0.1-completion.md Sprint 8 §8.1. Create new top-level proxy/ package (sibling to mcp-server/). Implement proxy/scripts/generate-root-ca.js using Node's crypto module: generate 4096-bit RSA Ed25519 root CA + private key + 10-year validity; write to proxy/certs/root-ca.{crt,key}; gitignore the .key. Document install steps for macOS Keychain (security add-trusted-cert), Windows Certificate Manager (certutil -addstore), Linux (cp + update-ca-certificates). Branch feat/issue-133-stage-1-root-ca.
+```
+
+**Validation:**
+- `node proxy/scripts/generate-root-ca.js` produces valid cert (verify with `openssl x509 -in proxy/certs/root-ca.crt -text -noout`)
+- `proxy/certs/root-ca.key` is gitignored
+- README install steps documented
+
+---
+
+## Item 8.2 — #133 Stage 2: proxy server implementation
+
+**Kickoff prompt:**
+```
+Execute Sprint 8 item 8.2 (#133 Stage 2: proxy server) per docs/plans/v0.1-completion.md Sprint 8 §8.2. Implement Node-side MITM HTTPS proxy in proxy/src/index.ts: (1) listen on configurable port (default 8443), (2) on each HTTPS request, dynamically generate per-host leaf cert signed by root CA, (3) decrypt request, run HoneyLLM probes via the same mcp-server runner pattern (item 7 stage 3 from master plan), (4) on CLEAN verdict forward unmodified to upstream, (5) on COMPROMISED return 451 (Unavailable For Legal Reasons) with explanation page, (6) on UNKNOWN forward with a header X-HoneyLLM-Status: unknown. Use 'http-mitm-proxy' or equivalent battle-tested lib; document why if rolling own. Branch feat/issue-133-stage-2-proxy-server.
+```
+
+**Validation:**
+- `npm test` in proxy/ passes
+- `node proxy/dist/index.js --port 8443` starts cleanly
+- Manual: `curl --proxy http://127.0.0.1:8443 --cacert proxy/certs/root-ca.crt https://example.com` returns expected page
+
+---
+
+## Item 8.3 — #133 Stage 3: MDM-friendly configuration
+
+**Kickoff prompt:**
+```
+Execute Sprint 8 item 8.3 (#133 Stage 3: MDM config) per docs/plans/v0.1-completion.md Sprint 8 §8.3. Add proxy/config.example.yaml documenting all configurable options: port, upstream allow-list, deny-list, log path, telemetry endpoint (off by default), HONEYLLM_LLM_BASE_URL/MODEL env vars for canary endpoint. Document deployment patterns: per-user (start at login), system-wide (launchd plist on macOS / systemd unit on Linux / Windows Service on Windows). NO per-user setup beyond cert install. Branch docs/issue-133-stage-3-mdm-config.
+```
+
+**Validation:**
+- `proxy/config.example.yaml` exists with all options documented
+- README has launchd / systemd / Windows Service example fragments
+
+---
+
+## Item 8.4 [USER] — Install root CA, smoke proxy
+
+**Manual playbook:** [`../v0.1-completion.md` §M-9](../v0.1-completion.md#m-9--local-proxy--root-ca-install-sprint-8). Summary: build proxy, generate cert, install root CA on macOS Keychain, configure Chrome proxy, visit Wikipedia + injection fixture, confirm proxy log + 451 block. Comment + close.
+
+**Validation:**
+- `gh issue view 133 --json state -q '.state'` → `CLOSED`
+- Comment on #133 has screenshots showing CLEAN forward + 451 block + proxy log entries
+
+---
+
+## Item 8.5 — Refresh ROADMAP + RAG_STATUS + RELEASE_NOTES_v0.4.0-internal.md
+
+**Kickoff prompt:**
+```
+Execute Sprint 8 item 8.5 (release-cut prep for v0.4.0-internal) per docs/plans/v0.1-completion.md Sprint 8 §8.5. Update ROADMAP + clone RAG_STATUS. Write RELEASE_NOTES_v0.4.0-internal.md headlining: isolate mode (#132) + Local Proxy w/ root CA (#133). Branch docs/issue-XXX-release-prep-v0.4.
+```
+
+---
+
+## Item 8.6 — Tag v0.4.0-internal
+
+**Kickoff prompt:**
+```
+Execute Sprint 8 item 8.6 (tag v0.4.0-internal) per docs/plans/v0.1-completion.md Sprint 8 §8.6. Tests + build clean. Bump manifest + package.json: 0.3.0-internal → 0.4.0-internal. release/v0.4.0-internal branch + PR + tag + gh release create --prerelease.
+```
+
+---
+
+## Sprint 8 close-out
+
+1. Epic #248: Sprint 8 ✅ DONE; tag link.
+2. Open Sprint 9: [`sprint-9-byok.md`](sprint-9-byok.md).

--- a/docs/plans/sprints/sprint-9-byok.md
+++ b/docs/plans/sprints/sprint-9-byok.md
@@ -1,0 +1,70 @@
+# Sprint 9 — BYOK #19 (Days 25-27)
+
+**Theme:** Bring-Your-Own-Key for Anthropic + OpenAI + Google providers, gated by per-origin policy. **Tag:** none. **Recommended model:** `claude-sonnet-4-6`, effort medium (well-trodden patterns).
+
+Master plan: [`../v0.1-completion.md` Sprint 9](../v0.1-completion.md#sprint-9-days-2527-byok-19). Tracking: epic #248.
+
+---
+
+## Pre-flight checklist
+
+- [ ] Model: `claude-sonnet-4-6` (medium).
+- [ ] Plugins baseline + `context7` for SDK docs lookup.
+- [ ] Repo state: v0.4.0-internal tag exists.
+
+```bash
+cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-sonnet-4-6
+```
+
+---
+
+## Item 9.1 — #19 Stage 1: design + provider abstraction
+
+**Kickoff prompt:**
+```
+Execute Sprint 9 item 9.1 (#19 Stage 1: BYOK design) per docs/plans/v0.1-completion.md Sprint 9 §9.1. Design RFC at docs/proposals/byok.md covering: (1) provider adapter interface mirroring mcp-server/src/probes/llm-endpoint.ts (LlmEndpoint shape), (2) key storage in chrome.storage.session (memory-only, not synced — wipes on browser restart) — rationale: API keys are sensitive, never sync, never persist beyond session, (3) per-origin policy ("use BYOK Claude for anthropic.com tabs"), (4) fallback behaviour on quota / network errors → fall back to local canary with telemetry log, (5) security model: keys never leave the offscreen doc; popup never sees raw key (only a redacted last-4-chars indicator). Open chore issue first. Branch docs/issue-XXX-byok-rfc.
+```
+
+---
+
+## Item 9.2 — #19 Stage 2: implementation (3 adapters)
+
+**Kickoff prompt:**
+```
+Execute Sprint 9 item 9.2 (#19 Stage 2: BYOK adapters) per docs/plans/v0.1-completion.md Sprint 9 §9.2. Pre-req: §9.1 RFC merged. Create src/probes/byok/ with: (1) types.ts defining BYOKProvider interface, (2) anthropic-byok.ts (Anthropic Messages API; current default model claude-opus-4-7), (3) openai-byok.ts (OpenAI Responses API or Chat Completions; current default gpt-5.4), (4) google-byok.ts (Gemini API; default gemini-3-flash-preview), (5) storage.ts for chrome.storage.session key handling, (6) policy.ts for per-origin routing rules. TDD: 6 cases per adapter (success, quota error fallback, network error fallback, key-not-set error, model-not-set error, response-shape validation). Branch feat/issue-19-stage-2-byok-adapters.
+```
+
+---
+
+## Item 9.3 — #19 Stage 3: settings UI in popup/options
+
+**Kickoff prompt:**
+```
+Execute Sprint 9 item 9.3 (#19 Stage 3: BYOK UI) per docs/plans/v0.1-completion.md Sprint 9 §9.3. Add BYOK section to popup settings (or new options page if popup is too crowded). Per provider: paste-key field (password-type input; show last-4 only after save), model selector dropdown, "Test connection" button (sends a 1-token completion to validate), per-origin policy editor. Keys stored via storage.ts (Stage 2). Branch feat/issue-19-stage-3-byok-ui.
+```
+
+---
+
+## Item 9.4 — #19 Stage 4: testing
+
+**Kickoff prompt:**
+```
+Execute Sprint 9 item 9.4 (#19 Stage 4: BYOK testing) per docs/plans/v0.1-completion.md Sprint 9 §9.4. Add: integration test for popup settings → storage → adapter selection on next probe dispatch; jsdom test for the popup UI components; Playwright E2E if feasible (mocking the API endpoint). Branch test/issue-19-stage-4-byok-tests.
+```
+
+---
+
+## Item 9.5 [USER] — Smoke each provider with own key
+
+**Manual playbook:** [`../v0.1-completion.md` §M-10](../v0.1-completion.md#m-10--byok-provider-smoke-sprint-9). Summary: get keys for Anthropic + OpenAI + Google; for each: paste key, select model, test connection, visit a test page, confirm popup shows the BYOK model name. Comment + close per provider.
+
+**Validation:**
+- `gh issue view 19 --json state -q '.state'` → `CLOSED`
+- 3 comments on #19, one per provider, each with a screenshot
+
+---
+
+## Sprint 9 close-out
+
+1. Epic #248: Sprint 9 ✅ DONE.
+2. Open Sprint 10: [`sprint-10-local-chat.md`](sprint-10-local-chat.md).

--- a/scripts/setup-project.sh
+++ b/scripts/setup-project.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Setup / re-sync the GitHub Project v2 board for HoneyLLM v0.1 → v1.0 completion.
+#
+# Idempotent: re-running after issues close or new ones land is safe (gh project item-add
+# returns the existing item id when the issue is already on the board; field sets overwrite).
+#
+# Pre-reqs:
+#   - gh auth token has scopes: project, read:project, repo
+#   - Project exists at https://github.com/users/JimmyCapps/projects/1
+#
+# Usage:
+#   bash scripts/setup-project.sh
+#
+# The board has 7 custom fields:
+#   Sprint, Status, Owner, Estimate (hrs), Tag target, DetermiLLM marker, Plan section
+# (Status is the built-in field, extended with "Partially Done", "Blocked", "Replaced".)
+#
+# When adding new issues post-launch, append rows to the SEED block at the bottom + re-run.
+#
+# bash 3.2 compatible (macOS default).
+
+set -eo pipefail
+
+OWNER="JimmyCapps"
+PROJECT_NUM=1
+PROJECT_NODE_ID='PVT_kwHOB3U2Us4BWlae'
+REPO="JimmyCapps/zentropy"
+
+# --- Field IDs (resolved via `gh project field-list 1 --owner JimmyCapps --format json`) ---
+F_SPRINT='PVTSSF_lAHOB3U2Us4BWlaezhR4Wsk'
+F_STATUS='PVTSSF_lAHOB3U2Us4BWlaezhR4Wkk'
+F_OWNER='PVTSSF_lAHOB3U2Us4BWlaezhR4Wv8'
+F_ESTIMATE='PVTF_lAHOB3U2Us4BWlaezhR4WwY'
+F_TAG='PVTSSF_lAHOB3U2Us4BWlaezhR4WxQ'
+F_DM='PVTSSF_lAHOB3U2Us4BWlaezhR4Wy8'
+F_PLAN='PVTF_lAHOB3U2Us4BWlaezhR4Wz0'
+
+# --- Single-select option IDs (case statements for bash 3.2 compat) ---
+sprint_id() {
+  case "$1" in
+    "Backlog") echo "928edf4a";;
+    "Sprint 1") echo "049ca63a";; "Sprint 2") echo "61a37eaa";; "Sprint 3") echo "8997c0f5";;
+    "Sprint 4") echo "716e4620";; "Sprint 5") echo "96cb0f18";; "Sprint 6") echo "8bd55412";;
+    "Sprint 7") echo "c5a47db6";; "Sprint 8") echo "4e5edaac";; "Sprint 9") echo "e8141f84";;
+    "Sprint 10") echo "62185958";; "Sprint 11") echo "cb96196d";; "Sprint 12") echo "f6f3d521";;
+    *) echo "ERROR: unknown sprint: $1" >&2; exit 1;;
+  esac
+}
+status_id() {
+  case "$1" in
+    "Todo") echo "6311ef11";; "In Progress") echo "49f4e629";; "Done") echo "03849d2a";;
+    "Partially Done") echo "06bc46fa";; "Blocked") echo "f832681e";; "Replaced") echo "eb002b91";;
+    *) echo "ERROR: unknown status: $1" >&2; exit 1;;
+  esac
+}
+owner_id() {
+  case "$1" in
+    "Claude") echo "7f6d66dc";; "User") echo "984afee5";; "Either") echo "4e1ce627";;
+    *) echo "ERROR: unknown owner: $1" >&2; exit 1;;
+  esac
+}
+tag_id() {
+  case "$1" in
+    "v0.2.0-internal") echo "fea2a71d";; "v0.3.0-internal") echo "54bebcaa";;
+    "v0.4.0-internal") echo "520eb20e";; "v0.5.0-internal") echo "0696d2b1";;
+    "v1.0.0") echo "7bc1e06f";; "backlog") echo "6d8d2277";;
+    *) echo "ERROR: unknown tag: $1" >&2; exit 1;;
+  esac
+}
+dm_id() {
+  case "$1" in
+    "none") echo "5732dfe5";; "DM-A") echo "ceda2793";; "DM-E") echo "53f3cc81";;
+    "DM-F") echo "81e91ee3";; "DM-G") echo "216e6f73";;
+    *) echo "ERROR: unknown DM marker: $1" >&2; exit 1;;
+  esac
+}
+
+set_field_select() {
+  local item_id="$1" field_id="$2" option_id="$3"
+  gh project item-edit --id "$item_id" --field-id "$field_id" --project-id "$PROJECT_NODE_ID" --single-select-option-id "$option_id" >/dev/null
+}
+set_field_number() {
+  local item_id="$1" field_id="$2" value="$3"
+  gh project item-edit --id "$item_id" --field-id "$field_id" --project-id "$PROJECT_NODE_ID" --number "$value" >/dev/null
+}
+set_field_text() {
+  local item_id="$1" field_id="$2" value="$3"
+  gh project item-edit --id "$item_id" --field-id "$field_id" --project-id "$PROJECT_NODE_ID" --text "$value" >/dev/null
+}
+
+process_issue() {
+  local issue="$1" sprint="$2" owner="$3" hrs="$4" tag="$5" dm="$6" plan="$7"
+  echo ">> #${issue}  Sprint=${sprint}  Owner=${owner}  Hrs=${hrs}  Tag=${tag}  DM=${dm}  Plan=${plan}"
+  local item_id
+  item_id=$(gh project item-add "$PROJECT_NUM" --owner "$OWNER" --url "https://github.com/${REPO}/issues/${issue}" --format json | jq -r '.id')
+  set_field_select "$item_id" "$F_SPRINT"   "$(sprint_id "$sprint")"
+  set_field_select "$item_id" "$F_OWNER"    "$(owner_id "$owner")"
+  set_field_select "$item_id" "$F_TAG"      "$(tag_id "$tag")"
+  set_field_select "$item_id" "$F_DM"       "$(dm_id "$dm")"
+  set_field_number "$item_id" "$F_ESTIMATE" "$hrs"
+  set_field_text   "$item_id" "$F_PLAN"     "$plan"
+  set_field_select "$item_id" "$F_STATUS"   "$(status_id "Todo")"
+}
+
+# --- SEED rows (issue|sprint|owner|hrs|tag|dm|plan_section) ---
+process_issue 220 "Sprint 1" "Claude" 0.3 "v0.2.0-internal" "none" "1.1"
+process_issue 226 "Sprint 1" "Claude" 2 "v0.2.0-internal" "none" "1.2"
+process_issue 232 "Sprint 1" "Claude" 1.5 "v0.2.0-internal" "none" "1.3"
+process_issue 217 "Sprint 1" "Claude" 3 "v0.2.0-internal" "none" "1.4"
+process_issue 157 "Sprint 1" "Claude" 1 "v0.2.0-internal" "none" "1.5"
+process_issue 14 "Sprint 1" "User" 1 "v0.2.0-internal" "none" "1.6"
+process_issue 2 "Sprint 2" "Either" 3.5 "v0.2.0-internal" "none" "2.1, 2.2, 2.9"
+process_issue 9 "Sprint 2" "Either" 3.5 "v0.2.0-internal" "none" "2.3, 2.4, 2.5"
+process_issue 124 "Sprint 2" "User" 0.5 "v0.2.0-internal" "none" "2.6"
+process_issue 129 "Sprint 2" "User" 0.5 "v0.2.0-internal" "none" "2.7"
+process_issue 8 "Sprint 2" "User" 1 "v0.2.0-internal" "none" "2.8"
+process_issue 120 "Sprint 3" "Either" 1.5 "v0.2.0-internal" "none" "3.1, 3.2"
+process_issue 128 "Sprint 3" "Claude" 2 "v0.2.0-internal" "none" "3.4"
+process_issue 244 "Sprint 4" "Claude" 2 "v0.3.0-internal" "DM-A" "4.1"
+process_issue 245 "Sprint 4" "Claude" 1.5 "v0.3.0-internal" "DM-E" "4.2"
+process_issue 246 "Sprint 4" "Claude" 1 "v0.3.0-internal" "DM-F" "4.3"
+process_issue 247 "Sprint 4" "Claude" 2 "v0.3.0-internal" "DM-G" "4.4"
+process_issue 3 "Sprint 4" "Claude" 8 "v0.3.0-internal" "none" "4.5, 5.1, 5.2, 6.1"
+process_issue 60 "Sprint 5" "Claude" 2 "v0.3.0-internal" "none" "5.3"
+process_issue 119 "Sprint 5" "Claude" 3 "v0.3.0-internal" "none" "5.4"
+process_issue 227 "Sprint 6" "Claude" 2 "v0.3.0-internal" "none" "6.2"
+process_issue 15 "Sprint 6" "Claude" 1 "v0.3.0-internal" "none" "6.3"
+process_issue 132 "Sprint 7" "Either" 8 "v0.4.0-internal" "none" "7.1, 7.2, 7.3, 7.4"
+process_issue 133 "Sprint 8" "Either" 10 "v0.4.0-internal" "none" "8.1, 8.2, 8.3, 8.4"
+process_issue 19 "Sprint 9" "Either" 9 "v0.5.0-internal" "none" "9.1, 9.2, 9.3, 9.4, 9.5"
+process_issue 4 "Sprint 10" "Either" 8.5 "v0.5.0-internal" "none" "10.1, 10.2, 10.3, 10.4, 10.5"
+process_issue 5 "Sprint 11" "Either" 17 "v1.0.0" "none" "11.1, 11.2, 11.3, 12.1, 12.2, 12.3"
+
+echo ""
+echo "Done. Project board: https://github.com/users/${OWNER}/projects/${PROJECT_NUM}"


### PR DESCRIPTION
## Summary
- 12 per-sprint kickoff files (\`docs/plans/sprints/sprint-{1..12}-*.md\`) + sprints/README.md
- Re-runnable \`scripts/setup-project.sh\` that rebuilds the GitHub Project v2 board from a seed table
- Companion (out-of-repo): \`~/.claude/commands/sprint.md\` slash command + \`~/.claude/settings.json\` SessionStart hook

## Why
Per the session-per-item discipline (memory: \`feedback_session_per_item_discipline.md\`), each work item is a single Claude session: pre-flight check → paste kickoff → validate → exit. Sprint files are the paste-ready playbooks; the master plan at \`docs/plans/v0.1-completion.md\` is the spec. Slash command \`/sprint <N.M>\` looks up the right block.

## Setup script
- bash 3.2 compatible (macOS default)
- Idempotent (gh project item-add returns existing item id when issue already on board)
- Field/option IDs hardcoded at top with comment showing the discovery command (\`gh project field-list 1 --owner JimmyCapps --format json\`)

## Test plan
- [x] Doc files render in GitHub UI
- [x] \`bash scripts/setup-project.sh\` ran cleanly (27 issues populated; verified at https://github.com/users/JimmyCapps/projects/1)
- [x] Pre-push hook (typecheck + test + build) passes
- [x] \`npm audit\` clean
- [x] AIza secret grep clean on staged paths

Closes #249
Refs #248