### PR TITLE
chore(plan-#272): re-sweep CLOSED sprint-issue plan-pointer comments

### DIFF
--- a/docs/plans/audit-log-2026-05-05.md
+++ b/docs/plans/audit-log-2026-05-05.md
@@ -112,3 +112,20 @@ Manual AC (user spot-check on github.com):
 The rewriter is idempotent: re-running on already-corrected comments is a no-op (negative lookahead `(?<!quantrix:)` and the model regex matches the new value as a no-op replace).
 
 For future reuse: the per-issue `ISSUE_TARGETS` map at the top of the script is the source of truth for tier assignments. Update that map and re-run if a future sprint adds new issues or the tier table itself changes.
+
+## Follow-up — closed-issue troubleshoot block cleanup (2026-05-05, post-merge)
+
+Initial audit grandfathered all CLOSED items on the principle that their building launch block "reflects the model that ran the work". That was wrong on a second axis: the **troubleshoot launch block in the same comment is forward-relevant** — anyone hitting a regression on a shipped fix needs portable paths + namespaced `/quantrix:troubleshooter` to act on it. Sprint 1.3 (#232) surfaced this directly: still flagging in manual testing, but its plan-pointer comment told the user to `cd /Users/node3/...` and run `/troubleshoot 1.3`.
+
+Re-ran the rewriter on the 6 CLOSED sprint items (`target=None`, so paths + slash commands rewritten but the historical building-model recommendation left intact as a record of what ran).
+
+| Issue | Sprint | Comment ID | Building model (preserved) | Changes |
+|---|---|---|---|---|
+| #220 | 1.1 (mitigation rollback) | 4367437070 | `claude-haiku-4-5-20251001` / `medium` | path→portable; slash→quantrix: |
+| #226 | 1.2 (logging coverage) | 4367437102 | `claude-haiku-4-5-20251001` / `medium` | path→portable; slash→quantrix: |
+| #232 | 1.3 (bricklink FP) | 4367437146 | `claude-haiku-4-5-20251001` / `medium` | path→portable; slash→quantrix: |
+| #60 | 5.3 (Nano AbortSignal) | 4367437774 | `claude-sonnet-4-6` / `medium` | path→portable; slash→quantrix: |
+| #119 | 5.4 (Lang Detector) | 4367437808 | `claude-sonnet-4-6` / `medium` | path→portable; slash→quantrix: |
+| #120 | 3.1–3.2 (pedagogical FP) | 4367437439 | `claude-opus-4-7` / `high` | path→portable; slash→quantrix: |
+
+Net: **26 plan-pointer comments swept** across the audit + cleanup combined.


### PR DESCRIPTION
## Summary

Follow-up to PR #271. The initial audit grandfathered CLOSED items on the principle that their building launch block reflects the model that ran the work — but the **troubleshoot launch block in the same comment is forward-relevant**. #232 surfaced this: shipped Haiku fix still flagging in manual testing, but the comment told the user to \`cd /Users/node3/...\` and run \`/troubleshoot 1.3\`.

6 closed plan-pointer comments PATCHed (#220 #226 #232 #120 #60 #119). Building-model lines preserved as historical record.

## Test plan

- [ ] CI green
- [ ] Spot-check #232 — \`/quantrix:troubleshooter 1.3\` block with portable path
- [ ] Spot-check #226 — building-model line still says \`claude-haiku-4-5-20251001\`/\`medium\` (historical)

Closes #272
Refs #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)