### PR TITLE
docs(sprints-#253): add launch flags to sprint files

### DIFF
--- a/docs/plans/sprints/README.md
+++ b/docs/plans/sprints/README.md
@@ -13,11 +13,11 @@ The discipline is **one Claude session per work item**, regardless of model / ef
 For each item:
 
 1. Read the sprint file's pre-flight checklist. Confirm or set: model, effort, plugins, MCP servers, repo state.
-2. Open Claude in repo root with the recommended model:
+2. Open Claude in repo root with the recommended model + effort + flags. The exact paste-ready command is in **each issue's plan-pointer comment** (see project board → click any issue → first comment). Generic shape:
    ```bash
-   cd /Users/node3/Documents/projects/HoneyLLM && claude --model <model>
+   cd /Users/node3/Documents/projects/HoneyLLM && claude --model <model> --effort <low|medium|high|xhigh|max> --remote-control --chrome --dangerously-skip-permissions
    ```
-   Or use the slash command (see below).
+   Effort `xhigh` and `max` enable extended thinking; there's no separate `--thinking` flag — thinking is folded into effort.
 3. Paste the item's kickoff prompt block into Claude. Wait for it to complete.
 4. Run the validation commands from the file. If they pass, exit (`Ctrl+D`). If they fail, paste the closeout prompt or escalate.
 5. Next item → next fresh session.

--- a/docs/plans/sprints/sprint-1-stability.md
+++ b/docs/plans/sprints/sprint-1-stability.md
@@ -17,7 +17,7 @@ Tracking: epic #248. Project board: <https://github.com/JimmyCapps/zentropy/proj
 
 **Start Claude in repo root:**
 ```bash
-cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-haiku-4-5-20251001
+cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-haiku-4-5-20251001 --effort medium --remote-control --chrome --dangerously-skip-permissions
 ```
 
 ---

--- a/docs/plans/sprints/sprint-10-local-chat.md
+++ b/docs/plans/sprints/sprint-10-local-chat.md
@@ -13,7 +13,7 @@ Master plan: [`../v0.1-completion.md` Sprint 10](../v0.1-completion.md#sprint-10
 - [ ] Repo state: v0.4.0-internal tag exists; BYOK shipped (Sprint 9).
 
 ```bash
-cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-sonnet-4-6
+cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-sonnet-4-6 --effort medium --remote-control --chrome --dangerously-skip-permissions
 ```
 
 ---

--- a/docs/plans/sprints/sprint-11-agentic-design.md
+++ b/docs/plans/sprints/sprint-11-agentic-design.md
@@ -13,7 +13,7 @@ Master plan: [`../v0.1-completion.md` Sprint 11](../v0.1-completion.md#sprint-11
 - [ ] Repo state: v0.5.0-internal tag exists; isolate mode (#132) on main.
 
 ```bash
-cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-opus-4-7
+cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-opus-4-7 --effort high --remote-control --chrome --dangerously-skip-permissions
 ```
 
 ---

--- a/docs/plans/sprints/sprint-12-tag-v1.md
+++ b/docs/plans/sprints/sprint-12-tag-v1.md
@@ -13,7 +13,7 @@ Master plan: [`../v0.1-completion.md` Sprint 12](../v0.1-completion.md#sprint-12
 - [ ] Repo state: Sprint 11 deliverables on main (RFC + alarms-bridge + task-store + verdict-gate).
 
 ```bash
-cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-sonnet-4-6
+cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-sonnet-4-6 --effort medium --remote-control --chrome --dangerously-skip-permissions
 ```
 
 ---

--- a/docs/plans/sprints/sprint-2-phase3-closure.md
+++ b/docs/plans/sprints/sprint-2-phase3-closure.md
@@ -15,7 +15,7 @@ Master plan: [`../v0.1-completion.md` Sprint 2](../v0.1-completion.md#sprint-2-d
 - [ ] Confirm: PR #221, #226 fix, #232 fix all on main from Sprint 1.
 
 ```bash
-cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-haiku-4-5-20251001
+cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-haiku-4-5-20251001 --effort medium --remote-control --chrome --dangerously-skip-permissions
 ```
 
 ---

--- a/docs/plans/sprints/sprint-3-tag-v0.2.md
+++ b/docs/plans/sprints/sprint-3-tag-v0.2.md
@@ -16,7 +16,7 @@ Master plan: [`../v0.1-completion.md` Sprint 3](../v0.1-completion.md#sprint-3-d
 - [ ] Repo state: `npm test` passes; all Sprint 1+2 PRs on main.
 
 ```bash
-cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-opus-4-7
+cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-opus-4-7 --effort high --remote-control --chrome --dangerously-skip-permissions
 ```
 
 ---

--- a/docs/plans/sprints/sprint-4-determillm-bridge.md
+++ b/docs/plans/sprints/sprint-4-determillm-bridge.md
@@ -15,7 +15,7 @@ Master plan: [`../v0.1-completion.md` Sprint 4](../v0.1-completion.md#sprint-4-d
 - [ ] Read [`docs/determillm/ARCHITECTURE.md`](../../determillm/ARCHITECTURE.md) before items 4.1-4.4 — that's the design contract.
 
 ```bash
-cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-haiku-4-5-20251001
+cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-haiku-4-5-20251001 --effort medium --remote-control --chrome --dangerously-skip-permissions
 ```
 
 ---

--- a/docs/plans/sprints/sprint-5-wolf-nano.md
+++ b/docs/plans/sprints/sprint-5-wolf-nano.md
@@ -13,7 +13,7 @@ Master plan: [`../v0.1-completion.md` Sprint 5](../v0.1-completion.md#sprint-5-d
 - [ ] Repo state: Wolf scaffold from Sprint 4 on main; DM-A/E/F/G all merged.
 
 ```bash
-cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-sonnet-4-6
+cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-sonnet-4-6 --effort medium --remote-control --chrome --dangerously-skip-permissions
 ```
 
 ---

--- a/docs/plans/sprints/sprint-6-tag-v0.3.md
+++ b/docs/plans/sprints/sprint-6-tag-v0.3.md
@@ -13,7 +13,7 @@ Master plan: [`../v0.1-completion.md` Sprint 6](../v0.1-completion.md#sprint-6-d
 - [ ] Repo state: Wolf stages 1-3 on main; #60 + #119 on main.
 
 ```bash
-cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-sonnet-4-6
+cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-sonnet-4-6 --effort medium --remote-control --chrome --dangerously-skip-permissions
 ```
 
 ---

--- a/docs/plans/sprints/sprint-7-isolate-mode.md
+++ b/docs/plans/sprints/sprint-7-isolate-mode.md
@@ -13,7 +13,7 @@ Master plan: [`../v0.1-completion.md` Sprint 7](../v0.1-completion.md#sprint-7-d
 - [ ] Repo state: v0.3.0-internal tag exists on main.
 
 ```bash
-cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-opus-4-7
+cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-opus-4-7 --effort high --remote-control --chrome --dangerously-skip-permissions
 ```
 
 ---

--- a/docs/plans/sprints/sprint-8-local-proxy.md
+++ b/docs/plans/sprints/sprint-8-local-proxy.md
@@ -13,7 +13,7 @@ Master plan: [`../v0.1-completion.md` Sprint 8](../v0.1-completion.md#sprint-8-d
 - [ ] Repo state: v0.3.0-internal tag exists; #132 closed.
 
 ```bash
-cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-opus-4-7
+cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-opus-4-7 --effort high --remote-control --chrome --dangerously-skip-permissions
 ```
 
 ---

--- a/docs/plans/sprints/sprint-9-byok.md
+++ b/docs/plans/sprints/sprint-9-byok.md
@@ -13,7 +13,7 @@ Master plan: [`../v0.1-completion.md` Sprint 9](../v0.1-completion.md#sprint-9-d
 - [ ] Repo state: v0.4.0-internal tag exists.
 
 ```bash
-cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-sonnet-4-6
+cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-sonnet-4-6 --effort medium --remote-control --chrome --dangerously-skip-permissions
 ```
 
 ---


### PR DESCRIPTION
## Summary
Sprint files' pre-flight launch commands now include --effort + --remote-control + --chrome + --dangerously-skip-permissions, matching each issue's plan-pointer comment paste-ready command.

Closes #253
Refs #248