### PR TITLE
fix(content-#217): mask Function.prototype.toString for wrapped fetch + XHR.open

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -30,7 +30,11 @@ interface BuildEntry {
 const entries: readonly BuildEntry[] = [
   { name: 'service-worker/index', input: 'src/service-worker/index.ts', format: 'es' },
   { name: 'content/index', input: 'src/content/index.ts', format: 'iife' },
-  { name: 'content/main-world-inject', input: 'src/content/main-world-inject.ts', format: 'iife' },
+  // Issue #217 — entry input is `main-world-inject.entry.ts` (the IIFE
+  // wrapper that calls `installNetworkGuard`). The exported module
+  // `main-world-inject.ts` itself has no top-level side effects so it can
+  // be unit-tested without patching the test runner's globals.
+  { name: 'content/main-world-inject', input: 'src/content/main-world-inject.entry.ts', format: 'iife' },
   // Issue #126 (N7a) — chat-portal observer content script. Loaded only on
   // chatgpt.com / chat.openai.com / claude.ai / gemini.google.com per the
   // manifest content_scripts entry; coexists with the <all_urls> page-scan

--- a/src/content/main-world-inject.entry.ts
+++ b/src/content/main-world-inject.entry.ts
@@ -1,0 +1,5 @@
+import { installNetworkGuard } from './main-world-inject.js';
+
+(function honeyLLMMainWorld() {
+  installNetworkGuard();
+})();

--- a/src/content/main-world-inject.test.ts
+++ b/src/content/main-world-inject.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { installNetworkGuard, type MainWorldTarget } from './main-world-inject.js';
+
+interface MockTarget {
+  fetch: typeof window.fetch;
+  XMLHttpRequest: { prototype: { open: (...args: unknown[]) => unknown } };
+  addEventListener: (type: string, listener: (event: MessageEvent) => void) => void;
+  __AI_SITE_STATUS__?: string;
+  __AI_SECURITY_REPORT__?: unknown;
+  __HONEYLLM_GUARD_ACTIVE__?: boolean;
+}
+
+const NATIVE_FETCH = 'function fetch() { [native code] }';
+const NATIVE_OPEN = 'function open() { [native code] }';
+const NATIVE_TO_STRING = 'function toString() { [native code] }';
+
+let originalToString: typeof Function.prototype.toString;
+
+function makeTarget(overrides: Partial<MockTarget> = {}): MockTarget {
+  const baseFetch = vi.fn(() => Promise.resolve(new Response('ok'))) as unknown as typeof fetch;
+  const baseOpen = vi.fn();
+  return {
+    fetch: baseFetch,
+    XMLHttpRequest: { prototype: { open: baseOpen } },
+    addEventListener: vi.fn(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  originalToString = Function.prototype.toString;
+});
+
+afterEach(() => {
+  Function.prototype.toString = originalToString;
+});
+
+describe('installNetworkGuard — toString masking (issue #217)', () => {
+  it('wrapped fetch.toString() returns native-code string', () => {
+    const target = makeTarget();
+    installNetworkGuard(target as unknown as MainWorldTarget);
+
+    expect(target.fetch.toString()).toBe(NATIVE_FETCH);
+  });
+
+  it('Function.prototype.toString.call(wrappedFetch) returns native-code string', () => {
+    const target = makeTarget();
+    installNetworkGuard(target as unknown as MainWorldTarget);
+
+    expect(Function.prototype.toString.call(target.fetch)).toBe(NATIVE_FETCH);
+  });
+
+  it('wrapped XHR.open.toString() returns native-code string', () => {
+    const target = makeTarget();
+    installNetworkGuard(target as unknown as MainWorldTarget);
+
+    const wrappedOpen = target.XMLHttpRequest.prototype.open as Function;
+    expect(wrappedOpen.toString()).toBe(NATIVE_OPEN);
+  });
+
+  it('Function.prototype.toString.call(wrappedXhrOpen) returns native-code string', () => {
+    const target = makeTarget();
+    installNetworkGuard(target as unknown as MainWorldTarget);
+
+    const wrappedOpen = target.XMLHttpRequest.prototype.open as Function;
+    expect(Function.prototype.toString.call(wrappedOpen)).toBe(NATIVE_OPEN);
+  });
+
+  it('the patched Function.prototype.toString is itself self-masking', () => {
+    const target = makeTarget();
+    installNetworkGuard(target as unknown as MainWorldTarget);
+
+    expect(Function.prototype.toString.call(Function.prototype.toString)).toBe(NATIVE_TO_STRING);
+    expect(Function.prototype.toString.toString()).toBe(NATIVE_TO_STRING);
+  });
+
+  it('non-wrapped user functions still serialize to source (no global breakage)', () => {
+    const target = makeTarget();
+    installNetworkGuard(target as unknown as MainWorldTarget);
+
+    function userFn(x: number): number {
+      return x + 1;
+    }
+    const serialized = Function.prototype.toString.call(userFn);
+    expect(serialized).toContain('return x + 1');
+    expect(serialized).not.toBe(NATIVE_FETCH);
+  });
+
+  it('an unrelated native function still serializes to native via the patched toString', () => {
+    const target = makeTarget();
+    installNetworkGuard(target as unknown as MainWorldTarget);
+
+    expect(Function.prototype.toString.call(Math.max)).toContain('[native code]');
+  });
+
+  it('preserves fetch pass-through when guard is inactive', async () => {
+    const baseFetch = vi.fn(() => Promise.resolve(new Response('passthrough'))) as unknown as typeof fetch;
+    const target = makeTarget({ fetch: baseFetch });
+    installNetworkGuard(target as unknown as MainWorldTarget);
+
+    const res = await target.fetch('https://example.com/asset.js');
+    expect(baseFetch).toHaveBeenCalledTimes(1);
+    expect(await res.text()).toBe('passthrough');
+  });
+
+  it('preserves XHR.open pass-through when guard is inactive', () => {
+    const baseOpen = vi.fn();
+    const target = makeTarget({ XMLHttpRequest: { prototype: { open: baseOpen } } });
+    installNetworkGuard(target as unknown as MainWorldTarget);
+
+    const fakeXhr = {} as { readyState?: number };
+    (target.XMLHttpRequest.prototype.open as Function).call(fakeXhr, 'GET', 'https://example.com/x');
+    expect(baseOpen).toHaveBeenCalledWith('GET', 'https://example.com/x');
+  });
+});

--- a/src/content/main-world-inject.ts
+++ b/src/content/main-world-inject.ts
@@ -10,18 +10,22 @@ declare global {
   }
 }
 
-(function honeyLLMMainWorld() {
+export type MainWorldTarget = Window & typeof globalThis;
+
+export function installNetworkGuard(
+  target: MainWorldTarget = globalThis as MainWorldTarget,
+): void {
   let guardActive = false;
 
-  const originalFetch = window.fetch;
-  const originalXhrOpen = XMLHttpRequest.prototype.open;
+  const originalFetch = target.fetch;
+  const originalXhrOpen = target.XMLHttpRequest.prototype.open;
 
   function isBlocked(url: string): boolean {
     if (!guardActive) return false;
     return BLOCKED_PATTERNS.some((p) => p.test(url));
   }
 
-  window.fetch = function guardedFetch(
+  const guardedFetch = function guardedFetch(
     input: RequestInfo | URL,
     init?: RequestInit,
   ): Promise<Response> {
@@ -32,14 +36,15 @@ declare global {
       return Promise.reject(new Error('[HoneyLLM] Request blocked by security guard'));
     }
 
-    return originalFetch.call(window, input, init);
+    return originalFetch.call(target, input, init);
   };
 
-  XMLHttpRequest.prototype.open = function guardedOpen(
+  const guardedOpen = function guardedOpen(
+    this: XMLHttpRequest,
     method: string,
     url: string | URL,
     ...args: unknown[]
-  ) {
+  ): unknown {
     const urlStr = typeof url === 'string' ? url : url.href;
 
     if (isBlocked(urlStr)) {
@@ -47,20 +52,60 @@ declare global {
       throw new Error('[HoneyLLM] Request blocked by security guard');
     }
 
-    return (originalXhrOpen as Function).call(this, method, url, ...args);
+    return (originalXhrOpen as (...a: unknown[]) => unknown).call(this, method, url, ...args);
   };
 
-  window.addEventListener('message', (event) => {
-    if (event.source !== window) return;
+  target.fetch = guardedFetch as typeof target.fetch;
+  target.XMLHttpRequest.prototype.open = guardedOpen as typeof target.XMLHttpRequest.prototype.open;
+
+  installToStringMask([
+    [guardedFetch, 'fetch'],
+    [guardedOpen, 'open'],
+  ]);
+
+  target.addEventListener('message', (event: MessageEvent) => {
+    if (event.source !== target) return;
 
     if (event.data?.type === 'HONEYLLM_ACTIVATE_GUARD') {
       guardActive = event.data.active === true;
-      window.__HONEYLLM_GUARD_ACTIVE__ = guardActive;
+      target.__HONEYLLM_GUARD_ACTIVE__ = guardActive;
     }
 
     if (event.data?.type === 'HONEYLLM_SET_STATUS') {
-      window.__AI_SITE_STATUS__ = event.data.status;
-      window.__AI_SECURITY_REPORT__ = event.data.report;
+      target.__AI_SITE_STATUS__ = event.data.status;
+      target.__AI_SECURITY_REPORT__ = event.data.report;
     }
   });
-})();
+}
+
+// Issue #217 — anti-adblock systems detect non-native fetch / XHR.open by
+// calling `Function.prototype.toString.call(window.fetch)` and checking for
+// `[native code]`. A direct `.toString` override on the function is bypassed
+// by callers that use `.call`, so we proxy `Function.prototype.toString`
+// itself: a WeakMap of wrappers returns the synthesized native string,
+// everything else falls through. Self-masked so the patched toString also
+// rounds-trips as native, otherwise a probe of toString itself unmasks the
+// patch. Without this, dynamic-DOM commerce pages (e.g. officeworks.com.au)
+// trigger an ad-rotation cascade on detection that runs the renderer RSS
+// past 5 GB inside 5 minutes idle.
+function installToStringMask(wrappers: ReadonlyArray<readonly [Function, string]>): void {
+  const FunctionProto = Function.prototype;
+  const originalToString = FunctionProto.toString;
+  const masked = new WeakMap<Function, string>();
+  for (const [fn, name] of wrappers) {
+    masked.set(fn, `function ${name}() { [native code] }`);
+  }
+
+  const proxiedToString = new Proxy(originalToString, {
+    apply(targetFn, thisArg, args): unknown {
+      if (typeof thisArg === 'function') {
+        const m = masked.get(thisArg);
+        if (m !== undefined) return m;
+      }
+      return Reflect.apply(targetFn, thisArg, args);
+    },
+  });
+  masked.set(proxiedToString, 'function toString() { [native code] }');
+
+  FunctionProto.toString = proxiedToString;
+}


### PR DESCRIPTION
## Summary

Closes #217. Sprint 1 §1.4 of the v0.1 → v1.0 plan. Refs #248.

Patches `Function.prototype.toString` so anti-adblock systems on dynamic-DOM commerce pages (officeworks.com.au homepage repro from the issue) cannot detect HoneyLLM's wrapped `fetch` and `XMLHttpRequest.prototype.open`. Without the mask, detection trips immediately and the page retaliates with an ad-rotation cascade that runs renderer RSS past 5 GB inside 5 min idle (vs. 255 MB with the extension disabled).

This addresses **Hypothesis 2** from the issue's diagnostic. Hypothesis 1 (synchronous `documentElement.outerHTML` capture forcing layout) is deferred — to be added on this branch only if the manual Officeworks idle test still shows runaway after this fix lands.

## What changed

- `src/content/main-world-inject.ts` — refactored the IIFE into a pure module that exports `installNetworkGuard(target = globalThis)`. Added `installToStringMask`: a `Function.prototype.toString` Proxy backed by a `WeakMap<Function, string>` that returns synthesized native-code strings for the wrapped fetch / XHR.open and for the patched toString itself (so probing toString does not unmask the patch). Direct `.toString` overrides on the wrappers are bypassed by `.call`, which is why the patch must live on the prototype.
- `src/content/main-world-inject.entry.ts` — new thin runtime wrapper (the IIFE that calls `installNetworkGuard()`). Build entry now points here.
- `src/content/main-world-inject.test.ts` — 9 vitest cases pinning the invariant for both `wrapped.toString()` and `Function.prototype.toString.call(wrapped)`, plus self-mask on the patched toString and pass-through on unrelated user / native functions.
- `build.ts` — bundle entry input swap to `main-world-inject.entry.ts`. Output filename `dist/content/main-world-inject.js` unchanged so `network-guard.ts` and the manifest stay untouched.

## Test plan

- [x] Unit tests: `npm test` → 1562 passed (+9 new).
- [x] Typecheck: `npm run typecheck` clean.
- [x] Build: `npm run build` produces `dist/content/main-world-inject.js` (1466 bytes minified IIFE) with the toString-mask logic inline.
- [x] Audit-trail: `npm audit` (0 vulns) + AIza-≥20 secret grep (clean).
- [ ] **Manual gate (acceptance criterion from #217):** load `dist/` unpacked in a test profile (not daily profile — leak escalates fast), open Chrome Task Manager + macOS Activity Monitor, visit `https://www.officeworks.com.au/`, idle 5 min without interacting. Renderer RSS should stay <1.5 GB. Compare against the 255 MB / 27% CPU baseline with the extension disabled on the site. Comment results on this PR + #217.

## If the manual gate fails

The manual test confirms or rules out Hypothesis 2 in isolation. If renderer still climbs, push a second commit on this branch adding the deferred-capture fix for `extractor.ts:64` (Hypothesis 1) and re-run the same idle test. If both fixes land and the leak persists, fall back to the heap-profile / known-issue paragraph path documented in the issue's acceptance criteria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)