### PR TITLE
docs(plan-#251): link project board to repo + update references

### DIFF
--- a/docs/plans/sprints/README.md
+++ b/docs/plans/sprints/README.md
@@ -4,6 +4,8 @@ Sequential 3-day sprints to ship the v0.1 → v1.0 completion plan. Each file is
 
 Source-of-truth spec: [`../v0.1-completion.md`](../v0.1-completion.md). The plan doc holds the architecture / dependencies / scope-cut rules; the sprint files hold the paste-ready commands.
 
+**Project board:** <https://github.com/JimmyCapps/zentropy/projects> · **Epic tracking:** [#248](https://github.com/JimmyCapps/zentropy/issues/248).
+
 ## How to run a work item
 
 The discipline is **one Claude session per work item**, regardless of model / effort / thinking choices (memory rule: `feedback_session_per_item_discipline.md`). Compression and context degradation hit every model past a threshold; fresh sessions per item keep cache warm and avoid debugging-by-degradation.

--- a/docs/plans/sprints/sprint-1-stability.md
+++ b/docs/plans/sprints/sprint-1-stability.md
@@ -3,7 +3,7 @@
 **Theme:** Bug fixes + observability primary. **Tag at end:** none. **Recommended model:** `claude-haiku-4-5-20251001`, effort medium.
 
 Master plan section: [`../v0.1-completion.md` Sprint 1](../v0.1-completion.md#sprint-1-days-13-stability--bugs--observability).
-Tracking: epic #248. Project board: <https://github.com/users/JimmyCapps/projects/1>.
+Tracking: epic #248. Project board: <https://github.com/JimmyCapps/zentropy/projects>.
 
 ---
 

--- a/docs/plans/v0.1-completion.md
+++ b/docs/plans/v0.1-completion.md
@@ -523,7 +523,7 @@ The board is the **runtime view** of this plan. The plan doc is the **spec**. Sp
 1. User says: `Execute Sprint 1 item 1.2 (#226 logging coverage)`.
 2. Session reads this doc's Sprint 1 section.
 3. Session reads `gh issue view 226` — sees the plan-pointer comment + the existing issue body.
-4. Session checks the project board: `gh project item-list <PROJ-#> --owner JimmyCapps --format json | jq '.items[] | select(.content.number == 226)'` — confirms Sprint, Status, Owner, Tag target.
+4. Session checks the project board: `gh project item-list 1 --owner JimmyCapps --format json | jq '.items[] | select(.content.number == 226)'` — confirms Sprint, Status, Owner, Tag target.
 5. Session executes per the plan section.
 6. PR closes the issue normally. Project moves it to Done. Update the epic's spillover log only if there was scope drift or spillover.
 


### PR DESCRIPTION
## Summary
- Update plan doc + sprints/README + sprint-1 to surface https://github.com/JimmyCapps/zentropy/projects as the primary project URL
- Project board was just made public + linked to the repo (so it now appears in the repo Projects tab)

Closes #251
Refs #248