### PR TITLE
chore(plan-#232): AC v0.2.0 amendment for Sprint 1.3 bricklink fix

### DIFF
--- a/docs/agent-context/known-surfaces.md
+++ b/docs/agent-context/known-surfaces.md
@@ -348,6 +348,7 @@ Cross-cutting surfaces cited by `Manual AC` `[manual] · ... · verify via <key>
 | `popup:accordion-hunters` | `<details id="accordion-hunters">` — Spider/Hawk/embeddings/DetermiLLM rows + per-hunter scores | `src/popup/hunter-findings.ts` |
 | `popup:accordion-canary` | `<details id="accordion-canary">` — selected canary engine + Wolf-refusal rows (#3) | `src/popup/canary-findings.ts` |
 | `popup:accordion-mitigations` | `<details id="accordion-mitigations">` — active mitigation badges (network-guard, redirect-blocker, dom_sanitized) | `src/popup/mitigation-status.ts` |
+| `popup:accordion-cache` | `<details id="accordion-cache">` — scan-cache stats (entries, size, TTL, hit rate) + dynamically-rendered "Clear cache" button inside `#cache-body`. Cache-clear is the canonical force-fresh-scan surface; required for any "N consecutive cache-cleared scans" Manual AC. | `src/popup/popup.html` `#accordion-cache` / `#cache-body`, `src/popup/popup.ts:538` `initCacheAccordion` |
 | `popup:accordion-protectai` | `<details id="accordion-protectai">` — ProtectAI confirmer findings (#128, conditional on ship) | TBD `src/popup/` |
 | `popup:accordion-agentic` | `<details id="accordion-agentic">` — agentic task results + verdict-gate violations (#5) | TBD `src/popup/` |
 | `popup:byok-settings` | `<section id="byok-settings">` — BYOK provider keys + model selectors + per-origin policy editor (#19) | TBD `src/popup/byok-settings.ts` |

--- a/docs/plans/ac-review-2026-05-05.md
+++ b/docs/plans/ac-review-2026-05-05.md
@@ -85,6 +85,29 @@ The Sprint 1.3 (#232) flow-through proves why this matters: the issue had a Manu
 
 ---
 
+### #232 (Sprint 1.3) — bricklink false-positive (RETROSPECTIVE AMENDMENT 2026-05-06)
+
+**Why this entry exists.** This issue was the cautionary tale cited in the top-level finding (line 27) but was not given an accepted AC draft in the original 2026-05-05 review pass — at that time the fix had already shipped and the issue was treated as "done". The false-positive subsequently re-emerged on bricklink.com, exactly the failure mode the top-level finding predicted ("the AC didn't pin the cache-clear surface or the popup-verdict surface, so the verification ran a different path than current re-checks"). Sprint 1.3 has been re-opened to fix it again, so the AC contract is being authored post-hoc to bind the re-fix and any future re-emergence to a verifiable surface set.
+
+**Current state (pre-amendment).** 3-bullet `## Acceptance Criteria` block: regression test in flagging primitive's directory, "3 consecutive cache-cleared scans" manual gate (no surface-map key cited — the gap), Phase 2 byte-locked baseline + pedagogical-FP corpus regression invariant.
+
+**Conformance gap.** No dual heading. Manual gate cites "cache-cleared scans" without naming the cache-clear surface or the verdict / per-hunter surfaces that confirm the fix held — so successive walkthroughs run a different verification path each time.
+
+**Proposed Code AC** (≤3):
+- [ ] Regression test in `src/hunters/embeddings/bricklink-regression.test.ts` (file already exists from prior fix attempt; tighten it) — embeds the BrickLink-shaped phrases ("Buy now! Click here! Limited offer!") via the actual embeddings hunter (not just an assertion on the threshold constant) and asserts top cosine similarity against `data/injection-corpus.json` is strictly less than `EMBEDDING_COSINE_THRESHOLD = 0.85`. Test fails on pre-fix corpus, passes post-fix.
+- [ ] Per-hunter regression: tests for the flagging primitive (Spider, Hawk, embeddings — whichever the per-hunter logging from #226 identifies as the source) include the bricklink phrases as a negative fixture and assert no flag.
+- [ ] No regression: `docs/testing/inbrowser-results.json` byte-identical AND no flips on `docs/testing/phase5/pedagogical-corpus.jsonl` (the corpus expansion that fixed #232 must not introduce new flips).
+
+**Proposed Manual AC** (≤2):
+- [ ] [manual] · Reload extension; from popup, expand **Scan cache** accordion and click "Clear cache"; navigate to `https://www.bricklink.com/v2/main.page`; wait for scan to complete · expect popup verdict CLEAN, **Mitigations** accordion empty (no `network_guard_active`, no `redirect_blocker_active`, no `dom_sanitized:N`), **Hunters** accordion shows embeddings top similarity strictly < 0.85 with no other hunter scoring above its threshold · verify via `popup:accordion-cache` (cache-clear) + `popup:verdict` (headline) + `popup:accordion-mitigations` + `popup:accordion-hunters` (+ `popup:accordion-embeddings` for embedding detail) + `chrome.storage.local.get('honeyllm:verdict:bricklink.com')` matches CLEAN.
+- [ ] [manual] · Repeat the cache-clear + reload + verify cycle two more times for a total of 3 cache-cleared scans · expect 3/3 CLEAN with consistent per-hunter scores (no run flips a primitive above its threshold) · verify via `popup:accordion-cache` (each clear) + `popup:verdict` (each scan) + `popup:accordion-hunters` (each scan).
+
+**Sprint file update.** `sprint-1-stability.md §1.3` — add Companion link block to `docs/testing/manual-tests/1.3.md` (authored as part of this amendment). Surfaces map updated in this amendment to add `popup:accordion-cache` (the cache-clear gap the top-level finding called out).
+
+**Note on retrospective discipline.** Future "done at the time" issues that re-open should not have AC authored on the user's behalf without confirmation; this amendment was authored at the user's explicit request after `/quantrix:sprint 1.3` failed AC pre-flight.
+
+---
+
 ## Sprint 2 — Phase 3 closure + smokes (haiku 4.5 / medium baseline)
 
 ### #2 — Phase 3 Track B resume

--- a/docs/plans/sprints/sprint-1-stability.md
+++ b/docs/plans/sprints/sprint-1-stability.md
@@ -69,10 +69,12 @@ Execute Sprint 1 item 1.2 (#226 logging coverage) per docs/plans/v0.1-completion
 Execute Sprint 1 item 1.3 (#232 bricklink false-positive fix) per docs/plans/v0.1-completion.md Sprint 1 §1.3. Pre-req: #226 must be merged. Workflow: re-run a bricklink scan with the new jsonl; identify flagging primitive from per-hunter scores. If embeddings: add commerce/promotional-copy negative examples to data/injection-corpus.json + npm run embed:corpus + lock with "Buy now! Click here! Limited offer!" unit test below EMBEDDING_COSINE_THRESHOLD = 0.85. If Hawk or Spider: tune that primitive + add bricklink homepage to test-pages/clean/ as a regression fixture. Acceptance: 3 consecutive CLEAN scans of bricklink.com/v2/main.page. Branch fix/issue-232-bricklink-fp.
 ```
 
+**Companion:** [`../../testing/manual-tests/1.3.md`](../../testing/manual-tests/1.3.md) (Manual AC walkthrough). Verifies via `popup:accordion-cache` (cache-clear), `popup:verdict` (headline), `popup:accordion-hunters` + `popup:accordion-embeddings` (per-hunter scores), `popup:accordion-mitigations` (no active mitigations).
+
 **Validation:**
 - `gh pr view <N> --json state -q '.state'` → `MERGED`
 - `gh issue view 232 --json state -q '.state'` → `CLOSED`
-- Manual: load `dist/`, visit `https://www.bricklink.com/v2/main.page` 3 times, all CLEAN.
+- Manual: walk `/quantrix:guide 1.3` end-to-end, 3/3 CLEAN scans with cache-cleared between each, no mitigations, embeddings top similarity < 0.85 each pass.
 
 **Closeout:** none.
 

--- a/docs/testing/manual-tests/1.3.md
+++ b/docs/testing/manual-tests/1.3.md
@@ -1,0 +1,139 @@
+# Manual test — Sprint 1.3 — #232 bricklink false-positive fix
+
+Companion to issue #232's Manual AC. `/quantrix:guide 1.3` walks parent steps one at a time, ≤10 sub-steps each.
+
+The original #232 fix passed manual review at the time but the false-positive re-emerged. The AC review (`docs/plans/ac-review-2026-05-05.md` line 27) attributes this to the prior verification not pinning the cache-clear surface or popup-verdict surface — three "scans" of the same URL without a cache-clear are 1 fresh scan + 2 cache hits (per `popup:accordion-cache` gotcha note). This walkthrough fixes that by forcing a cache-clear between every scan and verifying the per-hunter scores in the popup accordion, not just the headline verdict.
+
+## Parent 1 — Pre-flight
+
+Sub-step 1.1 — Confirm clean build
+
+  Action:    `npm run build` from repo root.
+  Expected:  Exit 0; `dist/` populated.
+  Verify via: shell exit code.
+  Run:       `npm run build`
+
+Sub-step 1.2 — Load extension unpacked
+
+  Action:    `chrome://extensions/` → Developer mode ON → Load unpacked → select `dist/`.
+  Expected:  HoneyLLM appears in extension list with no error badge.
+  Verify via: `chrome://extensions/` row.
+  Run:       (manual click)
+
+Sub-step 1.3 — Reload after build
+
+  Action:    Click reload icon on the HoneyLLM card.
+  Expected:  Extension restarts; service-worker chip shows "active".
+  Verify via: `chrome://extensions/` row.
+  Run:       (manual click)
+
+Sub-step 1.4 — Confirm scan-cache is empty before run
+
+  Action:    Open HoneyLLM popup on any tab → expand the **Scan cache** accordion → click "Clear cache".
+  Expected:  Toast "Cache cleared"; Entries: 0; Hit rate: — (no lookups yet).
+  Verify via: `popup:accordion-cache`.
+  Run:       (manual click)
+
+## Parent 2 — Cache-cleared bricklink scan #1
+
+Sub-step 2.1 — Navigate to bricklink homepage
+
+  Action:    Open new tab, go to `https://www.bricklink.com/v2/main.page`.
+  Expected:  Page loads; HoneyLLM scan completes within ~30s.
+  Verify via: `popup:verdict`.
+  Run:       (manual)
+
+Sub-step 2.2 — Headline verdict is CLEAN
+
+  Action:    Open HoneyLLM popup; read the verdict summary block.
+  Expected:  CLEAN with score reflecting the canary's clean output (NOT COMPROMISED, NOT SUSPICIOUS).
+  Verify via: `popup:verdict`.
+  Run:       (manual read)
+
+Sub-step 2.3 — No mitigations applied
+
+  Action:    In the popup, expand the **Mitigations** accordion.
+  Expected:  No active badges (network-guard not active, redirect-blocker not active, no `dom_sanitized:N`).
+  Verify via: `popup:accordion-mitigations`.
+  Run:       (manual read)
+
+Sub-step 2.4 — No hunter scored above threshold
+
+  Action:    Expand the **Hunters** accordion.
+  Expected:  Embeddings row shows top similarity < 0.85 (the `EMBEDDING_COSINE_THRESHOLD` gate); Spider, Hawk, DetermiLLM rows show no findings or findings well below their score thresholds. Aggregate hunter tier did not flip the verdict.
+  Verify via: `popup:accordion-hunters` (+ `popup:accordion-embeddings` for the embeddings detail).
+  Run:       (manual read)
+
+Sub-step 2.5 — Capture per-origin verdict storage
+
+  Action:    DevTools on the popup → Application → Storage → Extension → chrome.storage.local → read `honeyllm:verdict:bricklink.com`.
+  Expected:  Per-origin verdict record shows CLEAN matching the headline; timestamp within the last minute.
+  Verify via: `browser:devtools-storage` + storage key `honeyllm:verdict:bricklink.com`.
+  Run:       (manual read)
+
+Sub-step 2.6 — Force-clear cache before next scan
+
+  Action:    Popup → **Scan cache** accordion → "Clear cache".
+  Expected:  Toast "Cache cleared"; Entries: 0.
+  Verify via: `popup:accordion-cache`.
+  Run:       (manual click)
+
+## Parent 3 — Cache-cleared bricklink scan #2
+
+Sub-step 3.1 — Reload the bricklink tab
+
+  Action:    Reload the bricklink tab (Ctrl+R / Cmd+R) — same URL, fresh scan because cache was cleared.
+  Expected:  Page reloads; HoneyLLM re-scans (you should see scan progress, not an instant cache-hit verdict).
+  Verify via: `popup:verdict` returning to "Scanning…" then resolving.
+  Run:       (manual)
+
+Sub-step 3.2 — Headline verdict is CLEAN
+
+  Action:    Open HoneyLLM popup; read verdict summary.
+  Expected:  CLEAN.
+  Verify via: `popup:verdict`.
+  Run:       (manual read)
+
+Sub-step 3.3 — No mitigations applied + no hunter above threshold
+
+  Action:    Expand both **Mitigations** and **Hunters** accordions.
+  Expected:  No active mitigations; same per-hunter pattern as scan #1 (embeddings top similarity < 0.85).
+  Verify via: `popup:accordion-mitigations` + `popup:accordion-hunters`.
+  Run:       (manual read)
+
+Sub-step 3.4 — Force-clear cache before next scan
+
+  Action:    Popup → **Scan cache** accordion → "Clear cache".
+  Expected:  Toast "Cache cleared".
+  Verify via: `popup:accordion-cache`.
+  Run:       (manual click)
+
+## Parent 4 — Cache-cleared bricklink scan #3
+
+Sub-step 4.1 — Reload the bricklink tab
+
+  Action:    Reload the bricklink tab.
+  Expected:  Fresh scan.
+  Verify via: `popup:verdict` returning to "Scanning…" then resolving.
+  Run:       (manual)
+
+Sub-step 4.2 — Headline verdict is CLEAN
+
+  Action:    Open HoneyLLM popup; read verdict summary.
+  Expected:  CLEAN.
+  Verify via: `popup:verdict`.
+  Run:       (manual read)
+
+Sub-step 4.3 — No mitigations applied + no hunter above threshold
+
+  Action:    Expand **Mitigations** and **Hunters** accordions.
+  Expected:  No active mitigations; embeddings top similarity < 0.85; consistent with scans #1 and #2.
+  Verify via: `popup:accordion-mitigations` + `popup:accordion-hunters`.
+  Run:       (manual read)
+
+Sub-step 4.4 — Aggregate result
+
+  Action:    Confirm all three scans were CLEAN with no mitigations and no hunter above its threshold.
+  Expected:  3 / 3 CLEAN, deterministic across cache-cleared runs.
+  Verify via: visual aggregate of scans #1–#3.
+  Run:       (manual)


### PR DESCRIPTION
## Summary

Authors the missing Code AC + Manual AC contract for #232 (Sprint 1.3) post-hoc, after `/quantrix:sprint 1.3` failed AC pre-flight on the legacy `## Acceptance Criteria` block. #232 was the cautionary tale cited by the 2026-05-05 AC review (line 27) but was treated as "done" at the time; the false-positive has now re-emerged on bricklink.com — exactly the failure mode the review's top-level finding predicted.

## What changed

- **Issue #232 body** (already applied via `gh issue edit`, mirrors PR #277's pattern): legacy `## Acceptance Criteria` block replaced with `## Code AC` (3 bullets — pinning the existing `bricklink-regression.test.ts` to actually run the embeddings hunter rather than just asserting the threshold constant) + `## Manual AC` (2 bullets, both citing surface-map keys for cache-clear, headline verdict, mitigations, hunters, embeddings detail, and per-origin verdict storage).
- **`docs/agent-context/known-surfaces.md`**: added `popup:accordion-cache` row — the cache-clear surface the AC review's top-level finding called out as missing.
- **`docs/testing/manual-tests/1.3.md`**: new companion walkthrough for `/quantrix:guide 1.3` (4 parents, 17 sub-steps, every sub-step cites a verify-via key, ≤6 sub-steps per parent).
- **`docs/plans/sprints/sprint-1-stability.md §1.3`**: added Companion: pointer block matching §1.4's pattern; updated Validation to walk `/quantrix:guide 1.3` end-to-end with cache-clear between each scan.
- **`docs/plans/ac-review-2026-05-05.md`**: appended retrospective-amendment entry under Sprint 1 explaining the post-hoc authoring discipline.

## Why now

The original AC ("3 consecutive cache-cleared scans → CLEAN, no mitigations") passed user-run validation when the prior fix shipped, but did NOT pin a cache-clear surface or per-hunter verification path. Successive checks ran a different verification path each time (cache hits masquerading as fresh scans; verdicts read at different rendering tiers). The amended AC binds every check to the same surface set so the next regression — or the next "done" — is reproducible.

## Test plan

- [ ] CI green (typecheck + test + build) — no source code touched, only docs + surfaces map
- [ ] `gh issue view 232` shows the `## Code AC` + `## Manual AC` headings (already verified by `gh issue edit` round-trip)
- [ ] `/quantrix:sprint 1.3` AC pre-flight gate now passes (re-run after merge)

Refs #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)