### PR TITLE
chore(plan-#270): audit + rewrite sprint-issue plan-pointer comments for quantrix v0.2.0

### DIFF
--- a/docs/plans/audit-log-2026-05-05.md
+++ b/docs/plans/audit-log-2026-05-05.md
@@ -1,0 +1,114 @@
+# Plan-pointer comment audit — 2026-05-05
+
+Tracking issue: [#270](https://github.com/JimmyCapps/zentropy/issues/270) · scope: every OPEN sprint-tracked HoneyLLM issue with a `**Plan context:**` comment.
+
+## Why
+
+Each board-seeded issue carries a comment that prescribes the launch command + slash command for that work item. Three axes had drifted:
+
+1. **Local paths.** `cd /Users/node3/Documents/projects/HoneyLLM && claude ...` — not portable to a fresh checkout, a worktree, or any other contributor.
+2. **Slash command names.** `/sprint`, `/qa`, `/te`, `/troubleshoot` were the bare names from the in-repo prototype. Quantrix v0.2.0 (extracted to its own repo in [PR #269](https://github.com/JimmyCapps/zentropy/pull/269)) namespaces them: `/quantrix:sprint`, `/quantrix:quality`, `/quantrix:guide`, `/quantrix:troubleshooter`.
+3. **Model/effort floors.** Sprint 1 baseline was Haiku 4.5 / medium. Sprint 1.3 (#232 bricklink false-positive fix) was authored on Haiku and shipped a fix that's still flagging in manual testing — suspected Haiku weakness on classification-sensitive test fidelity. Items with test authorship around classification thresholds or hunter scoring are bumped to Sonnet 4.6 / medium.
+
+## Tier table applied
+
+| Item type | Model floor | Effort floor |
+|---|---|---|
+| Test authorship + classification-sensitive code | sonnet 4.6 | medium |
+| Deep reasoning / security / architecture | opus 4.7 | high |
+| Mechanical wiring (no classification judgement) | haiku 4.5 | medium |
+| Manual / [USER] items | n/a | n/a |
+| Documentation-only | haiku 4.5 | medium |
+
+## Out of scope
+
+- **Sprint 1.1 / 1.2 / 1.3** (#220, #226, #232) — already executed; comment launch blocks reflect the model that ran the work. Not amended.
+- **CLOSED items** (#60, #119, #120, plus the Sprint 1.1–1.3 set above) — same grandfather rule. Reflect what ran.
+- **#2** — long-running issue (Phase 3 Track B). No plan-pointer comment exists; was set up before this audit framework. Leaving alone; redesign per N10 methodology is tracked separately.
+- **Issue bodies** that mention `/Users/node3` (#2, #8) — bodies are out of audit scope (comments only).
+- **Scripts / sprint files / setup-project.sh template** — already swept in prior PRs (#267, #261). Not re-touched.
+- **Filing T-issues for Haiku-suspect existing fixes** — separate troubleshoot work; the table below notes them.
+
+## Per-issue change table
+
+Comment IDs preserved (PATCH, not delete-and-repost). Backups of pre-rewrite bodies live at `/tmp/honeyllm-comment-backup-2026-05-05/` on the audit machine.
+
+| Issue | Sprint | Comment ID | New model / effort | Changes applied |
+|---|---|---|---|---|
+| [#217](https://github.com/JimmyCapps/zentropy/issues/217) | 1.4 (renderer leak) | 4367437190 | `claude-sonnet-4-6` / `medium` | path→portable; slash→quantrix:; **model: haiku 4.5 → sonnet 4.6** (debugging memory leak with test authorship) |
+| [#157](https://github.com/JimmyCapps/zentropy/issues/157) | 1.5 (LLM bypass) | 4367437232 | `claude-sonnet-4-6` / `medium` | path→portable; slash→quantrix:; **model: haiku 4.5 → sonnet 4.6** (classification logic + tests) |
+| [#14](https://github.com/JimmyCapps/zentropy/issues/14) | 1.6 (Nano replicate) | 4367437267 | [USER] | path→portable; slash→quantrix: (troubleshoot block only) |
+| [#2](https://github.com/JimmyCapps/zentropy/issues/2) | 2.1 / 2.2 / 2.9 | (skipped) | — | no plan-pointer comment exists |
+| [#9](https://github.com/JimmyCapps/zentropy/issues/9) | 2.3–2.5 (image probe) | 4367437299 | `claude-sonnet-4-6` / `medium` | path→portable; slash→quantrix:; **model: haiku 4.5 → sonnet 4.6** (multimodal classification) |
+| [#124](https://github.com/JimmyCapps/zentropy/issues/124) | 2.6 (Browse MCP) | 4367437342 | [USER] | path→portable; slash→quantrix: |
+| [#129](https://github.com/JimmyCapps/zentropy/issues/129) | 2.7 (embeddings) | 4367437371 | [USER] | path→portable; slash→quantrix: |
+| [#8](https://github.com/JimmyCapps/zentropy/issues/8) | 2.8 (Chromium audit) | 4367437408 | [USER] | path→portable; slash→quantrix: |
+| [#128](https://github.com/JimmyCapps/zentropy/issues/128) | 3.4 (ProtectAI) | 4367437510 | `claude-opus-4-7` / `high` | path→portable; slash→quantrix: (already at floor — Sprint 3 default) |
+| [#244](https://github.com/JimmyCapps/zentropy/issues/244) | 4.1 (DM-A stub) | 4367437562 | `claude-haiku-4-5-20251001` / `medium` | path→portable; slash→quantrix: (mechanical wiring; Haiku retained per tier) |
+| [#245](https://github.com/JimmyCapps/zentropy/issues/245) | 4.2 (DM-E telemetry) | 4367437615 | `claude-haiku-4-5-20251001` / `medium` | path→portable; slash→quantrix: (mechanical) |
+| [#246](https://github.com/JimmyCapps/zentropy/issues/246) | 4.3 (DM-F refactor) | 4367437665 | `claude-haiku-4-5-20251001` / `medium` | path→portable; slash→quantrix: (mechanical) |
+| [#247](https://github.com/JimmyCapps/zentropy/issues/247) | 4.4 (DM-G triage) | 4367437697 | `claude-haiku-4-5-20251001` / `medium` | path→portable; slash→quantrix: (triage / docs-ish) |
+| [#3](https://github.com/JimmyCapps/zentropy/issues/3) | 4.5 / 5.1 / 5.2 / 6.1 (Hunters umbrella) | 4367437738 | `claude-sonnet-4-6` / `medium` | path→portable; slash→quantrix:; **model: haiku 4.5 → sonnet 4.6** (umbrella with classification + test authorship) |
+| [#227](https://github.com/JimmyCapps/zentropy/issues/227) | 6.2 (harness state API) | 4367437843 | `claude-sonnet-4-6` / `medium` | path→portable; slash→quantrix: (already at floor — Sprint 6 default) |
+| [#15](https://github.com/JimmyCapps/zentropy/issues/15) | 6.3 (mini-sweep) | 4367437890 | `claude-sonnet-4-6` / `medium` | path→portable; slash→quantrix: (already at floor) |
+| [#132](https://github.com/JimmyCapps/zentropy/issues/132) | 7.x (isolate mode) | 4367437932 | `claude-opus-4-7` / `high` | path→portable; slash→quantrix: (already at floor — security-critical; `--permission-mode plan` preserved) |
+| [#133](https://github.com/JimmyCapps/zentropy/issues/133) | 8.x (local proxy) | 4367437958 | `claude-opus-4-7` / `high` | path→portable; slash→quantrix: (already at floor) |
+| [#19](https://github.com/JimmyCapps/zentropy/issues/19) | 9.x (BYOK) | 4367437990 | `claude-sonnet-4-6` / `medium` | path→portable; slash→quantrix: (already at floor) |
+| [#4](https://github.com/JimmyCapps/zentropy/issues/4) | 10.x (local chat) | 4367438032 | `claude-sonnet-4-6` / `medium` | path→portable; slash→quantrix: (already at floor) |
+| [#5](https://github.com/JimmyCapps/zentropy/issues/5) | 11.x (agentic) | 4367438064 | `claude-opus-4-7` / `high` | path→portable; slash→quantrix: (already at floor — Sprint 11 default) |
+
+## Per-sprint summary
+
+| Sprint | Issues touched | Model bumps |
+|---|---|---|
+| 1 | 3 (#217, #157, #14) | 2 × haiku 4.5 → sonnet 4.6 (#217 #157) |
+| 2 | 4 (#9, #124, #129, #8) | 1 × haiku 4.5 → sonnet 4.6 (#9) |
+| 3 | 1 (#128) | 0 |
+| 4 | 5 (#244, #245, #246, #247, #3) | 1 × haiku 4.5 → sonnet 4.6 (#3) |
+| 5 | 0 (all CLOSED — grandfathered) | 0 |
+| 6 | 2 (#227, #15) | 0 |
+| 7 | 1 (#132) | 0 |
+| 8 | 1 (#133) | 0 |
+| 9 | 1 (#19) | 0 |
+| 10 | 1 (#4) | 0 |
+| 11 | 1 (#5) | 0 |
+| **Total** | **20 comments PATCHed** | **4 model bumps** |
+
+## Haiku-suspect existing fixes
+
+Sprint 1.3 (#232 bricklink false-positive fix) was authored on Haiku 4.5 / medium and shipped a fix that's still flagging in manual testing. Mechanism suspected: Haiku may have written a fix that's wrong AND added tests that are tautological — Haiku's classification of "does this test actually verify the behavior" is the failure mode that bites. Test fidelity is exactly the false-positive surface that justifies Sonnet's reasoning premium.
+
+Items in this category for follow-up troubleshoot triage (NOT in this PR's scope):
+
+- **#232** (Sprint 1.3 bricklink FP) — already-shipped Haiku fix. Manual testing surfaces FP again. Candidate for `/quantrix:troubleshooter` pass on Sonnet 4.6 / medium.
+
+Future work: items #226 (Sprint 1.2 logging coverage) and #220 (Sprint 1.1 mitigation rollback) shipped on Haiku too; surface any regressions on those for the same triage path.
+
+## Verification
+
+Code AC:
+
+- [x] All `/Users/node3` references removed from sprint-issue comment bodies (`gh issue view <n> --json comments --jq '[.comments[] | select(.body | contains("/Users/node3"))] | length'` returns 0 for all 20 audited issues).
+- [x] Every plan-pointer comment uses `cd "$(git rev-parse --show-toplevel)"` form (verified via fresh re-fetch of #244, #217 — both blocks rewritten).
+- [x] Every plan-pointer comment uses `/quantrix:<command>` shape — no bare `/sprint`, `/qa`, `/te`, `/troubleshoot` in audited bodies.
+- [x] Every model/effort meets floor (4 Haiku→Sonnet bumps applied; existing Opus/Sonnet picks left in place).
+- [x] This audit-log file exists with one row per audited issue.
+
+Manual AC (user spot-check on github.com):
+
+- [ ] Open #244 — Haiku 4.5 / medium retained (mechanical wiring per tier table).
+- [ ] Open #128 — Opus 4.7 / high (Sprint 3 reasoning-heavy validation).
+- [ ] Open #226 (grandfathered) — comment NOT amended (still on Haiku).
+- [ ] Try `/quantrix:sprint 1.4` (issue #217) and confirm the corrected comment renders.
+
+## Mechanism
+
+`scripts/audit-rewrite-2026-05-05.py` (committed alongside this log) is the rewriter. It:
+
+1. Fetches each issue's `**Plan context:**` comment via `gh api /repos/JimmyCapps/zentropy/issues/<n>/comments`.
+2. Applies regex rewrites: bash launch lines → portable path, slash commands → namespaced, recommended-model bullet → tier floor.
+3. PATCHes the comment via `gh api -X PATCH /repos/JimmyCapps/zentropy/issues/comments/<id>`.
+
+The rewriter is idempotent: re-running on already-corrected comments is a no-op (negative lookahead `(?<!quantrix:)` and the model regex matches the new value as a no-op replace).
+
+For future reuse: the per-issue `ISSUE_TARGETS` map at the top of the script is the source of truth for tier assignments. Update that map and re-run if a future sprint adds new issues or the tier table itself changes.

--- a/scripts/audit-rewrite-2026-05-05.py
+++ b/scripts/audit-rewrite-2026-05-05.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Rewrite plan-pointer comments on HoneyLLM sprint-tracked issues for quantrix v0.2.0.
+
+Per-issue model+effort overrides applied per the tier table in issue #270.
+USER items (target=None) get path+slash-command rewrites only — no model bump.
+"""
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = "JimmyCapps/zentropy"
+
+# Per-issue target (model, effort) for the BUILDING block.
+# None = USER item, leave model alone (no building model exists in comment).
+ISSUE_TARGETS: dict[int, tuple[str, str] | None] = {
+    217: ("claude-sonnet-4-6", "medium"),
+    157: ("claude-sonnet-4-6", "medium"),
+    14:  None,
+    2:   ("claude-opus-4-7", "high"),
+    9:   ("claude-sonnet-4-6", "medium"),
+    124: None,
+    129: None,
+    8:   None,
+    128: ("claude-opus-4-7", "high"),
+    244: ("claude-haiku-4-5-20251001", "medium"),
+    245: ("claude-haiku-4-5-20251001", "medium"),
+    246: ("claude-haiku-4-5-20251001", "medium"),
+    247: ("claude-haiku-4-5-20251001", "medium"),
+    3:   ("claude-sonnet-4-6", "medium"),
+    227: ("claude-sonnet-4-6", "medium"),
+    15:  ("claude-sonnet-4-6", "medium"),
+    132: ("claude-opus-4-7", "high"),
+    133: ("claude-opus-4-7", "high"),
+    19:  ("claude-sonnet-4-6", "medium"),
+    4:   ("claude-sonnet-4-6", "medium"),
+    5:   ("claude-opus-4-7", "high"),
+}
+
+# Sprint-item code each issue maps to (for /quantrix:sprint <N.M> rewrite).
+# Multi-section comments use the first section's N.M as the slash arg.
+ISSUE_SPRINT_ARG: dict[int, str] = {
+    217: "1.4", 157: "1.5", 14: "1.6",
+    2: "2.1", 9: "2.3", 124: "2.6", 129: "2.7", 8: "2.8",
+    128: "3.4",
+    244: "4.1", 245: "4.2", 246: "4.3", 247: "4.4", 3: "4.5",
+    227: "6.2", 15: "6.3",
+    132: "7.1", 133: "8.1",
+    19: "9.1", 4: "10.1", 5: "11.1",
+}
+
+LOCAL_PATH_PATTERN = re.compile(
+    r"cd\s+/Users/node3/Documents/projects/HoneyLLM\s*&&\s*claude\s",
+    re.IGNORECASE,
+)
+
+
+def fetch_plan_comment(issue: int) -> tuple[str, str] | None:
+    """Return (comment_id, body) of the plan-pointer comment, or None."""
+    out = subprocess.check_output(
+        ["gh", "api", f"/repos/{REPO}/issues/{issue}/comments", "--paginate"],
+        text=True,
+    )
+    comments = json.loads(out)
+    for c in comments:
+        if c.get("body", "").startswith("**Plan context:**"):
+            return str(c["id"]), c["body"]
+    return None
+
+
+def rewrite_body(issue: int, body: str) -> str:
+    target = ISSUE_TARGETS.get(issue)
+
+    new_body = body
+
+    # 1. Fix bash launch lines.
+    #    "cd /Users/node3/Documents/projects/HoneyLLM && claude ..." → multiline portable.
+    def replace_launch(match: re.Match[str]) -> str:
+        line = match.group(0)
+        # Strip leading "cd ... && " portion
+        rest = re.sub(LOCAL_PATH_PATTERN, "claude ", line, count=1)
+        return 'cd "$(git rev-parse --show-toplevel)"\n' + rest
+
+    # Apply per-line so we replace ONLY the launch lines starting with cd /Users/node3/...
+    new_lines = []
+    for line in new_body.splitlines():
+        if LOCAL_PATH_PATTERN.search(line):
+            stripped = re.sub(LOCAL_PATH_PATTERN, "claude ", line, count=1)
+            new_lines.append('cd "$(git rev-parse --show-toplevel)"')
+            new_lines.append(stripped)
+        else:
+            new_lines.append(line)
+    new_body = "\n".join(new_lines)
+
+    # 2. If target overrides building model: rewrite the bullet + bash launch model.
+    if target is not None:
+        model, effort = target
+
+        # Bullet: "- **Recommended model:** `<model>` · **effort:** `<effort>`"
+        new_body = re.sub(
+            r"(\*\*Recommended model:\*\*\s*`)[^`]+(`\s*·\s*\*\*effort:\*\*\s*`)[^`]+(`)",
+            rf"\g<1>{model}\g<2>{effort}\g<3>",
+            new_body,
+        )
+
+        # First (building) bash launch — model+effort flags. There may be a
+        # second launch (troubleshoot) using opus 4.7 high; we only rewrite
+        # the first one matching a non-opus pattern when target != opus.
+        # Simplest correct approach: we know the original building line was
+        # the first bash claude line that does NOT specify opus-4-7+high
+        # OR is the first one when target IS opus. Scan and replace first.
+        replaced = {"done": False}
+        def replace_first_claude(match: re.Match[str]) -> str:
+            if replaced["done"]:
+                return match.group(0)
+            replaced["done"] = True
+            return f"claude --model {model} --effort {effort}"
+
+        new_body = re.sub(
+            r"claude\s+--model\s+\S+\s+--effort\s+\S+",
+            replace_first_claude,
+            new_body,
+            count=1,
+        )
+
+    # 3. Slash-command rewrites. Negative lookahead [A-Za-z0-9_-] avoids
+    #    matching inside identifiers like /sprint-4-determillm-bridge.md.
+    new_body = re.sub(r"(?<!quantrix:)/sprint(?![A-Za-z0-9_-])", "/quantrix:sprint", new_body)
+    new_body = re.sub(r"(?<!quantrix:)/troubleshoot(?![A-Za-z0-9_-])", "/quantrix:troubleshooter", new_body)
+    new_body = re.sub(r"(?<!quantrix:)/qa(?![A-Za-z0-9_-])", "/quantrix:quality", new_body)
+    new_body = re.sub(r"(?<!quantrix:)/te(?![A-Za-z0-9_-])", "/quantrix:guide", new_body)
+
+    # 4. Append quantrix-required footer if not already present.
+    footer = (
+        "\n---\n"
+        "_Quantrix v0.2.0+ required for the slash commands above. "
+        "Install per [CLAUDE.md → Required plugin: quantrix]"
+        "(https://github.com/JimmyCapps/zentropy/blob/main/CLAUDE.md"
+        "#required-plugin-quantrix-sprint-pipeline)._\n"
+    )
+    if "Quantrix v0.2.0+ required" not in new_body:
+        new_body = new_body.rstrip() + "\n" + footer
+
+    return new_body
+
+
+def patch_comment(comment_id: str, new_body: str) -> None:
+    # Use stdin to avoid arg-length / shell-quoting issues.
+    payload = json.dumps({"body": new_body})
+    subprocess.run(
+        ["gh", "api", "-X", "PATCH",
+         f"/repos/{REPO}/issues/comments/{comment_id}",
+         "--input", "-"],
+        input=payload, text=True, check=True, capture_output=True,
+    )
+
+
+def main() -> int:
+    if len(sys.argv) > 1 and sys.argv[1] == "--dry-run":
+        dry = True
+        issues = [int(a) for a in sys.argv[2:]] if len(sys.argv) > 2 else list(ISSUE_TARGETS)
+    else:
+        dry = False
+        issues = list(ISSUE_TARGETS) if len(sys.argv) == 1 else [int(a) for a in sys.argv[1:]]
+
+    log_rows: list[str] = []
+
+    for issue in issues:
+        result = fetch_plan_comment(issue)
+        if result is None:
+            print(f"#{issue}: no plan-pointer comment found", file=sys.stderr)
+            log_rows.append(f"| #{issue} | (skipped) | no plan-pointer comment |")
+            continue
+        comment_id, body = result
+        target = ISSUE_TARGETS[issue]
+        had_local_path = "/Users/node3" in body
+        had_bare_sprint = bool(re.search(r"(?<!quantrix:)/sprint\b", body))
+        had_bare_troubleshoot = bool(re.search(r"(?<!quantrix:)/troubleshoot\b", body))
+
+        new_body = rewrite_body(issue, body)
+        if new_body == body:
+            print(f"#{issue}: no change")
+            log_rows.append(f"| #{issue} | (no change) | already conforms |")
+            continue
+
+        # Capture what we changed
+        changes = []
+        if had_local_path:
+            changes.append("path→portable")
+        if had_bare_sprint:
+            changes.append("/sprint→/quantrix:sprint")
+        if had_bare_troubleshoot:
+            changes.append("/troubleshoot→/quantrix:troubleshooter")
+        if target is not None:
+            old_match = re.search(
+                r"\*\*Recommended model:\*\*\s*`([^`]+)`\s*·\s*\*\*effort:\*\*\s*`([^`]+)`",
+                body,
+            )
+            old = f"{old_match.group(1)}/{old_match.group(2)}" if old_match else "n/a"
+            new = f"{target[0]}/{target[1]}"
+            if old != new:
+                changes.append(f"model: {old} → {new}")
+
+        change_str = "; ".join(changes) if changes else "footer-only"
+        kind = "[USER]" if target is None else f"`{target[0]}` / `{target[1]}`"
+        log_rows.append(f"| #{issue} | {comment_id} | {kind} | {change_str} |")
+
+        if dry:
+            print(f"#{issue}: WOULD update comment {comment_id} — {change_str}")
+        else:
+            patch_comment(comment_id, new_body)
+            print(f"#{issue}: updated comment {comment_id} — {change_str}")
+
+    print("\n--- audit-log rows ---")
+    for r in log_rows:
+        print(r)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Audit and rewrite of every plan-pointer comment on HoneyLLM sprint-tracked issues to align with quantrix v0.2.0 (the plugin extracted to its own repo in #269).

**20 comments PATCHed** across 11 sprints:
- Local paths replaced: `claude` → portable `cd "$(git rev-parse --show-toplevel)"` + multiline.
- Slash commands namespaced: `/sprint` → `/quantrix:sprint`, `/qa` → `/quantrix:quality`, `/troubleshoot` → `/quantrix:troubleshooter`.
- 4 model bumps: haiku 4.5 → sonnet 4.6 for classification-sensitive test-authorship items (#217 #157 #9 #3) — Sprint 1.3 (#232) shipped on Haiku and is still flagging in manual testing, so future test-authorship-around-classification items get the Sonnet floor.

Comment IDs preserved (PATCH, not delete-and-repost).

## Files

- `docs/plans/audit-log-2026-05-05.md` — per-issue change table + per-sprint summary + verification checklist + Haiku-suspect existing-fix triage list.
- `scripts/audit-rewrite-2026-05-05.py` — the idempotent rewriter (per-issue tier map at top is the source of truth; re-runnable).

## Out of scope

- Sprint 1.1 / 1.2 / 1.3 (#220, #226, #232) — already executed; comment launch blocks reflect the model that ran the work. **Grandfathered.**
- CLOSED items (#60, #119, #120) — same grandfather rule.
- #2 — no plan-pointer comment exists (predates the audit framework).
- Issue *bodies* with `/Users/node3` (#2, #8) — comments only per the audit charter.

## Test plan

- [ ] CI green (typecheck + test + build — doc/script-only change so should be fast)
- [ ] Spot-check #244 on github.com — Haiku 4.5 / medium retained (mechanical wiring)
- [ ] Spot-check #128 on github.com — Opus 4.7 / high (Sprint 3 reasoning-heavy)
- [ ] Spot-check #217 on github.com — Sonnet 4.6 / medium (Haiku→Sonnet bump)
- [ ] Spot-check #226 on github.com — comment NOT amended (grandfathered, still on Haiku)
- [ ] Try `/quantrix:sprint 1.4` (issue #217) and confirm corrected comment renders

## Risks / reversibility

Per-comment backups in `/tmp/honeyllm-comment-backup-2026-05-05/` on the audit machine. To roll back any single comment: `gh api -X PATCH /repos/JimmyCapps/zentropy/issues/comments/<id> --input <backup-file>` (after re-encoding to JSON). The rewriter is idempotent so re-running on already-corrected comments is safe.

Closes #270
Refs #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)