### PR TITLE
chore(plan-#266): add quantrix self-contained marketplace.json shim

### DIFF
--- a/.claude/plugins/quantrix/.claude-plugin/marketplace.json
+++ b/.claude/plugins/quantrix/.claude-plugin/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "name": "quantrix-local",
+  "description": "Self-contained marketplace for the quantrix plugin (sprint+qa+te+ts pipeline)",
+  "owner": {
+    "name": "JimmyCapps"
+  },
+  "plugins": [
+    {
+      "name": "quantrix",
+      "description": "Agile-loop pipeline: /sprint authors and gates, /qa verifies code AC from diff and manual AC from /te artifacts, /te walks the user through manual tests with state-resumable boundary-grouped steps, /troubleshoot investigates and gates resolution back to /qa PASS",
+      "source": "."
+    }
+  ]
+}


### PR DESCRIPTION
Refs #266 #248

## Summary

- Adds `.claude/plugins/quantrix/.claude-plugin/marketplace.json` so Claude Code's `/plugin install` can register and install the local plugin without needing a separate marketplace repo.
- One file, 14 lines.

## Why

PR #267 shipped the plugin but Claude Code's `/plugin install` verb requires a registered marketplace — running `/plugin install .claude/plugins/quantrix` errored with `Marketplace ... not found`. This shim makes the plugin's own directory act as a self-contained marketplace.

## Install workflow (from anywhere with the repo cloned)

```
/plugin marketplace add /path/to/HoneyLLM/.claude/plugins/quantrix
/plugin install quantrix@quantrix-local
```

After install: `/sprint`, `/qa`, `/te`, `/troubleshoot` available globally.

## Test plan

- [x] File adds cleanly (1 file, 14 lines)
- [x] Mirror to ~/Documents/projects/toolkit/quantrix/ — will sync in toolkit-side dev session
- [ ] Manual: confirm install commands above succeed end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)