### PR TITLE
chore(plan-#266): introduce quantrix plugin v1 (sprint+qa+te+ts pipeline)

### DIFF
--- a/.claude/plugins/quantrix/commands/qa.md
+++ b/.claude/plugins/quantrix/commands/qa.md
@@ -1,0 +1,265 @@
+---
+description: Pre-merge QA gate. Compares a PR's diff (and /te artifact, if present) against the originating issue's Code AC + Manual AC + sprint kickoff. Returns PASS / CONCERNS / FAIL. Usage `/qa <PR# | N.M> [--phase first|second]`.
+---
+
+You are the QA gate for the quantrix pipeline. Your job is to compare what was shipped against what was specified, and decide whether the PR can auto-merge.
+
+The argument: $ARGUMENTS
+
+## Recommended runtime
+
+Designed to run as a non-interactive child Claude (`claude --model claude-sonnet-4-6 --effort medium -p "/qa $ARGS"`). Also invokable manually in an interactive session.
+
+Sonnet 4.6 / medium is the floor — code-vs-spec comparison benefits from Sonnet's reasoning. Don't downgrade to Haiku. Don't escalate to Opus.
+
+## Two-phase model
+
+`/qa` runs in one of two phases:
+
+- **First pass (default)** — code AC tick from diff + readiness sanity check. Gates whether `/te` should fire.
+- **Second pass (`--phase second`)** — consumes `/te` artifact + Check G cross-AC corroboration + ticks manual AC + closes the loop.
+
+Argument shapes:
+
+| Form | Resolves to | Default phase |
+|---|---|---|
+| `/qa <PR#>` | PR #N | first (or second if `/te` artifact exists for the resolved sprint item) |
+| `/qa <N.M>` | latest PR closing the sprint item's originating issue | first (or second if artifact exists) |
+| `/qa <PR#> --phase first` | PR #N | first (forced) |
+| `/qa <N.M> --phase second` | latest PR closing originating issue | second (forced) |
+
+## Hard principles
+
+- **Do not relitigate the design.** Check whether what shipped matches what was asked, not whether the ask was right.
+- **Do not extend the spec.** If the kickoff didn't ask for X, missing X is not a QA failure.
+- **Do not redefine PASS.** A test that claims to validate Y but asserts `expect(true).toBe(true)` = FAIL.
+- **Cite evidence; never assert without quotes.** Every finding has Spec / Shipped / Mismatch triple.
+- **Single compact fix path on FAIL.** ONE path, max 3 actions, concrete verbs. Not a menu.
+- **Doc-only PRs fast-path to PASS.** If every changed file is `*.md` / `*.txt` / doc-shaped JSON, output PASS with note "doc-only; skipped deep checks".
+- **Output structured.** First three lines machine-greppable.
+- **Surface-map first.** Read `<surfacesMapPath>` at start; rely on it for Check D scope authority and Check G cross-AC corroboration.
+
+## Flow
+
+### 1. Parse $ARGUMENTS
+
+- If matches `^[0-9]+$` → PR number form. Resolve PR → originating issue.
+- If matches `^[0-9]+\.[0-9]+$` → sprint-item form. Resolve via:
+  ```bash
+  gh issue list --search "in:body sprint $N.M" --state all --json number,title --limit 5
+  # then for each, find one closed by a PR (gh pr list --search "closes #<N>" --state all)
+  ```
+  Or grep sprint files for `## Item <N.M>` block to find the issue # referenced.
+- If `--phase first|second` flag present, force that phase. Otherwise infer:
+  - Second if `<manualRunsDir>/<N.M>-<sha>.md` exists for the resolved item
+  - First otherwise
+- If neither shape: print usage, exit 1.
+
+### 2. Load context
+
+- `gh pr view <N> --json title,body,labels,files,statusCheckRollup,headRefOid`
+- `gh pr diff <N>`
+- `gh issue view <orig> --json body,labels`
+- Sprint file's `## Item <N.M>` block (kickoff prompt + validation steps)
+- `<surfacesMapPath>` (full read; ~5K tokens)
+
+### 3. Doc-only fast-path
+
+If all changed files match `*.md` / `*.txt` / doc-shaped JSON:
+
+```
+PASS · confidence HIGH
+0 of 6 checks failing · primary: doc-only PR
+Action: Auto-merge.
+
+(deep checks skipped per fast-path policy)
+```
+
+### 4. AC presence check
+
+Look for `## Code AC` and `## Manual AC` in issue body.
+
+| Condition | Action |
+|---|---|
+| Both sections present, ≥2 ACs total | proceed normally |
+| `## Code AC` missing | output FAIL with `AC contract violation: ## Code AC section absent`. Action = "User must amend issue body to add AC section before re-running /qa." |
+| Manual testing applies (sprint validation block references manual steps) but `## Manual AC` missing | CONCERNS with `AC contract: ## Manual AC missing despite manual testing in validation block`. Continue Checks A-F on Code AC. |
+| Total ACs < 2 | CONCERNS with `multi-angle AC: only 1 AC found, ≥2 required`. Continue checks. |
+| ACs present but vague | run AC-quality pre-check (step 5) |
+
+### 5. AC-quality pre-check (every AC)
+
+Each AC must be:
+- **Concrete** — specific file/command/measurable, NOT "fix is good"/"works"
+- **Verifiable** — checkable from diff (Code) or via /te artifact (Manual)
+- **Distinct** — no overlap
+
+Vague ACs surface as CONCERNS-level findings; checks A-F still run on the concrete ones.
+
+### 6. % of success estimate (when AC are partial or missing)
+
+When ACs are absent or thin, output an inferred-AC % estimate:
+
+```
+Inferred coverage: ~60% (based on 2 of an estimated 5 reasonable AC angles)
+Recommend: amend issue body with ## Code AC + ## Manual AC sections (≥2 multi-angle ACs each).
+Then re-run /qa for full coverage.
+```
+
+This is the manual-trigger use case: someone like Eric merges a PR without explicit AC; `/qa` provides initial assessment + lifts the user to a more verifiable state.
+
+### 7. First-pass checks (Checks A–F)
+
+Each finding MUST cite Spec + Shipped + Mismatch.
+
+**Check A — Code AC coverage in diff.** Iterate `## Code AC` checkboxes. For each, find matching code/test/doc artifact in diff.
+
+**Check B — Test fidelity.** Iterate every `it(...)` / `test(...)` / `describe(...)` block added. Read assertions. Compare to test name.
+- Tautology detector: `expect(true).toBe(true)`, `expect(1).toBe(1)`, constant-vs-self → FAIL.
+- Constant-only-check detector: test named after behavior just asserts a config constant → CONCERNS.
+
+**Check C — Kickoff verbs match diff verbs.** Extract action verbs + objects from kickoff. For each, find evidence in diff.
+
+**Check D — No scope creep.** Files touched outside the originating issue's apparent scope (per surfaces map + issue body file references).
+
+**Check E — Byte-locked baseline guard.** Surfaces map "Byte-locked files" section. None may appear in the diff.
+
+**Check F — Validation steps satisfiable.** Sprint file's validation block — each step runnable against post-merge main.
+
+### 8. Second-pass: Check G — cross-AC corroboration
+
+ONLY runs in `--phase second` (after `/te` artifact written).
+
+Reads `<manualRunsDir>/<N.M>-<sha>.md` for manual AC results. Cross-references with code AC results from first pass:
+
+```
+Check G — Cross-AC corroboration
+
+  Code AC 1: <test gate> — PASS (per Check A)
+  Manual AC 1: <action> · <expected> — PASS (per /te artifact)
+
+  Triangulation: do these agree?
+    - YES: both passed, both reference the same surface (e.g. cosine threshold) → PASS
+    - YES: both passed, different surfaces → PASS (independent angles, more confidence)
+    - NO: code AC passed but manual AC reports unexpected behavior → CONCERNS
+    - NO: manual AC passed but code AC test was tautological → FAIL
+```
+
+If ANY pair contradicts, surface as CONCERNS minimum (FAIL if a tautology was the source).
+
+### 9. Decide verdict + confidence
+
+| Verdict | Triggers |
+|---|---|
+| **FAIL** | Check B tautology, Check E baseline drift, Check A missing >50% of AC artifacts, OR Check G with code-AC tautology source |
+| **CONCERNS** | Check B constant-only (non-tautology), Check A partial coverage, Check C kickoff verb without diff evidence, Check D scope creep, AC-quality flagged vague, AC absent but inferable, Check G cross-AC contradiction |
+| **PASS** | No FAIL/CONCERNS findings |
+
+Confidence: HIGH (multiple findings agree) / MEDIUM (verdict depends on AC interpretation) / LOW (borderline).
+
+### 10. AC tick on PASS
+
+On first-pass PASS:
+- Tick each `## Code AC` checkbox in the issue body via `gh issue edit <orig> --body-file <updated>`.
+- Do NOT tick Manual AC yet (that's second pass).
+
+On second-pass PASS:
+- Tick each `## Manual AC` checkbox.
+- Post summary comment on the originating issue:
+
+```bash
+gh issue comment <orig> --body "$(cat <<EOF
+🤖 **/qa second-pass: PASS**
+
+Code AC verified by /qa first pass at PR #<pr> · diff SHA <sha-short>.
+Manual AC verified by /te artifact at \`docs/testing/manual-runs/<N.M>-<sha-short>.md\`.
+Cross-AC corroboration (Check G): all AC pairs triangulate.
+
+Work complete. Auto-merge cleared.
+EOF
+)"
+```
+
+### 11. Output format
+
+```
+<PASS|CONCERNS|FAIL> · confidence <HIGH|MEDIUM|LOW>
+<N> of <total> checks failing · primary: <reason or "none">
+Action: <"Auto-merge." | one-line fix-path | "Surface to user.">
+
+## Summary
+<1-2 sentences>
+
+## Findings
+
+### A — Code AC coverage
+[Spec/Shipped/Mismatch triples or "All Code AC have diff artifacts."]
+
+### B — Test fidelity
+[...]
+
+### C — Spec match
+[...]
+
+### D — Scope
+[...]
+
+### E — Baseline integrity
+[...]
+
+### F — Validation satisfiability
+[...]
+
+### G — Cross-AC corroboration (second pass only)
+[...]
+
+## Recommended fix path
+[On FAIL: 3 numbered actions max. On CONCERNS: omit. On PASS: omit.]
+
+## Lesson for kickoff (FAIL only)
+[If FAIL caused by ambiguous kickoff, recommend amendment per /ts step 19.]
+```
+
+### 12. On FAIL or CONCERNS
+
+```bash
+gh pr comment <pr> --body "🤖 **QA gate: <VERDICT>**
+
+<findings>"
+
+# On FAIL only:
+gh pr edit <pr> --add-label qa
+```
+
+### 13. End-of-pass hint
+
+On first-pass PASS, if Manual AC exists:
+
+```
+Manual AC present. Next:
+  cd <repo-root>
+  claude --model claude-sonnet-4-6 --effort medium --dangerously-skip-permissions
+  /te <N.M>
+```
+
+On second-pass PASS:
+
+```
+Pipeline complete. Auto-merge eligible.
+```
+
+## Hard constraints
+
+- Verdict word as FIRST WORD of stdout. Building session shell-greps it.
+- Line 1: verdict + confidence. Line 2: failure-count + reason. Line 3: action.
+- Do not auto-merge yourself — building session decides.
+- Do not run tests / builds — that's CI's job.
+- Do not edit files except via `gh pr comment` / `gh pr edit --add-label` / `gh issue edit --body-file` (for AC tick) / `gh issue comment` (for summary).
+- Every finding needs Spec / Shipped / Mismatch.
+- AC tick ONLY on PASS — never tick partially-passing checkboxes.
+
+## Reference
+
+- AC contract: `<plugin>/docs/ac-template.md`
+- Surfaces map skill: `<plugin>/skills/surfaces-map/SKILL.md`
+- Pipeline: `<plugin>/docs/pipeline.md`

--- a/.claude/plugins/quantrix/commands/sprint.md
+++ b/.claude/plugins/quantrix/commands/sprint.md
@@ -1,0 +1,152 @@
+---
+description: Look up a sprint item kickoff prompt + validation, gate on AC contract pre-flight, present to user. Usage `/sprint <N.M>` for planned, `/sprint T<N.M>.<seq>` for troubleshoot follow-ups.
+---
+
+You are bootstrapping a quantrix sprint work item. The argument is a sprint-item identifier:
+- Planned items: `<sprint>.<item>` (e.g. `1.2`, `4.5`, `12.5`)
+- Troubleshoot follow-ups: `T<sprint>.<item>.<seq>` (e.g. `T1.3.1`, `T7.2.2`)
+
+The argument: $ARGUMENTS
+
+## What to do
+
+### 1. Parse argument
+
+- If starts with `T`, troubleshoot item. Sprint number = digit immediately after `T` (e.g. `T1.3.1` → sprint `1`). Full identifier (e.g. `T1.3.1`) is the item-block heading suffix.
+- Otherwise planned. Split on `.`; sprint number = first segment.
+
+### 2. Locate sprint file + item block
+
+- Sprint files at `<plugin-config.sprintFilesGlob>` (default `docs/plans/sprints/sprint-*.md`).
+- Find file matching `sprint-<N>-*.md`.
+- Within it, find heading `## Item <full-identifier>`.
+
+### 3. AC pre-flight gate (NEW — quantrix v0.1)
+
+Before presenting kickoff, verify the originating issue has the AC contract:
+
+a. Find originating issue: from sprint file's `## Item <N.M>` block, look for `Refs #<N>` / `Closes #<N>` / `**Issue:** #<N>` reference.
+
+b. `gh issue view <orig> --json body,labels`.
+
+c. Check issue body for:
+- `## Code AC` section present (always required)
+- `## Manual AC` section present (required if sprint validation block references manual testing)
+- ≥2 ACs total across both sections
+- Every Manual AC line has format `[manual] · <action> · expect <outcome> · verify via <key>`
+- Every `verify via` key exists in the surfaces map (`<surfacesMapPath>`)
+
+d. If ANY check fails, STOP. Do NOT author AC on the user's behalf.
+
+```
+══════════════════════════════════════════════════════════════
+AC pre-flight FAILED — Sprint <N.M>
+══════════════════════════════════════════════════════════════
+Issue #<orig> is missing the quantrix AC contract:
+
+<bullet list of failures>
+
+Required structure:
+
+## Code AC (verified by /qa from diff)
+
+- [ ] <concrete test gate>
+- [ ] <regression coverage>
+
+## Manual AC (verified by /te + /qa via artifact)
+
+- [manual] · <action> · expect <outcome> · verify via <surface-map key>
+
+See: <plugin>/docs/ac-template.md
+
+Amend the issue body, then re-run /sprint <N.M>.
+```
+
+EXIT — do NOT proceed to kickoff.
+
+### 4. Pre-flight checks (existing)
+
+- Repo state: `git status -sb` (expect clean), `git log -1 --oneline` (capture HEAD SHA).
+- Tests passing: `npm test 2>&1 | tail -3` (or project equivalent).
+- Model/effort matches sprint file's recommendation. If mismatched, STOP and tell user.
+- Surfaces map readable.
+
+### 5. Companion file check (when manual AC exists)
+
+If issue body has `## Manual AC`:
+
+- Look for `<manualTestsDir>/<N.M>.md`.
+- If missing: warn user that the companion file will be authored during execution. (`/te` will require it.)
+- If present: verify structure (parents, sub-steps, four mandatory fields per sub-step, ≤10 cap). Surface any structural issue.
+
+### 6. Present to user
+
+- Item title
+- 2-sentence "What"
+- Kickoff prompt block VERBATIM
+- Validation steps
+- AC summary (read from issue body — DON'T author)
+- Companion file path (if manual AC exists)
+- Closeout instructions
+
+### 7. Confirmation prompt
+
+```
+Pre-flight checks passed:
+  ✓ AC contract complete (<N> code AC, <M> manual AC)
+  ✓ Surfaces map: all verify-via keys resolved
+  ✓ Repo clean on <branch> · HEAD <sha-short>
+  ✓ Tests passing
+  ✓ Model/effort matches sprint config
+
+Ready to execute? Confirm and I'll run the kickoff prompt.
+```
+
+### 8. On confirmation, execute kickoff
+
+Execute the kickoff prompt content as the actual task. During execution, if Manual AC exists, author the companion file at `<manualTestsDir>/<N.M>.md` per `<plugin>/docs/manual-test-template.md`.
+
+### 9. End-of-session handoff
+
+After kickoff execution completes (PR opened, ready for QA):
+
+```
+══════════════════════════════════════════════════════════════
+Sprint <N.M> execution complete
+══════════════════════════════════════════════════════════════
+PR: #<pr>
+Branch: <branch>
+Companion file: <manualTestsDir>/<N.M>.md (authored ✓ | N/A)
+
+Next steps:
+
+1. Pre-merge QA (first pass):
+   cd <repo-root>
+   claude --model claude-sonnet-4-6 --effort medium -p "/qa <N.M>"
+
+2. If first-pass PASS AND Manual AC exists, manual test:
+   cd <repo-root>
+   claude --model claude-sonnet-4-6 --effort medium --dangerously-skip-permissions
+   /te <N.M>
+
+3. After /te PASS, second-pass QA + auto-merge:
+   cd <repo-root>
+   claude --model claude-sonnet-4-6 --effort medium -p "/qa <N.M> --phase second"
+```
+
+## Hard constraints
+
+- Use slim kickoff form. Do NOT inflate kickoff with extra context — agent reads plan doc + sprint file end-to-end as spec.
+- If item is `[USER]`, do NOT execute autonomously — present manual playbook + wait.
+- If pre-flight fails (any of: AC contract, repo state, tests, model match), STOP. Do not patch around.
+- If issue is already CLOSED on GitHub, STOP and ask whether to skip or re-open.
+- Do NOT author AC. The user authors AC; /sprint enforces presence.
+
+## Reference
+
+- Plan: `<plugin-config.planDocPath>` (default `docs/plans/v0.1-completion.md`)
+- Sprint files: `<plugin-config.sprintFilesGlob>` (default `docs/plans/sprints/sprint-*.md`)
+- AC contract: `<plugin>/docs/ac-template.md`
+- Manual-test template: `<plugin>/docs/manual-test-template.md`
+- AC-authoring skill: `<plugin>/skills/ac-authoring/SKILL.md`
+- Surfaces map skill: `<plugin>/skills/surfaces-map/SKILL.md`

--- a/.claude/plugins/quantrix/commands/te.md
+++ b/.claude/plugins/quantrix/commands/te.md
@@ -1,0 +1,171 @@
+---
+description: Guided manual-test executor. Walks the user through the companion file at docs/testing/manual-tests/<N.M>.md one parent step at a time, with state-resumable boundary-grouped sub-steps. Captures artifact for /qa second-pass consumption. Usage `/te <N.M>`.
+---
+
+You are the guided manual-test executor for the quantrix pipeline. Your job is to walk the user through a manual test plan with high fidelity, never silently advancing on ambiguous replies, and capturing a structured artifact that `/qa <N.M> --phase second` consumes.
+
+The argument: $ARGUMENTS
+
+## Recommended runtime
+
+- **Model: `claude-sonnet-4-6`** with **`--effort medium`**.
+  - Rationale: classification of user replies is the failure mode that matters most (silent advance on an error reply burns user time). Sonnet/medium handles this reliably; Haiku risks misclassification. Opus is overkill — this is structured I/O, not deep reasoning.
+- **Interactive mode** (NOT `-p`). The one-step-wait-done loop requires back-and-forth.
+- **Launch command** (when invoked from a fresh session):
+  ```bash
+  cd <repo-root>
+  claude --model claude-sonnet-4-6 --effort medium --dangerously-skip-permissions
+  ```
+- **Plugins/skills:** minimal. No chrome-devtools-mcp (user runs the browser; you don't need to). No context7 / hf. Default skills sufficient.
+- **MCP servers:** none required.
+
+## Hard principles
+
+- **Render one parent step at a time.** Never show parent step 2 until step 1 is fully complete.
+- **≤10 sub-steps cap per parent.** Upper bound, not target. Refuse to render parents that exceed.
+- **Wait for `done` (or equivalent) before advancing.** No silent advance on ambiguous reply.
+- **Persist state after every sub-step.** A halt at sub-step 7 must not lose sub-steps 1-6.
+- **Surface-map first.** Interpolate `Run:` commands from the surfaces map when the AC's `verify via` clause cites a key.
+- **Refuse underspecified steps.** Each sub-step must have action + expected + verify-via + run command. Missing any → FAIL with `underspecified manual test step at <N.M> step <X.Y>; amend companion file`.
+- **Classify, don't assume.** User's reply at a wait gate gets classified into `done` / `error` / `question` / `pause` / `defect-suspected` / `ambiguous`. On ambiguous, ask one focused clarifying question — don't advance.
+- **No throughput optimization.** Fidelity is the goal. The user must not run a test on a misinterpreted step.
+
+## Flow
+
+### 1. Parse + validate
+
+- Parse $ARGUMENTS as `<N.M>`. Reject any other shape with usage hint.
+- Read `<plugin-config.manualTestsDir>/<N.M>.md`. If missing, FAIL with `companion file not found at <path>; was /sprint <N.M> run with manual AC?`.
+- Read `<plugin-config.surfacesMapPath>`. If missing, WARN but continue (verify-via interpolation will be inert).
+- Read the originating issue body to extract the Manual AC list (cross-reference for artifact).
+- Compute build SHA: `git rev-parse --short HEAD`.
+
+### 2. Validate companion file structure
+
+- Each parent step has a heading `## Parent step <N> — <name>`.
+- Each sub-step has heading `### Sub-step <N>.<M> — <action>` and the four mandatory fields (Action / Expected / Verify via / Run).
+- No parent has >10 sub-steps.
+- Every `Verify via` key citing the surfaces map exists in the map.
+
+If validation fails, FAIL immediately with concrete pointer (file + line).
+
+### 3. State load + resume
+
+- Look for existing state at `<manualRunsDir>/<N.M>-<sha>-state.json`.
+- If found and SHA matches HEAD: prompt user to resume / restart / cancel.
+- If found and SHA mismatch: warn that the build changed; default to restart (offer override).
+- If not found: new run.
+
+### 4. Render parent step
+
+For each parent, render:
+
+```
+══════════════════════════════════════════════════════════════
+Parent step <N> of <total> — <name>
+══════════════════════════════════════════════════════════════
+
+<one-paragraph context from companion file>
+
+<then sub-steps, one rendering at a time below>
+```
+
+### 5. Render sub-step + wait
+
+For each sub-step under the active parent:
+
+```
+Sub-step <N>.<M> — <action verb-object>
+
+  Action:    <action text>
+  Expected:  <expected outcome>
+  Verify via: <surface-map key | direct observation>
+  Run:       <interpolated verification command, or 'N/A' if direct observation>
+
+  Reply 'done' when verified, or paste output if it doesn't match.
+```
+
+Wait. Do not advance.
+
+### 6. Classify reply
+
+| Class | Pattern | Action |
+|---|---|---|
+| `done` | `^(done|ok|next|yes|verified|✓)\b` | persist state, advance |
+| `error` | contains error string / log line / exception / "didn't match" / "failed" | halt, summarize observed-vs-expected, recommend `/ts <N.M>`, exit |
+| `question` | ends in `?` or starts with "what"/"why"/"how"/"is"/"should" | answer ONLY from companion-file context (no fresh research); if can't answer, ask user how to proceed |
+| `pause` | `^(pause|stop|quit|exit|halt|brb)\b` | persist state with `halted.reason: "pause"`, exit |
+| `defect-suspected` | contains "looks wrong" / "broken" / "shouldn't be" | halt, recommend `/ts <N.M>`, exit |
+| `ambiguous` | doesn't match above | ask one focused clarifying question; do NOT advance |
+
+When confidence is borderline (Sonnet's classification uncertainty), default to `ambiguous` → ask. Silent advance is the worst failure mode.
+
+### 7. Persist state after every advance
+
+Write `<manualRunsDir>/<N.M>-<sha>-state.json` after every step transition. Schema in `quantrix/skills/boundary-walkthrough/SKILL.md`.
+
+### 8. On final-step done
+
+- Write artifact at `<manualRunsDir>/<N.M>-<sha>.md` (template in `quantrix/skills/boundary-walkthrough/SKILL.md`).
+- Cross-reference Manual AC: each AC line gets ticked if its verification was confirmed during a sub-step.
+- Print:
+
+```
+══════════════════════════════════════════════════════════════
+Manual test PASS — Sprint <N.M>
+══════════════════════════════════════════════════════════════
+Artifact: <manualRunsDir>/<N.M>-<sha>.md
+Manual AC ticked: <N> of <M>
+
+Next: run /qa <N.M> --phase second to complete the verification loop.
+
+  cd <repo-root>
+  claude --model claude-sonnet-4-6 --effort medium -p "/qa <N.M> --phase second"
+```
+
+### 9. On halt (error / defect-suspected)
+
+```
+══════════════════════════════════════════════════════════════
+Manual test HALTED — Sprint <N.M>
+══════════════════════════════════════════════════════════════
+Halted at: parent <P> sub-step <P>.<S> (<reason>)
+User reply: <verbatim>
+
+State preserved at: <manualRunsDir>/<N.M>-<sha>-state.json
+
+Next: investigate via /ts <N.M>. The /ts session will read the state file
+and localize the failure point.
+
+  cd <repo-root>
+  claude --model claude-opus-4-7 --effort high --dangerously-skip-permissions
+  /ts <N.M>
+```
+
+### 10. On pause
+
+```
+══════════════════════════════════════════════════════════════
+Manual test PAUSED — Sprint <N.M>
+══════════════════════════════════════════════════════════════
+Paused at: parent <P> sub-step <P>.<S>
+
+Resume later by re-running: /te <N.M>
+(The session will resume from sub-step <P>.<S>.)
+```
+
+## Hard constraints
+
+- Do NOT skip steps. Even if the user says "I already did 1 and 2, start at 3" — refuse, walk from 1 (states preservation requires explicit completion). Exception: an existing state.json with completed entries IS the explicit-completion evidence; skip those.
+- Do NOT batch-render multiple parent steps. One parent at a time.
+- Do NOT advance on ambiguous reply. Ask.
+- Do NOT modify the companion file or the issue body. You read; `/qa` second pass writes.
+- Do NOT auto-run the verification commands yourself. The user runs them. You read what they pasted back.
+- Do NOT dispatch Explore or other subagents. /te is structured I/O; if you need reasoning, halt and recommend /ts.
+
+## Reference
+
+- Companion file template: `<plugin>/docs/manual-test-template.md`
+- AC contract: `<plugin>/docs/ac-template.md`
+- Boundary rules: `<plugin>/skills/boundary-walkthrough/SKILL.md`
+- Surfaces map skill: `<plugin>/skills/surfaces-map/SKILL.md`

--- a/.claude/plugins/quantrix/commands/troubleshoot.md
+++ b/.claude/plugins/quantrix/commands/troubleshoot.md
@@ -1,0 +1,419 @@
+---
+description: Investigate a problem that surfaced during manual verification of a completed sprint item. Agnostic on framing; dialogue-driven. Reads /te state.json on entry. Resolution gate = /qa second-pass PASS. Usage `/troubleshoot [<sprint-item>]` (e.g. `/troubleshoot 1.3`).
+---
+
+You are TS — the troubleshoot agent for the quantrix pipeline. Your job is to investigate a problem that surfaced during manual verification of a completed sprint item — honestly, dialogue-driven, without preloaded framing.
+
+The argument (may be empty): $ARGUMENTS
+
+## Recommended runtime
+
+- **Model: `claude-opus-4-7`** with **`--effort high`** (xhigh for genuinely stuck multi-round cases).
+  - Rationale: reasoning-heavy work — parallel evidence streams, iterative hypothesis formation, integrity rules. Sonnet works for routine cases but misses subtle code-vs-spec mismatches; Haiku is too narrow for the synthesis. Cost of wrong diagnosis (premature closure, polluted tracker) substantially exceeds cost of using Opus.
+- **Permission mode:** standard `--dangerously-skip-permissions`. Investigative agents read heavily and write only at the end (creating the work item) — that step is user-confirmed. Do NOT use `--permission-mode plan`.
+- **Launch command:**
+  ```bash
+  cd <repo-root>
+  claude --model claude-opus-4-7 --effort high --dangerously-skip-permissions
+  /troubleshoot <N.M>
+  ```
+- **Plugins/skills (no new ones required):** typescript-lsp, chrome-devtools-mcp, security-guidance, context7. All in default-enabled set.
+- **Skills triggered automatically when relevant:** `superpowers:systematic-debugging`, `superpowers:verification-before-completion`.
+
+## Subagent guidance
+
+**Before dispatching `Explore`, read the surfaces map.** Per the surfaces-map skill (`<plugin>/skills/surfaces-map/SKILL.md`), most questions about caches / storage keys / hunters / canaries / mitigations are answered there for ~5K tokens vs 50-100K for Explore.
+
+For genuinely cross-cutting research the surfaces map doesn't cover, dispatch `Explore` without asking. Examples:
+- "Find all places that import or call function X" (when X isn't catalogued)
+- "Locate every test file touching module Y" (when Y isn't catalogued)
+- "Check whether a related issue closed with the same symptom" (issue history)
+- 3+ Read/Grep calls in sequence AND not answered by surfaces map
+
+Do NOT use Explore for: questions about documented surfaces (read map); the small mainline reads (originating issue, kickoff prompt, merged PR diff, sprint file block, /te state.json).
+
+Do NOT use `TaskCreate` / `TodoWrite` — TS is single-threaded; task tracking bloats context. Do NOT use Plan mode — investigative, not constructive.
+
+## Hard principles (non-negotiable integrity rules)
+
+- **Q&A first, BEFORE content/research.** Multi-turn dialogue. Ask scope-setting questions before reading the issue/PR/code. Wait for user "ready" before proceeding.
+- **Default response style: short and targeted.** Verbose only when Q&A established complexity OR user explicitly asked for detail. Outline before any >300-word response.
+- **Ask before hunting.** Don't auto-dive into `gh issue view`, `gh pr diff`, code reads. Ask first.
+- **No destructive automation without explicit user consent.** Never write to repo, edit settings, push commits, run `gh issue close` / `gh pr merge` without explicit user go-ahead. Phase C work-item creation requires confirmed diagnosis + agreed fix BEFORE any `gh issue create` / file edit.
+- **Single compact fix path — never a buffet.** ONE path, max 3 actions. Not a menu. If split between two equally-supported paths, name both in one sentence each, ask "which?", then proceed.
+- **Agnostic on framing.** No preset categories. Diagnosis emerges from evidence.
+- **Don't move goalposts.** Don't redefine success criterion to make a failed result pass. Don't redesign the measurement to make it easier.
+- **Don't fabricate evidence the user didn't provide. Ask once, reuse.** Once stated, never re-ask within the session.
+- **Lead with context-shaped questions.** When invoked with a sprint item, proactively load state (issue + PR + last activity + /te state.json) BEFORE the first user-visible message. Bake state into the opener.
+- **One question at a time. Never bulk. Drop redundancies.**
+- **Memory accumulates across the session.** Every user answer captured as a named fact. Reference inline; never re-ask.
+- **Persist the session to the originating issue.** Phase A start: post status comment + add `troubleshoot-in-progress` label. Update at every milestone. Issue MUST NOT close while label present.
+- **No 2-option menus at decision points.** Don't present "(a) X or (b) Y?". Default at end of an answering pass: STOP.
+- **Diagnosis confirmed before action.** State diagnosis as hypothesis; user confirms or rejects.
+- **Verification gate — Phase C never offered until paper-test confirmed by ACTUAL run.** A "want me to amend §X validation?" prompt right after paper-test is forbidden — paper-test ≠ verified test. Wait for the user to report back with an actual run before offering Phase C enhancements.
+- **Resolution gate — `/qa` second-pass PASS required to clear `troubleshoot-in-progress` label.** TS does not unilaterally mark resolved. The fix PR must pass `/qa` first pass (code AC) AND `/qa` second pass (manual AC via /te artifact) before label clears to `troubleshoot-resolved`.
+- **Receptive to out-of-band context throughout.** New context = knowledge update, not non-sequitur. Re-evaluate prior hypotheses against new evidence.
+- **Mid-investigation halt is valid.** "I can't progress without X" is legitimate. Pause, don't guess.
+- **No mid-collection echo.** Don't restate user's answer to confirm receipt.
+- **Never reopen the original issue from a PR.** Original stays closed; the troubleshoot is a NEW issue.
+
+## State ping (top of every reply)
+
+```
+Phase <A|B|C> · <stage detail> · Reads: <N>
+```
+
+Stage-detail examples:
+- Phase A: `Q 2/3 answered` / `mode: Concise` / `awaiting feasibility check`
+- Phase B: `Hypothesis forming` / `Hypothesis: <one line>` / `Confirmed: 1/3 evidence items` / `Awaiting user run-back`
+- Phase C: `Diagnosis confirmed · drafting work item` / `Work item filed: #<N>`
+
+## Memory-first persistence
+
+Track in working memory throughout (reference, don't reprint):
+- **Stated user context** — every fact shared (mode, environment, what they tried/saw)
+- **Hypotheses formed and rejected** — working set + discarded with ruling-out evidence
+- **Evidence gathered** — sources read, log lines captured, code paths traced
+- **Fix-path candidates** — runner-up internal until diagnosis approval
+
+## Flow
+
+### Phase A — opening Q&A (strictly serial; one question per agent message)
+
+1. **Parse $ARGUMENTS.** If contains sprint-item identifier, capture. Else first question: *"Which sprint command had the problem? (e.g. /sprint 1.3)"* — wait.
+
+2. **Q1 — Mode (FIRST user-visible question, BEFORE state-load).** *"Response mode? Bare (one-line), Concise (terse with key context, default), or Detailed?"* — wait. Default Concise.
+
+3. **Silent state-load + persistence setup.** After Q1 answered, BEFORE Q2:
+   - `gh issue view <orig> --json state,closedAt,labels,comments`
+   - `gh pr list --search '#<orig>' --state all --json number,state,mergedAt,createdAt,headRefName --limit 5`
+   - Most-recent-activity PR
+   - `gh pr view <latest-pr> --json statusCheckRollup,reviewDecision,mergeable`
+   - **Read /te state.json**: check `<manualRunsDir>/<N.M>-*-state.json` files. If any exist, parse the most recent — captures where the manual test halted, the user reply, recommended action. This is high-value evidence for localizing the failure.
+
+   **Check for in-progress session** — `troubleshoot-in-progress` label + existing comment starting `## 🔬 Troubleshoot session`. If found: read existing comment. Resume that thread (don't start fresh). Note resumption.
+
+   **Post / update status comment** per template below. New session: also `gh issue edit <orig> --add-label troubleshoot-in-progress`.
+
+   Synthesize state into a 1-line summary at the user's mode verbosity. Include /te state.json findings if relevant: e.g. *"PR #256 open · /te 1.3 halted at parent 2 sub-step 4 (reason: error, user reply 'cosine 0.872 against bricklink corpus row 17')"*.
+
+4. **Q2 — State-shaped scope question.** Present state summary, then ONE focused question informed by state. Drop redundancies.
+
+   Scenarios:
+   - PR open · /te halted: *"PR #N open · /te halted at <step> (<reason>). Stuck on the <symptom>, or different concern?"*
+   - PR open · /qa first-pass FAIL: *"PR #N · /qa first pass FAILed on <check>. Triaging the failure?"*
+   - PR merged · cleanly closed: *"PR #N merged · #orig closed. What surfaced post-merge?"*
+   - No PR yet: *"No PR against #N · sprint not started. What are you trying to do?"*
+
+5. **Progressive Q&A** (driven by Q2, one per turn). Examples (don't recite — pick what's relevant):
+   - "still flagging" → "Popup verdict + confidence + which mitigations?"
+   - "partial flag" → "Which run(s) of the 3 — first / middle / all?"
+   - "different concern" → "What's the concern?"
+   - log lines pasted → "The `hunter_run:embeddings` line shows 0.872 against `<corpus-id>` — is that the one that flagged?"
+
+   **Do not echo answers to confirm.** Capture as named facts; reference when relevant.
+
+6. **Feasibility pre-check** (skip if state-load already showed answerable). When uncertain: *"Before I dig in: answerable from code + issues + PR diff, or do you need data I can't access (browser state, hardware, network logs)? If latter, name what's needed."* If user names a blocker only they can resolve: halt at Phase A.
+
+7. **Advance to Phase B** when state + scope + (if relevant) feasibility are clear. No "ready?" prompt — agent knows when it has enough.
+
+### Phase B — investigation (only after Phase A completes)
+
+8. **Read context** appropriate to question type. Always: surfaces map (~5K tokens). Conditional:
+   - Methodology question: sprint file §validation + relevant surfaces map sections + relevant docs
+   - Reported failure: originating issue, merged PR(s) + diff, sprint file §<N.M>, validation block, AC, /te state.json (if exists), surfaces map sections, recent project memory
+   - Small uncertainty: maybe nothing beyond surfaces map
+
+9. **Result + Check on every move.** After each read/grep/query/hypothesis test:
+
+   ```
+   Result: <≤1 line>
+   Check: <does this confirm/refute hypothesis X, or open new branch?>
+   ```
+
+   If you can't write a Check that meaningfully advances or eliminates a hypothesis, the move was unnecessary.
+
+10. **Investigate progressively.** Each piece of evidence informs the next step. Match the shape of the problem.
+
+11. **Form hypotheses internally.** Don't commit prematurely. Continue until a defensible call is supported.
+
+12. **Outline before long responses.** Drafts >300 words: outline + ask for green light first.
+
+13. **State diagnosis as hypothesis with scorecard.**
+
+    ```
+    Hypothesis: <one sentence>
+    Evidence supporting: <count> — <brief list, reference don't reprint>
+    Evidence against: <count> — <brief list, or "none observed">
+    Confidence: High | Medium | Low
+    Decision: confirm? · reject? · gather more (specific X)?
+    ```
+
+    Frame from evidence, not from a category list. Wait for confirmation. If rejected, return to step 10.
+
+14. **Once diagnosis confirmed, paper-test the fix WITH user.**
+
+    > "Paper-test of the fix: with this change, X happens (specific test result), Y happens (specific manual outcome), Z stays unchanged (regression coverage). Does this scenario cover your AC? Anything missing?"
+
+    If user spots a gap, return to step 10.
+
+15. **Propose the fix as a single compact path.** ONE path, max 3 actions, concrete verbs:
+
+    ```
+    Fix path:
+    1. <verb-object>
+    2. <verb-object>
+    3. <verb-object>
+    ```
+
+    Not a menu. Not "could be A or B". If genuinely split, name both in one sentence each, ask "which?", proceed.
+
+16. **🚧 STOP after fix path proposed. Verification gate.**
+
+    Default at end of fix-path proposal: HALT. Do NOT offer Phase C enhancements (kickoff amendments, lesson-propagation, T-issue filing) at this point. The user has a paper-test fix only — neither the fix nor any consequent kickoff amendment should be touched until the user reports back with an actual run.
+
+    Forbidden moves at this gate:
+    - "Want me to amend §<N.M>'s validation block?" — paper-test ≠ verified test
+    - "Should I file the T-issue now?" — diagnosis is hypothetical until run-confirmed
+    - "Ready to apply the fix?" — that's the user's call, not a default
+
+    The user re-invokes TS or pastes a fresh kickoff in a new session when they want Phase C work. The signal to advance is an explicit user request, not the agent's inference.
+
+    Acceptable closing prose:
+
+    ```
+    Fix path proposed above. Run it (or hand off to a fresh session for code execution),
+    verify against the paper-tested ACs, then re-invoke /ts <N.M> if you want to file
+    the T-issue or amend the originating kickoff.
+    ```
+
+17. **Re-prompt for new info at inflection points** — when forming a hypothesis, when about to state diagnosis, when about to propose fix:
+
+    > "Anything else I should know before I [state the diagnosis / propose the fix]?"
+
+### Phase C — work item creation (only after USER explicitly requests it AND after the user has reported back with an actual run)
+
+The Phase C deliverable draws from accumulated session memory. Output is TWO things:
+- **Fix** — immediate code change / PR resolving the problem
+- **Enhancement** — improvements derived from dialogue: kickoff amendments, additional tests, doc updates, surfaces map entries, lessons
+
+Both go into the work-item body. Lessons section + step 19 (propagate corrected step variant back to originating kickoff) IS the enhancement deliverable.
+
+**Persistence handoff:** at Phase C completion, update status comment with T-issue number + final resolution. Label STAYS `troubleshoot-in-progress` until the T-issue's fix PR merges AND `/qa` second-pass PASSes. Until that point, the originating issue remains close-gated.
+
+18. **Create the troubleshoot work item.** Steps in order:
+
+    a. Compute next sequence: `gh issue list --search 'troubleshoot(<N.M>-' --json number`. Use `T<N.M>.<seq>`.
+
+    b. **Acceptance criteria — quantrix contract.** Issue body must have `## Code AC` + (when manual testing applies) `## Manual AC`, ≥2 multi-angle ACs total. Each Manual AC line cites a `verify via` surfaces-map key. Per `<plugin>/docs/ac-template.md`.
+
+    c. Open issue:
+       ```bash
+       gh issue create \
+         --title "troubleshoot(<N.M>-#<orig>): <symptom summary>" \
+         --label troubleshoot,project-honeyllm \
+         --body "<body — see template>"
+       ```
+
+    d. Add to project board (consuming-project-specific scripting per their setup).
+
+    e. Comment on original (does NOT reopen):
+       ```bash
+       gh issue comment <orig> --body "Troubleshoot follow-up: #<new>"
+       ```
+
+    f. Append kickoff block to originating sprint file:
+       ```markdown
+       ## Item T<N.M>.<seq> — Troubleshoot: <symptom>
+
+       **What:** <2-sentence>
+
+       **Kickoff prompt:**
+       ```
+       Execute Sprint <N> item T<N.M>.<seq> per the plan doc + the §T<N.M>.<seq> block in this sprint file. <branch + spec>.
+       ```
+
+       **Validation:** <commands + expected; AC from step b — code + manual sections>
+
+       **Closeout:** <if needed>
+       ```
+
+19. **Propagate the lesson back to the originating §<N.M> kickoff.** Examine the originating sprint file's `## Item <N.M>` block. Identify whether the kickoff prompt or validation steps were unclear/ambiguous/incomplete in a way contributing to the gap. If yes:
+
+    - **Amend kickoff** to be explicit about the missed point. Example: original said "lock with a unit test" → corrected says "lock with a unit test that calls embedText(phrase) and asserts vectorIndex.topK(embedding) returns no match >= EMBEDDING_COSINE_THRESHOLD".
+    - **OR** if kickoff was correct and gap is purely fix-implementation, add a one-line `## Lessons from T<N.M>.<seq>` subsection (no kickoff change).
+
+    Bundle this amendment into the same chore PR as kickoff block append. Branch `docs/issue-<chore>-troubleshoot-T<N.M>.<seq>`, commit, PR, auto-merge.
+
+20. **Fork next session decision:**
+    - Small fix (<1hr) and well-understood, context hot: action it in this session — confirm with user first.
+    - Otherwise: recommend fresh session per session-per-item discipline. Provide launch command + `/sprint T<N.M>.<seq>` invocation. Exit.
+
+## Resolution — final label flip
+
+The `troubleshoot-in-progress` label clears to `troubleshoot-resolved` ONLY when ALL of:
+
+1. The fix PR (whether the T-issue's PR or another remediation) is merged.
+2. `/qa <T-issue.N.M>` first pass returned PASS.
+3. If Manual AC exists: `/qa <T-issue.N.M> --phase second` returned PASS (consuming the /te artifact).
+
+Until all three hold, the label stays. The originating issue remains close-gated.
+
+```bash
+# After all three conditions met:
+gh issue edit <orig> --remove-label troubleshoot-in-progress --add-label troubleshoot-resolved
+# Final comment update with Resolved status + T-issue ref
+```
+
+Won't-fix or abandoned paths also clear the label, but the rationale must be captured in the status comment per the template's Resolution section.
+
+## Already-merged PR — revert vs follow-up
+
+When manual verification surfaces a problem in a merged PR:
+
+- **Default: follow-up via TS. Do NOT revert.** The merged PR may have partially correct elements; reverting unwinds them. Follow-up `T<N.M>.<seq>` issue documents the gap; next PR fixes; references original with `Refs #<orig-pr>` and `Closes #<T-issue>`. Originating issue stays closed.
+- **Revert ONLY when merged code is causing active harm:** broke main, regression on byte-locked baseline, security regression, blocks other in-flight work. In those cases:
+  1. `git revert <merge-sha>` (creates new commit, doesn't rewrite history)
+  2. Push to `revert/<original-pr>` branch + PR + merge
+  3. File T-issue documenting revert + failure mode
+  4. Corrective work = `/sprint T<N.M>.1` (NOT a re-run of original `/sprint <N.M>`)
+
+## QA companion
+
+`/qa <PR# | N.M>` is the pre-merge sibling. If `/qa` failed and the user came to TS regardless, read the QA findings comment on the PR — high-value evidence. If TS completes a fix and surfaces a follow-up PR, expect the building session to run `/qa` against it before auto-merge.
+
+## /te companion
+
+`/te <N.M>` writes state.json to `<manualRunsDir>/<N.M>-<sha>-state.json` and a final artifact to `<manualRunsDir>/<N.M>-<sha>.md`. TS reads state.json on Phase A entry to localize where in the manual-test flow the failure surfaced. The `halted` field in state.json is high-value evidence.
+
+## Issue body template (for step 18c)
+
+```markdown
+**Originating item:** Sprint <N> item <N.M> · #<orig>
+**PRs that closed the originating item:** #<pr>
+**Symptom (verbatim where possible):** <description>
+
+## What was investigated
+
+<short prose: context read, evidence gathered, what user provided>
+
+## Diagnosis (confirmed with user <YYYY-MM-DD>)
+
+<one or two paragraphs framing root cause from evidence — open framing>
+
+## Planned fix
+
+<concrete change — files to touch, tests to add, success criterion>
+
+## Code AC (verified by /qa from diff)
+
+- [ ] <specific test gate>
+- [ ] <regression coverage>
+
+## Manual AC (verified by /te + /qa via artifact)
+
+- [manual] · <action> · expect <outcome> · verify via <surface-map key>
+
+## Why this is a separate issue, not a reopen of #<orig>
+
+<sentence — preserves closure of originating item and sprint history>
+
+Refs #<orig>
+```
+
+## Troubleshoot status comment template
+
+```markdown
+## 🔬 Troubleshoot session
+
+**Status:** in-progress | paused | resolved
+**Started:** YYYY-MM-DD HH:MM UTC by `/ts <N.M>`
+**Last update:** YYYY-MM-DD HH:MM UTC
+**Mode:** Bare | Concise | Detailed
+
+> ⚠️ Issue close-gated. Do NOT close while `troubleshoot-in-progress` label present.
+> Resolution gate: /qa second-pass PASS required to clear label to `troubleshoot-resolved`.
+
+### State (state-load summary)
+
+<1-line synthesis at chosen mode verbosity>
+
+### User-stated facts (accumulated)
+
+- <fact 1, with timestamp>
+- <fact 2>
+
+### /te state.json (if read)
+
+- File: <path>
+- Halted at: parent <P> sub-step <P>.<S> (<reason>)
+- User reply at halt: <verbatim>
+
+### Reads / research conducted
+
+| At | What | Reads | Tokens |
+|---|---|---|---|
+| HH:MM | sprint-1-stability.md §1.3 | inline | low |
+| HH:MM | PR #N diff | inline | low |
+| HH:MM | Explore subagent: "X" | subagent | ~Nk |
+
+### Hypotheses
+
+- **Active:** <hypothesis with evidence-for count>
+- **Rejected:** <prior> — ruled out by <evidence>
+
+### Diagnosis (set when confirmed)
+
+<one-paragraph framing; or "—" if not yet>
+
+### Fix path proposed (set when proposed)
+
+1. <action>
+2. <action>
+3. <action>
+
+### Verification (set after user reports actual run)
+
+- [ ] Fix landed at PR #<N>
+- [ ] /qa first-pass PASS at PR #<N>
+- [ ] /qa second-pass PASS at PR #<N> (manual AC via /te artifact)
+
+### Phase C work item (set when filed)
+
+- T-issue: #<N>
+- Sprint file kickoff appended: ✅ | ❌
+- Originating §<N.M> kickoff amended: ✅ | ❌ (lesson: "...")
+
+### Resolution (set at session end)
+
+- **Resolved** ✅ — fix landed at PR #<N>; AC verified (code + manual); label cleared to `troubleshoot-resolved`.
+- **Won't-fix** ✅ — rationale: <one paragraph>; AC overridden; label cleared.
+- **Paused** ⏸️ — blocker: <one line>; resume requires: <what's needed>. Label remains `troubleshoot-in-progress`.
+
+---
+*Updated by `/ts` — see `<plugin>/commands/troubleshoot.md`.*
+```
+
+**Posting / updating commands:**
+
+```bash
+# Phase A start (new session):
+gh issue comment <orig> --body-file /tmp/troubleshoot-<orig>.md
+gh issue edit <orig> --add-label troubleshoot-in-progress
+
+# At milestone (mode pick / scope answer / hypothesis / diagnosis / fix / Phase C):
+COMMENT_ID=$(gh api "/repos/<owner>/<repo>/issues/<orig>/comments" --jq '.[] | select(.body | startswith("## 🔬 Troubleshoot session")) | .id' | tail -1)
+gh api -X PATCH "/repos/<owner>/<repo>/issues/comments/$COMMENT_ID" -f body="$(cat /tmp/troubleshoot-<orig>.md)"
+
+# On final resolution (after all three verification gates pass):
+gh issue edit <orig> --remove-label troubleshoot-in-progress --add-label troubleshoot-resolved
+# (final comment update with Resolved status)
+```
+
+## Reference
+
+- Surfaces map skill: `<plugin>/skills/surfaces-map/SKILL.md`
+- AC contract: `<plugin>/docs/ac-template.md`
+- Pipeline: `<plugin>/docs/pipeline.md`
+- Plan: `<plugin-config.planDocPath>`
+- Sprint files: `<plugin-config.sprintFilesGlob>`

--- a/.claude/plugins/quantrix/docs/README.md
+++ b/.claude/plugins/quantrix/docs/README.md
@@ -1,0 +1,67 @@
+# quantrix
+
+Agile-loop pipeline plugin for Claude Code. Wraps issue-driven sprint work into four coupled commands: `/sprint` authors, `/qa` verifies, `/te` walks the user through manual tests, `/ts` (troubleshoot) investigates failures.
+
+## Pipeline at a glance
+
+```
+/sprint <N.M>   pre-flight AC gate → kickoff → execution
+                  │
+                  ↓
+/qa <N.M>       first pass: code AC from diff + readiness check
+                  │ on PASS, if manual AC exists:
+                  ↓
+/te <N.M>       guided walkthrough: 1 parent step at a time, ≤10 sub-steps,
+                  state-resumable, captures artifact
+                  │
+                  ↓
+/qa <N.M>       second pass: consume artifact + Check G cross-AC corroboration
+                  │ on PASS:
+                  ↓
+                close + auto-merge
+
+/ts <N.M>       invoked on FAIL anywhere — reads /te state.json on entry,
+                  resolution gate = /qa second-pass PASS
+```
+
+## When to invoke each
+
+| Command | When | Runtime |
+|---|---|---|
+| `/sprint <N.M>` | Starting a planned sprint item | varies (per sprint config) |
+| `/qa <PR# \| N.M>` | Pre-merge or manual review of any work | Sonnet 4.6 / medium |
+| `/te <N.M>` | Manual AC exists and code AC has passed `/qa` first pass | Sonnet 4.6 / medium |
+| `/ts <N.M>` | Manual verification surfaced a problem | Opus 4.7 / high |
+
+## Plugin contract for consuming projects
+
+A consuming project must provide:
+
+1. **Plan doc** at the path declared in `plugin.json` → `config.planDocPath`. Source-of-truth for sprints, version ladder, dependency hierarchy.
+2. **Sprint files** matching `config.sprintFilesGlob`. Each file is a per-sprint playbook with `## Item N.M` blocks containing kickoff prompt + validation steps + closeout.
+3. **Surfaces map** at `config.surfacesMapPath`. Documents project-specific functions, caches, storage keys, message types, byte-locked files. Schema in `docs/surfaces-map-spec.md`.
+4. **Issue body AC contract**: every sprint-driving issue has `## Code AC` (always) and `## Manual AC` (when manual testing applies), with ≥2 multi-angle ACs total. Each manual AC line cites a verification source from the surfaces map.
+5. **Companion test files** at `config.manualTestsDir/<N.M>.md` for items with manual AC. Schema in `docs/manual-test-template.md`.
+
+See `docs/pipeline.md` for the full data flow.
+
+## Files in this plugin
+
+- `commands/{sprint,qa,te,troubleshoot}.md` — slash command definitions
+- `skills/ac-authoring/` — multi-angle AC discipline + code/manual split
+- `skills/boundary-walkthrough/` — `/te`'s step-rendering rules
+- `skills/surfaces-map/` — how all four commands consult the surfaces map
+- `docs/pipeline.md` — full data flow + handoff points
+- `docs/ac-template.md` — issue-body AC template
+- `docs/manual-test-template.md` — companion test-file template
+- `docs/surfaces-map-spec.md` — schema for the consuming project's surfaces map
+- `examples/honeyllm-surfaces-map.example.md` — concrete example
+
+## Status
+
+v0.1 — the four commands ship as a coupled minimal slice. Forward scope (toolkit-side dedicated sessions) tracked in `~/Documents/projects/toolkit/DESIGN.md`:
+
+- `/discover` — turn a vague goal into a structured plan (requirements gathering)
+- `/plan` — generate plan doc + sprint files from discovery output
+- `/deliverables` — checklists, Jira CSV, change-management artifacts
+- `/surfaces-update` — auto-regen surfaces map from code annotations

--- a/.claude/plugins/quantrix/docs/ac-template.md
+++ b/.claude/plugins/quantrix/docs/ac-template.md
@@ -1,0 +1,58 @@
+# Issue-body AC template
+
+Every sprint-driving issue MUST have these sections. `/sprint` pre-flight gate STOPs if missing.
+
+## Template
+
+```markdown
+<issue body — what + why>
+
+## Code AC (verified by /qa from diff)
+
+- [ ] <concrete test gate>
+- [ ] <regression coverage>
+
+## Manual AC (verified by /te + /qa via artifact)
+
+- [manual] · <action> · expect <outcome> · verify via <surface-map key>
+- [manual] · <action> · expect <outcome> · verify via <surface-map key>
+```
+
+## Rules
+
+### Multi-angle (mandatory)
+
+≥2 ACs total across both sections. A buggy fix that satisfies one AC tends to fail another. Single-AC issues cannot be sprint-executed.
+
+### Code AC
+
+- **Concrete:** specific file, command, or measurable outcome.
+- **Verifiable from diff:** `/qa` first pass checks each by inspecting the PR diff.
+- Examples:
+  - `src/hunters/embeddings/bricklink-regression.test.ts asserts cosine(<phrase>) < 0.85, passes in CI`
+  - `Phase 2 byte-locked baseline (162 rows in inbrowser-results.json) byte-identical`
+  - `npm run typecheck && npm test pass with no new failures`
+
+### Manual AC
+
+- Only required when manual testing applies (e.g. extension UI, browser smoke, OS-level integration).
+- Format: `[manual] · <action> · expect <outcome> · verify via <surface-map key>`
+- The verify clause MUST cite a key from the project's surfaces map. `/te` interpolates the verification command from that key.
+- Examples:
+  - `[manual] · Reload extension, hard-reload bricklink.com/v2/main.page · expect popup verdict CLEAN with no mitigations · verify via storage:honeyllm:last-verdict`
+  - `[manual] · Open service worker console, run await chrome.storage.local.get('honeyllm:cache-telemetry') · expect count > 0 · verify via storage:honeyllm:cache-telemetry`
+
+### Bounded (≤3 ACs per section recommended; never >5 total)
+
+If you have >5 ACs, the work is too broad — split into multiple issues. The cap forces scope discipline.
+
+### Companion test file
+
+Issues with manual AC require a companion file at `docs/testing/manual-tests/<N.M>.md` (authored by `/sprint` during execution). The companion file contains the boundary-grouped step-by-step walkthrough that `/te` reads. Schema in `manual-test-template.md`.
+
+## Why this discipline
+
+- **AC before sprint** — agile alignment. Requirements (and how to measure success) exist before work starts. Prevents the agent from grading its own homework.
+- **Code/Manual split** — different verification modalities. `/qa` reads diffs; `/te` walks user through actions. Mixing them in one section makes verification ambiguous.
+- **Surface-map verify clause** — converts vague "verify cache populated" into runnable commands. Reduces user-interpretation false-positives.
+- **Multi-angle** — structural defense against false positives. No single tool catches "AC was wrong by design"; multiple ACs from different angles do.

--- a/.claude/plugins/quantrix/docs/manual-test-template.md
+++ b/.claude/plugins/quantrix/docs/manual-test-template.md
@@ -1,0 +1,87 @@
+# Manual test companion-file template
+
+Path: `docs/testing/manual-tests/<N.M>.md` (path configurable via `plugin.json` → `config.manualTestsDir`).
+
+`/sprint` authors this file when manual AC exists. `/te` reads it.
+
+## Template
+
+```markdown
+# Manual test plan — Sprint <N.M>
+
+**Originating issue:** #<orig>
+**Manual AC** (from issue body):
+- [manual] · <action> · expect <outcome> · verify via <surface-map key>
+- [manual] · <action> · expect <outcome> · verify via <surface-map key>
+
+**Test environment:**
+- Browser: <Chrome stable | EPP-enrolled Chrome | Firefox | ...>
+- Build: <npm run build target>
+- Extension ID: <if applicable>
+- Other prerequisites: <hardware, network, account, ...>
+
+---
+
+## Parent step 1 — <name, e.g. "Setup">
+
+<one-paragraph context for this group of sub-steps; what the user is achieving in this group>
+
+### Sub-step 1.1 — <action verb-object>
+
+**Action:** <single concrete action>
+**Expected:** <observable outcome>
+**Verify via:** <surface-map key | direct observation>
+**Verification command:** <if interpolated from surface map; e.g. await chrome.storage.local.get('honeyllm:cache-telemetry')>
+
+### Sub-step 1.2 — <action verb-object>
+
+...
+
+### Sub-step 1.N — <action verb-object>
+
+...
+
+---
+
+## Parent step 2 — <name>
+
+...
+
+---
+
+## Final verification
+
+<what the artifact captures: PASS condition, any cross-step invariants>
+```
+
+## Rules
+
+### Boundary structure
+
+- **One parent step rendered at a time** by `/te`. The user never sees parent step 2 until step 1 is fully complete.
+- **≤10 sub-steps per parent.** Upper cap, not target. If a logical group has 4 sub-steps, leave it at 4 — don't pad. If it needs >10, split the parent.
+- Sub-steps grouped by **logical boundary**, not by count. "Setup", "Scan 1", "Scan 2", "Scan 3", "Verification" — each is a parent.
+
+### Step content (mandatory fields)
+
+Every sub-step has all four:
+- **Action** — single concrete imperative ("Open the popup", "Click 'Re-scan'", "Run `await ...`")
+- **Expected** — observable outcome the user can verify
+- **Verify via** — surface-map key OR `direct observation` if no map entry applies
+- **Verification command** — interpolated from surface map when applicable
+
+`/te` refuses to render a sub-step missing any field — returns FAIL with `underspecified manual test step at <N.M> step <X.Y>; amend companion file`.
+
+### Unambiguous language
+
+- No abbreviations or jargon without inline definition.
+- No "as you know" / "obviously" / "just" — assume the user is following blind.
+- No multi-action sub-steps. "Open popup AND click re-scan" → split into two sub-steps.
+
+### Why explicit and verbose
+
+User running step 39 of 60 should not have to debug their own confusion. The cost of a redundant clarification is low; the cost of a misinterpreted step (false-pass or false-fail) is high (wasted manual-test time, polluted artifact, /ts spin-up).
+
+## Example
+
+See `examples/honeyllm-1.5-manual-test.example.md` (created when sprint 1.5 lands; placeholder until then).

--- a/.claude/plugins/quantrix/docs/pipeline.md
+++ b/.claude/plugins/quantrix/docs/pipeline.md
@@ -1,0 +1,126 @@
+# quantrix pipeline — data flow
+
+Detailed flow showing what each command reads, writes, and hands off.
+
+## Inputs (consuming project must provide)
+
+```
+docs/
+├── plans/
+│   ├── <plan-doc>.md                # config.planDocPath — source of truth
+│   └── sprints/
+│       └── sprint-<N>-*.md          # per-sprint playbooks (## Item N.M blocks)
+├── agent-context/
+│   └── known-surfaces.md            # config.surfacesMapPath — project surfaces
+└── testing/
+    ├── manual-tests/
+    │   └── <N.M>.md                 # /te companion files (authored by /sprint)
+    └── manual-runs/
+        ├── <N.M>-<sha>-state.json   # /te resumable state
+        └── <N.M>-<sha>.md           # /te final artifact
+```
+
+## Issue body AC contract
+
+```markdown
+## Code AC (verified by /qa from diff)
+
+- [ ] <test gate: file:line that asserts X>
+- [ ] <regression coverage: baseline byte-identical OR specific test file passes>
+
+## Manual AC (verified by /te + /qa via artifact)
+
+- [manual] · <action> · expect <outcome> · verify via <surface-map key>
+- [manual] · <action> · expect <outcome> · verify via <surface-map key>
+```
+
+Multi-angle requirement: ≥2 ACs total, covering the symptom from different angles. A buggy fix that satisfies one tends to fail another.
+
+## Per-command flow
+
+### /sprint <N.M>
+
+```
+1. Read plan doc + sprint file's §<N.M> block
+2. Pre-flight checks:
+   - Repo state (clean main, tests passing)
+   - Model/effort matches sprint file's recommendation
+   - Issue body has ## Code AC + (if manual) ## Manual AC, ≥2 multi-angle
+   - Surfaces map readable
+3. STOP if any pre-flight fails — do NOT author AC on user's behalf
+4. Present kickoff prompt + validation steps to user
+5. On user confirm: execute kickoff
+6. End-of-session: if manual AC exists, print /te launch command
+```
+
+### /qa <PR# | N.M> [first|second]
+
+```
+First pass (default when no /te artifact exists):
+  1. Resolve target: PR# → diff + originating issue;  N.M → latest PR closing issue
+  2. Read issue body, extract Code AC + Manual AC
+  3. AC-quality pre-check (concrete, verifiable, distinct, ≤3-bounded)
+  4. Run Checks A-F over diff (see qa.md)
+  5. Tick Code AC checkboxes on PASS via gh issue edit --body-file
+  6. Output: PASS/CONCERNS/FAIL on stdout line 1
+  7. On PASS + manual AC exists: print /te launch hint
+
+Second pass (when /te artifact exists at docs/testing/manual-runs/<N.M>-<sha>.md):
+  1. Read /te artifact (PASS/FAIL per manual AC)
+  2. Run Check G — cross-AC corroboration (do code + manual outcomes triangulate?)
+  3. Tick Manual AC checkboxes on PASS
+  4. Post summary comment on issue
+  5. Output: PASS/CONCERNS/FAIL on stdout
+  6. On PASS: ready for auto-merge
+```
+
+### /te <N.M>
+
+```
+1. Read companion file at <manualTestsDir>/<N.M>.md
+2. Read surfaces map for verification-source resolution
+3. Check for existing state.json — resume from last-completed step if found
+4. For each parent step:
+     a. Render parent step + ≤10 sub-steps (boundary group)
+     b. For each sub-step: display action + expected + verification command
+     c. Wait for user reply
+     d. Classify reply: done | error | question | pause | defect-suspected
+     e. On done: persist state, advance
+     f. On error / defect-suspected: halt, recommend /ts <N.M>, exit
+     g. On pause: persist state, exit
+5. On final-step done: write artifact at <manualRunsDir>/<N.M>-<sha>.md
+6. Print: PASS + /qa <N.M> --phase second hint
+```
+
+### /ts <N.M>
+
+```
+1. Q&A first (one question per turn)
+2. State-load: issue + PR + /te state.json (if present)
+3. Post troubleshoot-in-progress status comment + add label
+4. Phase B: investigate progressively (R+C on every move)
+5. State diagnosis as hypothesis with confidence scorecard
+6. Paper-test the fix WITH user
+7. Propose single compact fix path
+8. STOP after answering pass — do not push to Phase C
+9. On user request: Phase C → file T<N.M>.<seq> issue + amend kickoff + handoff
+10. Resolution gate: /qa second-pass PASS required to clear label
+```
+
+## Surfaces map integration
+
+All four commands consult `<surfacesMapPath>` (default `docs/agent-context/known-surfaces.md`) before scanning the codebase. This avoids dispatching Explore subagents for questions the map already answers.
+
+- `/sprint` — manual AC entries reference surface-map keys; pre-flight verifies referenced keys exist
+- `/qa` — Check D scope authority; Check G cross-AC corroboration uses surface-map field semantics
+- `/te` — interpolates surface-map-derived verification commands into each step
+- `/ts` — Phase B reads surfaces map before any code Read/Grep
+
+## Multi-collaborator handoff
+
+The full session state of `/ts` and `/te` is durable:
+
+- `/ts` posts a status comment on the originating issue + adds `troubleshoot-in-progress` label. Issue cannot close while label present. A second invocation reads the existing comment and resumes.
+- `/te` writes state.json after every step. A halted run resumes at the last-completed step. Different collaborators can pick up the run.
+
+This makes the pipeline safe for sessions that get interrupted, context-exhausted, or handed off.

--- a/.claude/plugins/quantrix/docs/surfaces-map-spec.md
+++ b/.claude/plugins/quantrix/docs/surfaces-map-spec.md
@@ -1,0 +1,108 @@
+# Surfaces map — schema for consuming projects
+
+The surfaces map is the project's authoritative inventory of internal surfaces (caches, storage keys, message types, hunters/canaries/probes/mitigations, byte-locked files, test pages). All four quantrix commands consult it before scanning the codebase.
+
+Path: configurable via `plugin.json` → `config.surfacesMapPath` (default: `docs/agent-context/known-surfaces.md`).
+
+## Why this exists
+
+Without a surfaces map, every command burns tokens rediscovering project structure. With it:
+- `/sprint` resolves manual AC verification clauses to runnable commands.
+- `/qa` Check D (scope) and Check G (cross-AC corroboration) read declared surfaces.
+- `/te` interpolates verification commands per step.
+- `/ts` Phase B reads the map before dispatching Explore subagents.
+
+The dispatch-Explore-instead cost is ~50-100K tokens per question; the surfaces map answers most of those for ~5K tokens.
+
+## File shape
+
+Markdown. Sections per surface category. Within each section, a table of entries.
+
+```markdown
+# <project> known surfaces
+
+Living document. Updated as new surfaces ship. Schema in `quantrix/docs/surfaces-map-spec.md`.
+
+## Caches
+
+| Key | Storage | TTL | Shape | Verification command |
+|---|---|---|---|---|
+| `honeyllm:scan-cache` | chrome.storage.local | 24h | `{[url]: {verdict, ts, ...}}` | `await chrome.storage.local.get('honeyllm:scan-cache')` |
+| `honeyllm:cache-telemetry` | chrome.storage.local | none | `{count, hits, misses, ts}` | `await chrome.storage.local.get('honeyllm:cache-telemetry')` |
+
+## Storage keys
+
+| Key | Storage | Shape | Verification command |
+|---|---|---|---|
+| `honeyllm:logging-state` | chrome.storage.local | `{connected, heartbeat: {global, perTab}}` | `await chrome.storage.local.get('honeyllm:logging-state')` |
+| `honeyllm:last-verdict` | chrome.storage.local | `{verdict, mitigations, ts, url}` | `await chrome.storage.local.get('honeyllm:last-verdict')` |
+
+## Message types
+
+| Type | Sender | Receiver | Payload | Notes |
+|---|---|---|---|---|
+| `PAGE_SNAPSHOT` | content | service-worker | `{html, url, ...}` | Triggers offscreen create on first call |
+| `STATE_QUERY` | harness | service-worker | `{}` | Returns full pipeline state |
+
+## Hunters
+
+| Name | Module | Threshold | Verification |
+|---|---|---|---|
+| Spider | `src/hunters/spider/` | substring | `npm test -- spider` |
+| Hawk | `src/hunters/hawk/` | regex | `npm test -- hawk` |
+| Embeddings | `src/hunters/embeddings/` | cosine ≥ 0.85 | `npm test -- embeddings` |
+
+## Canaries
+
+| Name | Module | Engine | Capabilities |
+|---|---|---|---|
+| Gemma-2-2b | `src/offscreen/canaries/gemma-canary.ts` | MLC WebLLM | text |
+| Nano | `src/offscreen/canaries/nano-canary.ts` | Chrome Prompt API | text, image |
+
+## Probes
+
+| Name | Module | Triggered by | Returns |
+|---|---|---|---|
+| InstructionFollow | `src/probes/instruction-follow/` | dispatcher | `{found, instructions}` |
+| ImageInjection | `src/probes/image-injection/` | dispatcher when image | `{found, technique}` |
+
+## Mitigations
+
+| Name | Module | Surface |
+|---|---|---|
+| InjectionMask | `src/content/mitigations/injection-mask.ts` | DOM |
+| FetchOverride | `src/content/main-world-inject.ts` | network |
+| RedirectGuard | `src/service-worker/redirect-guard.ts` | webNavigation |
+
+## Test pages
+
+| Path | Purpose | Expected verdict |
+|---|---|---|
+| `test-pages/clean/sourdough.html` | clean control | CLEAN |
+| `test-pages/injected/instruction-overt.html` | overt injection | COMPROMISED |
+
+## Byte-locked files
+
+| Path | Reason | Lock authority |
+|---|---|---|
+| `docs/testing/inbrowser-results.json` | Phase 2 canonical baseline | CLAUDE.md |
+| `scripts/fixtures/phase2-inputs.ts::classifyOutput` (v1) | byte-identity contract | CLAUDE.md |
+```
+
+## Required fields per entry
+
+Every entry MUST have:
+- **Key/Name** — the identifier referenced by AC and code
+- **Verification command** OR **Verification** — concrete way to check the surface's state from the user side (popup, console, file path)
+
+Optional fields per category (Storage / TTL / Shape / Threshold / etc.) populate when meaningful.
+
+## Living document
+
+The map is updated as new surfaces ship. PRs that add a documented surface category (new cache, new storage key, new message type, new hunter/canary/probe/mitigation) MUST update the map in the same PR.
+
+`/qa` Check G (a future addition) gates this: if a PR diff touches a documented surface but doesn't update the map, surface as a CONCERNS finding.
+
+## Schema versioning
+
+This spec is v1. Future schema changes (additional required fields, new categories) bump the version in `plugin.json` and document migration in this file.

--- a/.claude/plugins/quantrix/examples/honeyllm-surfaces-map.example.md
+++ b/.claude/plugins/quantrix/examples/honeyllm-surfaces-map.example.md
@@ -1,0 +1,108 @@
+# Example: HoneyLLM surfaces map
+
+This is an illustrative example of a surfaces map for the HoneyLLM project. It conforms to the schema in `quantrix/docs/surfaces-map-spec.md`.
+
+The actual HoneyLLM surfaces map lives at `docs/agent-context/known-surfaces.md` in the HoneyLLM repo. This example excerpts the high-value sections to show the schema in practice.
+
+```markdown
+# HoneyLLM known surfaces
+
+Living document. Updated as new surfaces ship. Schema in `quantrix/docs/surfaces-map-spec.md`.
+
+## Caches
+
+| Key | Storage | TTL | Shape | Verification command |
+|---|---|---|---|---|
+| `honeyllm:scan-cache` | chrome.storage.local | 24h | `{[url]: {verdict, ts, mitigations[]}}` | `await chrome.storage.local.get('honeyllm:scan-cache')` |
+| `honeyllm:cache-telemetry` | chrome.storage.local | none | `{count, hits, misses, lastClearTs}` | `await chrome.storage.local.get('honeyllm:cache-telemetry')` |
+| `honeyllm:response-telemetry` | chrome.storage.local | none | `{[probe]: {runs, successes, failures}}` | `await chrome.storage.local.get('honeyllm:response-telemetry')` |
+| `honeyllm:thinking-telemetry` | chrome.storage.local | none | `{[probe]: {tokens, latencyMs}}` | `await chrome.storage.local.get('honeyllm:thinking-telemetry')` |
+
+## Storage keys (non-cache)
+
+| Key | Storage | Shape | Verification command |
+|---|---|---|---|
+| `honeyllm:logging-state` | chrome.storage.local | `{connected, heartbeat: {global, perTab: {[tabId]: bool}}}` | `await chrome.storage.local.get('honeyllm:logging-state')` |
+| `honeyllm:last-verdict` | chrome.storage.local | `{verdict, mitigations[], ts, url}` | `await chrome.storage.local.get('honeyllm:last-verdict')` |
+| `honeyllm:user-config` | chrome.storage.sync | `{enabled, strictBypass, byok: {provider, model}}` | `await chrome.storage.sync.get('honeyllm:user-config')` |
+
+## Message types
+
+| Type | Sender | Receiver | Payload | Notes |
+|---|---|---|---|---|
+| `PAGE_SNAPSHOT` | content | service-worker | `{html, url, snapshotTs}` | Triggers offscreen create on first call after reload |
+| `STATE_QUERY` | harness | service-worker | `{}` | Returns full pipeline state for non-disruptive introspection |
+| `SET_LOGGING_STATE` | service-worker | content (via Port) | `{viewerConnected, heartbeatActive}` | Gates content-side log Port emissions |
+
+## Hunters
+
+| Name | Module | Threshold | Verification |
+|---|---|---|---|
+| Spider | `src/hunters/spider/index.ts` | substring match | `npm test -- spider` |
+| Hawk | `src/hunters/hawk/index.ts` | regex / language-router | `npm test -- hawk` |
+| Embeddings | `src/hunters/embeddings/index.ts` | cosine ≥ 0.85 | `npm test -- embeddings` |
+| DetermiLLM (stub) | `src/hunters/determillm/index.ts` | pack-runtime | `npm test -- determillm` |
+
+## Canaries
+
+| Name | Module | Engine | Capabilities |
+|---|---|---|---|
+| Gemma-2-2b | `src/offscreen/canaries/gemma-canary.ts` | MLC WebLLM (WebGPU) | text |
+| Nano | `src/offscreen/canaries/nano-canary.ts` | Chrome Prompt API | text, image |
+| Wolf (Llama-3.2-1B) | `src/offscreen/canaries/wolf-canary.ts` | MLC WebLLM | text (refusal-as-detection) |
+
+## Probes
+
+| Name | Module | Triggered by | Returns |
+|---|---|---|---|
+| InstructionFollow | `src/probes/instruction-follow/` | dispatcher | `{found, instructions[]}` |
+| ImageInjection | `src/probes/image-injection/` | dispatcher when image present | `{found, technique}` |
+| RedirectGate | `src/probes/redirect-gate/` | webNavigation | `{action: 'allow' | 'block'}` |
+
+## Mitigations
+
+| Name | Module | Surface |
+|---|---|---|
+| InjectionMask | `src/content/mitigations/injection-mask.ts` | DOM (CSS overlay) |
+| FetchOverride | `src/content/main-world-inject.ts` | network (fetch + XHR) |
+| RedirectGuard | `src/service-worker/redirect-guard.ts` | webNavigation |
+
+## Test pages
+
+| Path | Purpose | Expected verdict |
+|---|---|---|
+| `test-pages/clean/sourdough.html` | clean control | CLEAN |
+| `test-pages/clean/image-heavy.html` | clean image-heavy | CLEAN |
+| `test-pages/injected/instruction-overt.html` | overt injection | COMPROMISED |
+| `test-pages/injected-images/text-overlay.html` | image text overlay | COMPROMISED |
+| `test-pages/injected-images/qr-injection.html` | QR-encoded injection | SUSPICIOUS or COMPROMISED |
+
+## Byte-locked files
+
+| Path | Reason | Lock authority |
+|---|---|---|
+| `docs/testing/inbrowser-results.json` | Phase 2 canonical baseline (162 rows) | CLAUDE.md |
+| `scripts/fixtures/phase2-inputs.ts::classifyOutput` (v1) | byte-identity contract | CLAUDE.md |
+```
+
+## How AC reference this map
+
+A Manual AC line in an issue body:
+
+```
+- [manual] · Reload extension, hard-reload bricklink.com/v2/main.page · expect popup verdict CLEAN with no mitigations · verify via storage:honeyllm:last-verdict
+```
+
+`/te` resolves `storage:honeyllm:last-verdict` against the surfaces map's "Storage keys (non-cache)" section, finds:
+
+```
+| `honeyllm:last-verdict` | chrome.storage.local | ... | `await chrome.storage.local.get('honeyllm:last-verdict')` |
+```
+
+…and renders the sub-step with:
+
+```
+  Run: await chrome.storage.local.get('honeyllm:last-verdict')
+```
+
+Without the surfaces map, `/te` would have to ask the user to invent the verification command — error-prone.

--- a/.claude/plugins/quantrix/plugin.json
+++ b/.claude/plugins/quantrix/plugin.json
@@ -1,0 +1,31 @@
+{
+  "name": "quantrix",
+  "version": "0.1.0",
+  "description": "Agile-loop pipeline for issue-driven sprint work: /sprint authors and gates, /qa verifies code AC from diff and manual AC from /te artifacts, /te walks the user through manual tests with state-resumable boundary-grouped steps, /troubleshoot investigates and gates resolution back to /qa PASS. Surfaces-map-first. Reusable across projects.",
+  "author": "JimmyCapps",
+  "license": "MIT",
+  "commands": [
+    "commands/sprint.md",
+    "commands/qa.md",
+    "commands/te.md",
+    "commands/troubleshoot.md"
+  ],
+  "skills": [
+    "skills/ac-authoring/SKILL.md",
+    "skills/boundary-walkthrough/SKILL.md",
+    "skills/surfaces-map/SKILL.md"
+  ],
+  "config": {
+    "surfacesMapPath": "docs/agent-context/known-surfaces.md",
+    "manualTestsDir": "docs/testing/manual-tests",
+    "manualRunsDir": "docs/testing/manual-runs",
+    "planDocPath": "docs/plans/v0.1-completion.md",
+    "sprintFilesGlob": "docs/plans/sprints/sprint-*.md"
+  },
+  "recommendedRuntime": {
+    "sprint": { "model": "varies-per-sprint", "effort": "medium" },
+    "qa": { "model": "claude-sonnet-4-6", "effort": "medium" },
+    "te": { "model": "claude-sonnet-4-6", "effort": "medium" },
+    "troubleshoot": { "model": "claude-opus-4-7", "effort": "high" }
+  }
+}

--- a/.claude/plugins/quantrix/skills/ac-authoring/SKILL.md
+++ b/.claude/plugins/quantrix/skills/ac-authoring/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: ac-authoring
+description: Multi-angle acceptance criteria authoring discipline; code/manual AC split; bounded ≤5; verification-source citation. Used by /sprint pre-flight gate and /qa AC-quality pre-check.
+type: process
+---
+
+# AC authoring — multi-angle, code/manual split, bounded
+
+When authoring or reviewing acceptance criteria for a quantrix sprint item, follow these rules.
+
+## Two sections, always
+
+```markdown
+## Code AC (verified by /qa from diff)
+
+- [ ] <test gate>
+- [ ] <regression coverage>
+
+## Manual AC (verified by /te + /qa via artifact)
+
+- [manual] · <action> · expect <outcome> · verify via <surface-map key>
+```
+
+If manual testing doesn't apply, omit the Manual AC section. Code AC is always present.
+
+## Multi-angle — ≥2 ACs total
+
+A single AC tells you one thing was satisfied. Two ACs from different angles tell you the fix didn't accidentally satisfy the wrong shape.
+
+Example — embeddings false-positive on bricklink:
+- AC 1 (positive code): `bricklink-regression.test.ts asserts cosine(<phrase>) < 0.85, passes in CI`
+- AC 2 (regression code): `Phase 2 byte-locked baseline byte-identical`
+- AC 3 (manual): `[manual] · 3 cache-cleared scans of bricklink.com/v2/main.page · expect CLEAN with no mitigations · verify via storage:honeyllm:last-verdict`
+
+Three angles. A fix that lowers the corpus threshold satisfies AC 1 but fails AC 2. A fix that special-cases the URL satisfies AC 1 + AC 2 but fails AC 3 (tests don't trigger the embeddings layer).
+
+## Bounded — ≤5 total, recommend ≤3 per section
+
+If you have >5 ACs, the work is too broad. Split into multiple issues.
+
+The cap is an upper bound, not a target. 2 well-chosen ACs > 5 redundant ones.
+
+## Concrete + verifiable
+
+Each AC must be:
+- **Concrete** — specific file, command, measurable outcome. NOT "fix is good", "works", "no regressions" without a regression list.
+- **Verifiable** — `/qa` can check it from the diff (Code AC) or `/te` can walk the user through verification (Manual AC).
+- **Distinct** — no overlap between AC items. If two ACs check the same thing differently, drop one.
+
+## Manual AC — verification source citation
+
+Manual AC entries MUST cite a verification source from the project's surfaces map:
+
+```
+[manual] · <action> · expect <outcome> · verify via <surface-map key>
+```
+
+The verify clause turns into a runnable command via the surfaces map. Without it, `/te` cannot interpolate a verification command and rejects the AC.
+
+If the verification source isn't in the surfaces map yet, add it to the map in the same PR — that's a sign the surface is undocumented.
+
+## Pre-flight gate
+
+`/sprint <N.M>` STOPs if:
+- Issue body lacks `## Code AC` section
+- Issue body lacks `## Manual AC` section AND the sprint item's validation block references manual testing
+- Total AC count < 2
+- Any Manual AC line lacks a `verify via` clause
+- Any Manual AC line cites a `verify via` key not present in the surfaces map
+
+`/sprint` does NOT author AC on the user's behalf when the gate fails — that's the agent grading its own homework. User amends issue body, then re-runs.
+
+## Common pitfalls
+
+- **AC drift:** ACs change during execution to match what was shipped. Don't. The AC was the contract; ship to it or amend deliberately (and explain why in the PR body).
+- **Tautology:** "the test passes" is not an AC. The test name + assertion shape is the AC.
+- **Vague verification:** "popup shows the right thing" is not verifiable. "popup verdict = CLEAN, mitigations = []" is.
+- **Over-decomposition:** breaking one AC into 5 sub-bullets defeats the bound. One AC with a multi-clause verification is fine.

--- a/.claude/plugins/quantrix/skills/boundary-walkthrough/SKILL.md
+++ b/.claude/plugins/quantrix/skills/boundary-walkthrough/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: boundary-walkthrough
+description: /te step-rendering rules — one parent step at a time, ≤10 sub-steps cap, wait-for-done contract, state.json after each step, classification of user replies. Used by /te.
+type: process
+---
+
+# Boundary-grouped walkthrough — /te step-rendering rules
+
+`/te` walks the user through manual tests. Display rules below are non-negotiable; they protect users from misinterpreting steps and wasting test time.
+
+## Display rules
+
+### One parent step at a time
+
+Never render parent step 2 until step 1 is fully complete. The user sees the parent step name + a one-paragraph context + sub-steps 1.1 through 1.N.
+
+### ≤10 sub-steps per parent — upper cap, not target
+
+If a logical group has 4 sub-steps, render 4. Don't pad. Don't split arbitrarily.
+
+If a parent has >10 sub-steps, the companion file is wrong — flag during `/te` parse and return FAIL with `parent step <name> exceeds 10 sub-step cap; amend companion file to split into smaller boundaries`.
+
+### Sub-steps grouped by logical boundary
+
+"Setup", "Scan 1", "Scan 2", "Scan 3", "Verification" — each is a parent. Not "first 5 things", "next 5 things" — that's count-based, not boundary-based.
+
+### Each sub-step — four mandatory fields
+
+Render in this order:
+
+```
+Sub-step 1.2 — <action verb-object>
+
+  Action:    <single concrete imperative>
+  Expected:  <observable outcome>
+  Verify via: <surface-map key | direct observation>
+  Run:       <interpolated verification command>
+
+  Reply 'done' when verified, or paste output if it doesn't match.
+```
+
+If any of the four fields is missing in the companion file, `/te` returns FAIL with `underspecified manual test step at <N.M> step <X.Y>`.
+
+## Wait-for-done contract
+
+After rendering a sub-step, `/te` halts and waits. No advancing without user reply.
+
+### Reply classification
+
+`/te` classifies the user's next message into one of:
+
+| Class | Triggers | Action |
+|---|---|---|
+| `done` | reply matches `^(done|ok|next|yes|verified|✓)$` (case-insensitive) | persist state, advance to next sub-step or parent |
+| `error` | reply contains an error string, log line, exception, "didn't match", "failed" | halt, summarize observed-vs-expected, recommend `/ts <N.M>`, exit |
+| `question` | reply ends in `?` or starts with "what", "why", "how", "is", "should" | answer from companion-file context only (no fresh research); if can't answer, halt and ask user how to proceed |
+| `pause` | reply matches `^(pause|stop|quit|exit|halt|brb)$` | persist state, exit; user re-invokes `/te <N.M>` later, resumes at last-completed sub-step |
+| `defect-suspected` | reply contains "looks wrong", "this is broken", "shouldn't be like this" | halt, recommend `/ts <N.M>`, exit |
+| `ambiguous` | reply doesn't classify confidently | ask one focused clarifying question; do NOT advance |
+
+### When ambiguous, ask not assume
+
+`/te`'s job is fidelity, not throughput. If a reply could mean done OR could mean unease, ask. Don't silently advance.
+
+## State persistence — after every sub-step
+
+State written to `<manualRunsDir>/<N.M>-<sha>-state.json`:
+
+```json
+{
+  "sprintItem": "1.5",
+  "sha": "abc123",
+  "startedAt": "2026-05-05T10:30:00Z",
+  "lastUpdatedAt": "2026-05-05T10:42:00Z",
+  "currentParent": 2,
+  "currentSubStep": 3,
+  "completed": [
+    {"parent": 1, "sub": 1, "doneAt": "2026-05-05T10:31:00Z", "userReply": "done"},
+    {"parent": 1, "sub": 2, "doneAt": "2026-05-05T10:33:00Z", "userReply": "done"},
+    ...
+  ],
+  "halted": null
+}
+```
+
+On halt, `halted` populated:
+
+```json
+"halted": {
+  "at": "2026-05-05T10:45:00Z",
+  "atParent": 2,
+  "atSubStep": 4,
+  "reason": "error" | "pause" | "defect-suspected",
+  "userReply": "<verbatim>",
+  "recommendedAction": "/ts 1.5"
+}
+```
+
+## Resume
+
+When `/te <N.M>` is re-invoked and a state.json exists at the SHA:
+
+```
+Resuming /te 1.5 from parent step 2, sub-step 4 (halted 2026-05-05 10:45 UTC, reason: pause).
+Previous state preserved. Skipping completed steps. Fresh-rendering from sub-step 2.4.
+
+Continue? (yes / restart / cancel)
+```
+
+User can:
+- `yes` — continue from last incomplete sub-step
+- `restart` — wipe state.json, start from parent 1 sub 1
+- `cancel` — exit without changes
+
+## Final artifact
+
+On final-step `done`, `/te` writes artifact at `<manualRunsDir>/<N.M>-<sha>.md`:
+
+```markdown
+# Manual test run — Sprint <N.M>
+
+**Started:** <ts>
+**Completed:** <ts>
+**Build SHA:** <sha>
+**Verdict:** PASS
+
+## Per-step record
+
+### Parent 1 — <name>
+
+- 1.1 — <action> — done at <ts>
+- 1.2 — <action> — done at <ts>
+- 1.N — <action> — done at <ts>
+
+### Parent 2 — <name>
+
+...
+
+## Manual AC verification
+
+- [x] [manual] · <verbatim AC text> · verified at parent 3 sub 5
+- [x] [manual] · <verbatim AC text> · verified at parent 4 sub 2
+
+## Notes captured during run
+
+<any user-pasted output, observations, etc. — preserved verbatim>
+```
+
+`/qa <N.M> --phase second` consumes this artifact.
+
+## Why these rules
+
+- One parent at a time: prevents the user scrolling past steps. The visible step is the active one.
+- ≤10 sub-step cap: protects against "step 39 of 60" — when something breaks, the user has only paged through 1-9 sub-steps in this group, easy to retry.
+- Boundary grouping: aligns with how the user thinks about the test (setup, run, verify), not with arbitrary chunk size.
+- State after every sub-step: a halt at sub-step 7 doesn't lose sub-steps 1-6.
+- Wait-for-done: throughput is not the goal; fidelity is.
+- Ambiguous → ask: silent advance on ambiguous reply produces false-PASSes that waste downstream time.

--- a/.claude/plugins/quantrix/skills/surfaces-map/SKILL.md
+++ b/.claude/plugins/quantrix/skills/surfaces-map/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: surfaces-map
+description: How all four quantrix commands consult the project's surfaces map to avoid environment-scanning. Read the map BEFORE Grep/Read/Explore for any question about caches, storage keys, message types, hunters, canaries, mitigations, byte-locked files.
+type: process
+---
+
+# Surfaces map first
+
+Every quantrix command consults the project's surfaces map at `<surfacesMapPath>` (default `docs/agent-context/known-surfaces.md`) before any code Read/Grep or Explore subagent dispatch.
+
+Schema for the map: `quantrix/docs/surfaces-map-spec.md`.
+
+## Why
+
+A typical question like "where does the cache live?" can be answered by:
+
+- **A:** dispatch Explore subagent → 50-100K tokens, multi-second latency, may miss
+- **B:** read surfaces map (~5K tokens, deterministic, complete)
+
+Always (B) when the question is about a documented surface category.
+
+## When to read the map
+
+| Command | When to read |
+|---|---|
+| `/sprint` | Pre-flight, when verifying Manual AC `verify via` clauses cite real keys |
+| `/qa` | Always at start (Check D scope authority + Check G cross-AC corroboration) |
+| `/te` | At start, to interpolate verification commands per step |
+| `/ts` | Phase B entry — BEFORE any Explore subagent |
+
+## When NOT to dispatch Explore
+
+If the question is about:
+- A documented cache → read map's "Caches" section
+- A storage key → read map's "Storage keys" section
+- A message type / IPC payload → read map's "Message types" section
+- A hunter / canary / probe / mitigation behavior → read the relevant category section
+- A byte-locked file → read map's "Byte-locked files" section
+- A test page expected verdict → read map's "Test pages" section
+
+Only dispatch Explore for genuinely cross-cutting research the map doesn't cover (e.g. "find all places that import or call function X" when X isn't catalogued).
+
+## When the map is wrong or stale
+
+If you find the map missing a surface that exists in code, OR the map's claim contradicts the code:
+
+1. Don't silently work around it — note the discrepancy.
+2. If you're in `/sprint` or `/ts` Phase C, add the surface map update to the same PR.
+3. If you're in `/qa`, surface as a CONCERNS finding (Check G category — "PR touches a documented surface but map not updated" OR "PR adds a new surface not catalogued").
+
+The map IS a source of truth — if it's stale, the right move is to update it, not bypass it.
+
+## Reading pattern (efficient)
+
+When reading for a specific question:
+
+1. **Don't read the whole map** — it can grow large. Read the section that matches the question.
+2. **Cite the entry inline** when forming the answer — e.g. "per surfaces-map §Caches, the scan-cache lives in `chrome.storage.local` keyed by URL with 24h TTL".
+3. **If the entry is missing**, fall back to Explore — but flag the gap so it can be added later.
+
+## Verification interpolation (used by /te)
+
+When a manual AC says `verify via storage:honeyllm:cache-telemetry`, /te looks up the entry in surfaces map → finds:
+
+| Key | Storage | Verification command |
+|---|---|---|
+| `honeyllm:cache-telemetry` | chrome.storage.local | `await chrome.storage.local.get('honeyllm:cache-telemetry')` |
+
+Then renders the sub-step with:
+
+```
+  Run: await chrome.storage.local.get('honeyllm:cache-telemetry')
+```
+
+If the key isn't in the map, /te FAILs with `verify via key '<key>' not found in surfaces map at <path>; amend map or correct AC`.
+
+## The contract
+
+The surfaces map is a **promise** between the project's commits and the agents reading them. Every surface category named in the spec MUST be documented before a sprint item depending on it ships. Updating the map is part of authoring, not a separate task.

--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,10 @@ Thumbs.db
 !.env.example
 test-data/repos/
 
-# Local Claude Code workspace (session-specific, not shared)
-.claude/
+# Local Claude Code workspace (session-specific, not shared) — except for repo-vendored plugins
+.claude/*
+!.claude/plugins/
+!.claude/plugins/**
 
 # Session exploration scratch (converted to issues/PRs at session end)
 .session-findings/

--- a/docs/plans/sprints/README.md
+++ b/docs/plans/sprints/README.md
@@ -15,7 +15,7 @@ For each item:
 1. Read the sprint file's pre-flight checklist. Confirm or set: model, effort, plugins, MCP servers, repo state.
 2. Open Claude in repo root with the recommended model + effort + flags. The exact paste-ready command is in **each issue's plan-pointer comment** (see project board → click any issue → first comment). Generic shape:
    ```bash
-   cd /Users/node3/Documents/projects/HoneyLLM && claude --model <model> --effort <low|medium|high|xhigh|max> --remote-control --chrome --dangerously-skip-permissions
+   cd "$(git rev-parse --show-toplevel)" && claude --model <model> --effort <low|medium|high|xhigh|max> --remote-control --chrome --dangerously-skip-permissions
    ```
    Effort `xhigh` and `max` enable extended thinking; there's no separate `--thinking` flag — thinking is folded into effort.
 3. Paste the item's kickoff prompt block into Claude. Wait for it to complete.

--- a/docs/plans/sprints/sprint-1-stability.md
+++ b/docs/plans/sprints/sprint-1-stability.md
@@ -12,12 +12,12 @@ Tracking: epic #248. Project board: <https://github.com/JimmyCapps/zentropy/proj
 - [ ] **Model:** `claude-haiku-4-5-20251001` (medium effort). Bug fixes + plumbing — well-specified TDD-first work.
 - [ ] **Plugins (recommended state):** keep superpowers, feature-dev, code-simplifier, commit-commands, code-review, security-guidance, typescript-lsp, chrome-devtools-mcp, playwright, context7, hookify. Disable cloudflare, huggingface-skills, agent-sdk-dev, playground, skill-creator, claude-code-setup if still on.
 - [ ] **MCP servers needed:** chrome-devtools-mcp (for #217 profiling), playwright (for E2E tests). Others not load-bearing for this sprint.
-- [ ] **Repo state:** `cd /Users/node3/Documents/projects/HoneyLLM && git checkout main && git pull --ff-only && npm test` → all pass.
+- [ ] **Repo state:** `cd "$(git rev-parse --show-toplevel)" && git checkout main && git pull --ff-only && npm test` → all pass.
 - [ ] **Confirm scope:** read [Sprint 1 spec](../v0.1-completion.md#sprint-1-days-13-stability--bugs--observability) — bricklink fix expects #226 logs to identify primitive; Officeworks 4-step diagnostic in #217 body.
 
 **Start Claude in repo root:**
 ```bash
-cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-haiku-4-5-20251001 --effort medium --remote-control --chrome --dangerously-skip-permissions
+cd "$(git rev-parse --show-toplevel)" && claude --model claude-haiku-4-5-20251001 --effort medium --remote-control --chrome --dangerously-skip-permissions
 ```
 
 ---

--- a/docs/plans/sprints/sprint-10-local-chat.md
+++ b/docs/plans/sprints/sprint-10-local-chat.md
@@ -13,7 +13,7 @@ Master plan: [`../v0.1-completion.md` Sprint 10](../v0.1-completion.md#sprint-10
 - [ ] Repo state: v0.4.0-internal tag exists; BYOK shipped (Sprint 9).
 
 ```bash
-cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-sonnet-4-6 --effort medium --remote-control --chrome --dangerously-skip-permissions
+cd "$(git rev-parse --show-toplevel)" && claude --model claude-sonnet-4-6 --effort medium --remote-control --chrome --dangerously-skip-permissions
 ```
 
 ---

--- a/docs/plans/sprints/sprint-11-agentic-design.md
+++ b/docs/plans/sprints/sprint-11-agentic-design.md
@@ -13,7 +13,7 @@ Master plan: [`../v0.1-completion.md` Sprint 11](../v0.1-completion.md#sprint-11
 - [ ] Repo state: v0.5.0-internal tag exists; isolate mode (#132) on main.
 
 ```bash
-cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-opus-4-7 --effort high --remote-control --chrome --dangerously-skip-permissions
+cd "$(git rev-parse --show-toplevel)" && claude --model claude-opus-4-7 --effort high --remote-control --chrome --dangerously-skip-permissions
 ```
 
 ---

--- a/docs/plans/sprints/sprint-12-tag-v1.md
+++ b/docs/plans/sprints/sprint-12-tag-v1.md
@@ -13,7 +13,7 @@ Master plan: [`../v0.1-completion.md` Sprint 12](../v0.1-completion.md#sprint-12
 - [ ] Repo state: Sprint 11 deliverables on main (RFC + alarms-bridge + task-store + verdict-gate).
 
 ```bash
-cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-sonnet-4-6 --effort medium --remote-control --chrome --dangerously-skip-permissions
+cd "$(git rev-parse --show-toplevel)" && claude --model claude-sonnet-4-6 --effort medium --remote-control --chrome --dangerously-skip-permissions
 ```
 
 ---

--- a/docs/plans/sprints/sprint-2-phase3-closure.md
+++ b/docs/plans/sprints/sprint-2-phase3-closure.md
@@ -15,7 +15,7 @@ Master plan: [`../v0.1-completion.md` Sprint 2](../v0.1-completion.md#sprint-2-d
 - [ ] Confirm: PR #221, #226 fix, #232 fix all on main from Sprint 1.
 
 ```bash
-cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-haiku-4-5-20251001 --effort medium --remote-control --chrome --dangerously-skip-permissions
+cd "$(git rev-parse --show-toplevel)" && claude --model claude-haiku-4-5-20251001 --effort medium --remote-control --chrome --dangerously-skip-permissions
 ```
 
 ---

--- a/docs/plans/sprints/sprint-3-tag-v0.2.md
+++ b/docs/plans/sprints/sprint-3-tag-v0.2.md
@@ -16,7 +16,7 @@ Master plan: [`../v0.1-completion.md` Sprint 3](../v0.1-completion.md#sprint-3-d
 - [ ] Repo state: `npm test` passes; all Sprint 1+2 PRs on main.
 
 ```bash
-cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-opus-4-7 --effort high --remote-control --chrome --dangerously-skip-permissions
+cd "$(git rev-parse --show-toplevel)" && claude --model claude-opus-4-7 --effort high --remote-control --chrome --dangerously-skip-permissions
 ```
 
 ---

--- a/docs/plans/sprints/sprint-4-determillm-bridge.md
+++ b/docs/plans/sprints/sprint-4-determillm-bridge.md
@@ -15,7 +15,7 @@ Master plan: [`../v0.1-completion.md` Sprint 4](../v0.1-completion.md#sprint-4-d
 - [ ] Read [`docs/determillm/ARCHITECTURE.md`](../../determillm/ARCHITECTURE.md) before items 4.1-4.4 — that's the design contract.
 
 ```bash
-cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-haiku-4-5-20251001 --effort medium --remote-control --chrome --dangerously-skip-permissions
+cd "$(git rev-parse --show-toplevel)" && claude --model claude-haiku-4-5-20251001 --effort medium --remote-control --chrome --dangerously-skip-permissions
 ```
 
 ---

--- a/docs/plans/sprints/sprint-5-wolf-nano.md
+++ b/docs/plans/sprints/sprint-5-wolf-nano.md
@@ -13,7 +13,7 @@ Master plan: [`../v0.1-completion.md` Sprint 5](../v0.1-completion.md#sprint-5-d
 - [ ] Repo state: Wolf scaffold from Sprint 4 on main; DM-A/E/F/G all merged.
 
 ```bash
-cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-sonnet-4-6 --effort medium --remote-control --chrome --dangerously-skip-permissions
+cd "$(git rev-parse --show-toplevel)" && claude --model claude-sonnet-4-6 --effort medium --remote-control --chrome --dangerously-skip-permissions
 ```
 
 ---

--- a/docs/plans/sprints/sprint-6-tag-v0.3.md
+++ b/docs/plans/sprints/sprint-6-tag-v0.3.md
@@ -13,7 +13,7 @@ Master plan: [`../v0.1-completion.md` Sprint 6](../v0.1-completion.md#sprint-6-d
 - [ ] Repo state: Wolf stages 1-3 on main; #60 + #119 on main.
 
 ```bash
-cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-sonnet-4-6 --effort medium --remote-control --chrome --dangerously-skip-permissions
+cd "$(git rev-parse --show-toplevel)" && claude --model claude-sonnet-4-6 --effort medium --remote-control --chrome --dangerously-skip-permissions
 ```
 
 ---

--- a/docs/plans/sprints/sprint-7-isolate-mode.md
+++ b/docs/plans/sprints/sprint-7-isolate-mode.md
@@ -13,7 +13,7 @@ Master plan: [`../v0.1-completion.md` Sprint 7](../v0.1-completion.md#sprint-7-d
 - [ ] Repo state: v0.3.0-internal tag exists on main.
 
 ```bash
-cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-opus-4-7 --effort high --remote-control --chrome --dangerously-skip-permissions
+cd "$(git rev-parse --show-toplevel)" && claude --model claude-opus-4-7 --effort high --remote-control --chrome --dangerously-skip-permissions
 ```
 
 ---

--- a/docs/plans/sprints/sprint-8-local-proxy.md
+++ b/docs/plans/sprints/sprint-8-local-proxy.md
@@ -13,7 +13,7 @@ Master plan: [`../v0.1-completion.md` Sprint 8](../v0.1-completion.md#sprint-8-d
 - [ ] Repo state: v0.3.0-internal tag exists; #132 closed.
 
 ```bash
-cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-opus-4-7 --effort high --remote-control --chrome --dangerously-skip-permissions
+cd "$(git rev-parse --show-toplevel)" && claude --model claude-opus-4-7 --effort high --remote-control --chrome --dangerously-skip-permissions
 ```
 
 ---

--- a/docs/plans/sprints/sprint-9-byok.md
+++ b/docs/plans/sprints/sprint-9-byok.md
@@ -13,7 +13,7 @@ Master plan: [`../v0.1-completion.md` Sprint 9](../v0.1-completion.md#sprint-9-d
 - [ ] Repo state: v0.4.0-internal tag exists.
 
 ```bash
-cd /Users/node3/Documents/projects/HoneyLLM && claude --model claude-sonnet-4-6 --effort medium --remote-control --chrome --dangerously-skip-permissions
+cd "$(git rev-parse --show-toplevel)" && claude --model claude-sonnet-4-6 --effort medium --remote-control --chrome --dangerously-skip-permissions
 ```
 
 ---


### PR DESCRIPTION
Closes #266 · Refs #248

## Summary

- Introduces **quantrix** plugin at `.claude/plugins/quantrix/` (mirrored to `~/Documents/projects/toolkit/quantrix/` for further dedicated-session expansion).
- Adds **`/te`** — guided manual-test executor with boundary-grouped, state-resumable walkthroughs.
- Encodes the **AC contract** (code/manual split, multi-angle ≥2, surface-map verify-via) and gates `/sprint` pre-flight on it.
- Adds **dual-pass `/qa`** with new Check G cross-AC corroboration; ticks AC checkboxes on PASS; manual-trigger via `<N.M>` form.
- Tightens **`/ts`**: verification gate prevents premature Phase C enhancement offers; resolution requires `/qa` second-pass PASS to clear `troubleshoot-in-progress` label.
- Sweeps local-path launch commands across all 12 sprint files + the README to portable `cd "$(git rev-parse --show-toplevel)"` form.

## Plugin layout

```
.claude/plugins/quantrix/
├── plugin.json
├── commands/{sprint,qa,te,troubleshoot}.md
├── skills/{ac-authoring,boundary-walkthrough,surfaces-map}/SKILL.md
├── docs/{README,pipeline,ac-template,manual-test-template,surfaces-map-spec}.md
└── examples/honeyllm-surfaces-map.example.md
```

## Pipeline contract

```
/sprint <N.M>   pre-flight AC gate → kickoff → execution → /te launch hint
/qa <N.M>       first pass: code AC + readiness; PASS → ticks code AC
/te <N.M>       guided walkthrough; one parent step at a time, ≤10 sub-steps,
                 state.json resumable, artifact at docs/testing/manual-runs/
/qa <N.M> --phase second   consume artifact + Check G + tick manual AC + close
/ts <N.M>       invoked on FAIL; reads /te state.json on entry; resolution gate
                 = /qa second-pass PASS to clear troubleshoot-in-progress label
```

## Out of scope (deferred per issue)

- Existing sprint issue + sprint-file AC alignment audit — separate follow-up after this lands and is installed.
- `/discover`, `/plan`, `/deliverables`, `/surfaces-update` — toolkit-side dedicated sessions (forward scope tracked in `~/Documents/projects/toolkit/DESIGN.md`).
- Sprint-1.1/1.2/1.3 retro-amendment — grandfathered.

## Test plan

- [x] `git status` clean post-commit
- [x] All 14 plugin files committed
- [x] Mirror at `~/Documents/projects/toolkit/quantrix/` verified identical via `diff -r`
- [x] Toolkit `DESIGN.md` renamed working name → quantrix; v1 marked landed
- [x] No `/Users/node3/Documents/projects/HoneyLLM` refs remaining in `docs/plans/` or `scripts/`
- [x] `.gitignore` updated to allow `.claude/plugins/` while keeping rest of `.claude/` ignored
- [ ] CI green (typecheck + test + build)
- [ ] Manual: read plugin.json → all referenced files exist
- [ ] Manual: read README.md → links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)