### PR TITLE
docs(plan-#259): add QA pre-merge gate + universal-across-sprints rule

### DIFF
--- a/docs/plans/sprints/README.md
+++ b/docs/plans/sprints/README.md
@@ -25,9 +25,13 @@ For each item:
 ## Slash commands
 
 - **`/sprint <N.M>`** (e.g. `/sprint 1.2`) — start a planned sprint item. Reads the matching sprint file, presents kickoff prompt + validation + any human-test steps. Also handles troubleshoot items (e.g. `/sprint T1.3.1`) — same lookup, finds the appended `## Item T<N.M>.<seq>` block in the originating sprint file.
+- **`/qa <PR#>`** — pre-merge QA gate. Compares the PR diff against acceptance criteria + the sprint kickoff prompt. Auto-invoked by the building session as a Sonnet child immediately before auto-merge; returns `PASS` / `CONCERNS` / `FAIL` on stdout. PRs FAIL `/qa` if tests are tautological (e.g. `expect(true).toBe(true)`), if the byte-locked Phase 2 baseline drifts, or if acceptance criteria are missing artifacts. See [`../v0.1-completion.md` §"Pre-merge QA gate"](../v0.1-completion.md#pre-merge-qa-gate--universal-across-all-sprints) for full spec.
 - **`/troubleshoot [<N.M>]`** — investigate a problem that surfaced during manual verification of a completed item. Agnostic on framing; dialogue-driven; honors integrity rules (don't move goalposts, don't fabricate evidence, diagnosis confirmed before action). Creates a follow-up `T<N.M>.<seq>` work item only after a confirmed diagnosis and an agreed fix. See [`../v0.1-completion.md` §"Troubleshoot workflow"](../v0.1-completion.md#troubleshoot-workflow--when-manual-verification-surfaces-a-problem) for the full spec.
 
-Slash commands live in `~/.claude/commands/`.
+Slash commands live in `~/.claude/commands/`. Recommended runtime per command:
+- `/sprint <N.M>` — model varies per sprint (see each sprint file's pre-flight checklist)
+- `/qa` — Sonnet 4.6 / medium effort (cheap, fast comparison)
+- `/troubleshoot` — Opus 4.7 / high effort (reasoning-heavy synthesis)
 
 ## Sprint files
 

--- a/docs/plans/v0.1-completion.md
+++ b/docs/plans/v0.1-completion.md
@@ -483,6 +483,46 @@ When DetermiLLM phase starts, **DM-A is already a working stub Hunter** with byt
 
 ---
 
+## Pre-merge QA gate — universal across all sprints
+
+Every PR that closes a sprint item must pass `/qa <PR#>` before auto-merge fires. This catches code-vs-kickoff mismatches BEFORE merge — preventing wasted manual verification on a known-broken PR.
+
+**Slash command:** `/qa <PR#>`. Compares the PR diff against the originating issue's acceptance criteria + the sprint file's kickoff prompt + validation block. Returns `PASS` / `CONCERNS` / `FAIL` on first line of stdout.
+
+**Building session integration.** When the building session is ready to merge (CI green), it runs `/qa` as a Sonnet child via:
+
+```bash
+claude --model claude-sonnet-4-6 --effort medium -p "/qa $PR_NUM" --output-format text --dangerously-skip-permissions
+```
+
+Then captures the first word of stdout:
+- `PASS` → `gh pr merge $PR_NUM --squash --delete-branch` proceeds
+- `CONCERNS` → halt, surface findings to user, await decision (rework / override / escalate to troubleshoot)
+- `FAIL` → halt, do NOT merge, surface findings; rework expected
+
+**Why pre-merge, not post-merge.** Post-merge QA (e.g. as a CI check that fails after merge) wastes the merge action and pollutes git history with revert+re-land cycles. Pre-merge gating means broken-spec PRs never land.
+
+**Why not agentic from the beginning** (running QA continuously alongside coding). Three reasons:
+- Doubles token cost — every iteration gets reviewed mid-flight when only the final state matters
+- TDD already locks the contract pre-implementation
+- Real value of QA is comparing FINAL diff vs kickoff intent — only meaningful at the end
+
+**What the building agent must include in its kickoff loop:**
+
+> When CI passes, run `/qa <PR#>` as a Sonnet child. Capture verdict word. Auto-merge ONLY on `PASS`. On `CONCERNS` or `FAIL`, halt and present QA findings (which `/qa` posts as a PR comment). Do NOT auto-merge a `CONCERNS` PR without explicit user override.
+
+**Doc-only PR fast-path.** If all changed files are `*.md` / `*.txt` / doc-shaped JSON, `/qa` outputs `PASS` with note "doc-only; deep checks skipped". This keeps doc PRs cheap.
+
+**Token cost target:** `/qa` is ~50–100K input + ~5K output per invocation. ~27 PRs × ~80K avg = ~2.2M tokens across the plan; <5% of building-session token cost.
+
+**Manual invocation.** You can call `/qa <PR#>` from a fresh interactive session to spot-check any open or closed PR. Useful for validating earlier merges retrospectively.
+
+**Outputs on FAIL.** `/qa` posts a structured findings comment on the PR (Acceptance criteria coverage / Test fidelity / Spec match / Scope / Baseline integrity) and applies the `qa` label. The PR stays open as the tracking surface; user reads, decides next step.
+
+**Relationship to troubleshoot.** `/qa` is proactive (pre-merge); `/troubleshoot` is reactive (post-merge, after manual verification surfaces a problem QA missed or didn't have visibility into — environment, hardware, world state). They cover different failure modes; both are first-class.
+
+---
+
 ## Troubleshoot workflow — when manual verification surfaces a problem
 
 Some sprint items can only be fully validated by the user (manual smoke, browser repro, hardware-dependent test). When that validation surfaces a problem after the original session has closed, the **troubleshoot agent** picks up the thread.


### PR DESCRIPTION
## Summary
Adds the pre-merge QA gate to the v0.1 → v1.0 workflow. `/qa <PR#>` runs as a Sonnet child immediately before auto-merge; returns PASS/CONCERNS/FAIL. Catches code-vs-kickoff mismatches (vacuous tests, AC misses, baseline drift) before merge.

Companion (out-of-repo): `~/.claude/commands/qa.md` slash command + `qa` repo label (created).

## Test plan
- [x] Plan doc renders the QA section cleanly in GitHub UI
- [x] Sprints README references QA + provides recommended runtime
- [x] `/qa` slash command loaded and visible in Claude session skill list
- [x] `qa` label exists on repo
- [x] Pre-push hook + npm audit clean

Closes #259
Refs #248