### PR TITLE
feat(observability-#280): debug-level log toggle via storage key

### DIFF
--- a/docs/agent-context/known-surfaces.md
+++ b/docs/agent-context/known-surfaces.md
@@ -72,6 +72,13 @@ Live memory monitor (usedJSHeapSize, totalJSHeapSize, jsHeapSizeLimit, DOM node 
 - **Defined at:** `src/content/diagnostic-heartbeat.ts`
 - **Trigger:** opt-in via `chrome.storage.local['honeyllm:logging-state'].heartbeat`
 
+### Debug-level toggle (#280) *(scope: shared, applied at SW + offscreen + content)*
+Logger source-side `minLevel` is hard-coded to `'info'` so #226 structured `hunter_run:` / `chunk_created` / `probe_run` / `verdict_emitted` events at `level='debug'` are dropped before reaching the LogBus. The bootstrap reads `chrome.storage.local['honeyllm:log-level']` at each entry-point init and registers a `chrome.storage.onChanged` listener so toggling debug capture does NOT require an extension reload.
+
+- **Defined at:** `src/shared/log-level-bootstrap.ts`
+- **Invoked at:** `src/service-worker/index.ts`, `src/offscreen/index.ts`, `src/content/index.ts` (immediately after `setLogSink`)
+- **Toggle:** `chrome.storage.local.set({'honeyllm:log-level': 'debug'})` from any DevTools console (SW preferred); `chrome.storage.local.remove('honeyllm:log-level')` to revert. Default unset = `'info'`.
+
 <!-- END CURATED · logging -->
 
 ---
@@ -202,6 +209,7 @@ All `chrome.storage.local` keys use the `honeyllm:` prefix. Privacy contract: ID
 | `honeyllm:registry` | signed site-structure registry bundle (SR-D/E) | `src/registry/lookup.ts` |
 | `honeyllm:registry-telemetry` | SR-G hit/miss/verifyFailure counters | `src/registry/telemetry.ts` |
 | `honeyllm:logging-state` | `{connected, heartbeat: {global, perTab: {[tabId]: bool}}}` (#236) | `src/content/index.ts`, `src/log-viewer/log-viewer.ts` |
+| `honeyllm:log-level` | `'debug' \| 'info' \| 'warn' \| 'error'` (#280) — runtime logger threshold; absent = `'info'` default | `src/shared/log-level-bootstrap.ts` |
 | `honeyllm:install-secret` | Ed25519 install secret (per-install) | `src/service-worker/install-secret.ts` |
 | `honeyllm:pack-match-telemetry` | (planned DM-E #245) `{patternId, chunkId, language, score, ts}` | TBD `src/hunters/determillm/` |
 | `honeyllm:isolate-preferences` | (planned #132) per-origin always-isolate flags | TBD |

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -2,6 +2,7 @@ import type { HoneyLLMMessage, PageSnapshotMessage } from '@/types/messages.js';
 import type { SecurityVerdict } from '@/types/verdict.js';
 import { CONTENT_PING_INTERVAL_MS } from '@/shared/constants.js';
 import { createLogger, setLogSink, setLogSource, type LogEntry } from '@/shared/logger.js';
+import { bootstrapLogLevel } from '@/shared/log-level-bootstrap.js';
 import { LOG_PORT_NAME } from '@/shared/log-bus.js';
 
 // Issue #236 — content→SW logging via long-lived Port (`chrome.runtime.connect`)
@@ -49,6 +50,7 @@ setLogSink((entry: LogEntry) => {
     logPort = null;
   }
 });
+void bootstrapLogLevel();
 import { extractPageSnapshot } from './ingestion/extractor.js';
 import {
   injectNetworkGuard,

--- a/src/offscreen/index.ts
+++ b/src/offscreen/index.ts
@@ -9,6 +9,7 @@ import type {
   ProbeDirectResultMessage,
 } from '@/types/messages.js';
 import { createLogger, setLogSink, setLogSource, type LogEntry } from '@/shared/logger.js';
+import { bootstrapLogLevel } from '@/shared/log-level-bootstrap.js';
 
 // Issue #218 — forward log entries to the SW so the unified log-viewer
 // page can stream them. console.* output is preserved by the logger
@@ -20,6 +21,7 @@ setLogSink((entry: LogEntry) => {
     // SW asleep / disconnected. Console line is already on screen.
   });
 });
+void bootstrapLogLevel();
 import { isTestModeEnabled } from '@/shared/test-mode.js';
 import { initEngine, generateCompletion, getLoadedModelId, getLoadedCanaryId, getWebGPUAdapterInfo } from './engine.js';
 import { runProbes } from './probe-runner.js';

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -6,6 +6,7 @@ import type {
 } from '@/types/messages.js';
 import { STORAGE_KEY_PENDING_INTERCEPT, MAX_INTERCEPT_LATENCY_MS } from '@/shared/constants.js';
 import { createLogger, setLogSink, setLogSource } from '@/shared/logger.js';
+import { bootstrapLogLevel } from '@/shared/log-level-bootstrap.js';
 import { LogBus, LOG_PORT_NAME } from '@/shared/log-bus.js';
 import { startKeepalive } from './keepalive.js';
 import { analyzeSnapshot, AnalysisAbortedError, getInFlightCount, getInFlightTabIds } from './orchestrator.js';
@@ -42,6 +43,7 @@ import { bootstrapEmbeddingsHunter } from './embeddings-bootstrap.js';
 const logBus = new LogBus();
 setLogSource('sw');
 setLogSink((entry) => logBus.push(entry));
+void bootstrapLogLevel();
 
 const log = createLogger('ServiceWorker');
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -398,6 +398,17 @@ export const STORAGE_KEY_CACHE_TTL_MS = 'honeyllm:cache-ttl-ms';
 export const STORAGE_KEY_CACHE_MAX_BYTES = 'honeyllm:cache-max-bytes';
 
 /**
+ * Issue #280 — runtime-toggleable logger minLevel. When set to a valid
+ * `LogLevel` ('debug' | 'info' | 'warn' | 'error') the logger source-side
+ * filter (`src/shared/logger.ts:setLogLevel`) updates so events at or above
+ * that level reach the LogBus + sink. Default unset = current behaviour
+ * ('info'). Used during /quantrix:troubleshooter sessions to capture #226
+ * structured `hunter_run:` / `chunk_created` / `probe_run` / `verdict_emitted`
+ * events that ship at debug level.
+ */
+export const STORAGE_KEY_LOG_LEVEL = 'honeyllm:log-level';
+
+/**
  * Issue #127 (N11) — telemetry counter for cache hit/miss rate. Persisted
  * in chrome.storage.local so the popup can render a hit-rate stat without
  * a message round-trip to the SW. Shape: `{ hits: number; misses: number;

--- a/src/shared/log-level-bootstrap.test.ts
+++ b/src/shared/log-level-bootstrap.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { bootstrapLogLevel } from './log-level-bootstrap.js';
+import {
+  createLogger,
+  resetLoggerForTests,
+  setLogSink,
+  setLogLevel,
+  type LogEntry,
+} from './logger.js';
+import { STORAGE_KEY_LOG_LEVEL } from './constants.js';
+
+type StorageChangeListener = (
+  changes: Record<string, { oldValue?: unknown; newValue?: unknown }>,
+  areaName: string,
+) => void;
+
+interface ChromeStub {
+  storage: {
+    local: {
+      get: (key: string) => Promise<Record<string, unknown>>;
+    };
+    onChanged: {
+      addListener: (fn: StorageChangeListener) => void;
+      removeListener: (fn: StorageChangeListener) => void;
+    };
+  };
+}
+
+interface StubControls {
+  setStored(value: unknown): void;
+  fireChange(changes: Record<string, { newValue?: unknown }>, area?: string): void;
+  listenerCount(): number;
+}
+
+function stubChrome(initial?: unknown): StubControls {
+  let stored: unknown = initial;
+  const listeners: StorageChangeListener[] = [];
+  const chromeStub: ChromeStub = {
+    storage: {
+      local: {
+        get: async (_key: string) =>
+          stored === undefined ? {} : { [STORAGE_KEY_LOG_LEVEL]: stored },
+      },
+      onChanged: {
+        addListener: (fn) => {
+          listeners.push(fn);
+        },
+        removeListener: (fn) => {
+          const idx = listeners.indexOf(fn);
+          if (idx >= 0) listeners.splice(idx, 1);
+        },
+      },
+    },
+  };
+  vi.stubGlobal('chrome', chromeStub);
+  return {
+    setStored(value: unknown) {
+      stored = value;
+    },
+    fireChange(changes, area = 'local') {
+      for (const listener of listeners) listener(changes, area);
+    },
+    listenerCount() {
+      return listeners.length;
+    },
+  };
+}
+
+describe('bootstrapLogLevel', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    resetLoggerForTests();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    resetLoggerForTests();
+  });
+
+  it('leaves the logger at default info when the storage key is absent', async () => {
+    stubChrome();
+    const sink = vi.fn<(entry: LogEntry) => void>();
+    setLogSink(sink);
+
+    await bootstrapLogLevel();
+    const log = createLogger('Test');
+    log.debug('not delivered');
+    log.info('delivered');
+
+    const calls = sink.mock.calls.map((c) => c[0]);
+    expect(calls.some((e) => e.level === 'debug')).toBe(false);
+    expect(calls.some((e) => e.level === 'info')).toBe(true);
+  });
+
+  it('applies a stored debug level so debug events reach the sink', async () => {
+    stubChrome('debug');
+    const sink = vi.fn<(entry: LogEntry) => void>();
+    setLogSink(sink);
+
+    await bootstrapLogLevel();
+    const log = createLogger('Test');
+    log.debug('delivered');
+
+    const calls = sink.mock.calls.map((c) => c[0]);
+    expect(calls.some((e) => e.level === 'debug' && e.message === 'delivered')).toBe(true);
+  });
+
+  it('ignores invalid stored values and leaves the logger at info', async () => {
+    stubChrome('verbose');
+    const sink = vi.fn<(entry: LogEntry) => void>();
+    setLogSink(sink);
+
+    await bootstrapLogLevel();
+    const log = createLogger('Test');
+    log.debug('not delivered');
+
+    const calls = sink.mock.calls.map((c) => c[0]);
+    expect(calls.some((e) => e.level === 'debug')).toBe(false);
+  });
+
+  it('registers a storage change listener that re-applies on key updates', async () => {
+    const ctrl = stubChrome();
+    const sink = vi.fn<(entry: LogEntry) => void>();
+    setLogSink(sink);
+
+    await bootstrapLogLevel();
+    expect(ctrl.listenerCount()).toBe(1);
+
+    ctrl.fireChange({ [STORAGE_KEY_LOG_LEVEL]: { newValue: 'debug' } });
+    const log = createLogger('Test');
+    log.debug('after-toggle');
+    const calls = sink.mock.calls.map((c) => c[0]);
+    expect(calls.some((e) => e.level === 'debug' && e.message === 'after-toggle')).toBe(true);
+  });
+
+  it('falls back to info when the storage key is removed at runtime', async () => {
+    const ctrl = stubChrome('debug');
+    const sink = vi.fn<(entry: LogEntry) => void>();
+    setLogSink(sink);
+
+    await bootstrapLogLevel();
+    const log = createLogger('Test');
+    log.debug('delivered-before');
+    ctrl.fireChange({ [STORAGE_KEY_LOG_LEVEL]: { newValue: undefined } });
+    log.debug('not-delivered-after');
+
+    const calls = sink.mock.calls.map((c) => c[0]);
+    expect(calls.some((e) => e.message === 'delivered-before')).toBe(true);
+    expect(calls.some((e) => e.message === 'not-delivered-after')).toBe(false);
+  });
+
+  it('ignores changes in non-local storage areas', async () => {
+    const ctrl = stubChrome();
+    const sink = vi.fn<(entry: LogEntry) => void>();
+    setLogSink(sink);
+
+    await bootstrapLogLevel();
+    ctrl.fireChange({ [STORAGE_KEY_LOG_LEVEL]: { newValue: 'debug' } }, 'sync');
+
+    const log = createLogger('Test');
+    log.debug('not-delivered');
+    const calls = sink.mock.calls.map((c) => c[0]);
+    expect(calls.some((e) => e.level === 'debug')).toBe(false);
+  });
+
+  it('swallows errors when chrome.storage is unavailable', async () => {
+    vi.stubGlobal('chrome', undefined);
+    setLogLevel('info');
+    await expect(bootstrapLogLevel()).resolves.toBeUndefined();
+  });
+
+  it('swallows errors when chrome.storage.local.get throws', async () => {
+    vi.stubGlobal('chrome', {
+      storage: {
+        local: {
+          get: async () => {
+            throw new Error('storage unavailable');
+          },
+        },
+        onChanged: {
+          addListener: () => {},
+          removeListener: () => {},
+        },
+      },
+    });
+    setLogLevel('info');
+    await expect(bootstrapLogLevel()).resolves.toBeUndefined();
+  });
+});

--- a/src/shared/log-level-bootstrap.ts
+++ b/src/shared/log-level-bootstrap.ts
@@ -1,0 +1,54 @@
+import { setLogLevel, type LogLevel } from './logger.js';
+import { STORAGE_KEY_LOG_LEVEL } from './constants.js';
+
+const VALID_LEVELS: ReadonlySet<LogLevel> = new Set<LogLevel>([
+  'debug',
+  'info',
+  'warn',
+  'error',
+]);
+const DEFAULT_LEVEL: LogLevel = 'info';
+
+function asLogLevel(value: unknown): LogLevel | null {
+  return typeof value === 'string' && VALID_LEVELS.has(value as LogLevel)
+    ? (value as LogLevel)
+    : null;
+}
+
+function applyValue(value: unknown): void {
+  const level = asLogLevel(value);
+  setLogLevel(level ?? DEFAULT_LEVEL);
+}
+
+interface StorageChange {
+  readonly oldValue?: unknown;
+  readonly newValue?: unknown;
+}
+
+type StorageChangeListener = (
+  changes: Record<string, StorageChange>,
+  areaName: string,
+) => void;
+
+export async function bootstrapLogLevel(): Promise<void> {
+  if (typeof chrome === 'undefined' || chrome.storage?.local?.get === undefined) {
+    return;
+  }
+
+  try {
+    const result = await chrome.storage.local.get(STORAGE_KEY_LOG_LEVEL);
+    const stored = result[STORAGE_KEY_LOG_LEVEL];
+    if (stored !== undefined) applyValue(stored);
+  } catch {
+    // Storage unavailable; leave logger at its current level.
+  }
+
+  if (chrome.storage.onChanged?.addListener === undefined) return;
+  const listener: StorageChangeListener = (changes, areaName) => {
+    if (areaName !== 'local') return;
+    const change = changes[STORAGE_KEY_LOG_LEVEL];
+    if (change === undefined) return;
+    applyValue(change.newValue);
+  };
+  chrome.storage.onChanged.addListener(listener);
+}


### PR DESCRIPTION
## Summary

Adds `chrome.storage.local['honeyllm:log-level']` toggle so logger `minLevel` can be flipped to `'debug'` without an extension reload, unblocking #226's structured `hunter_run:` / `chunk_created` / `probe_run` / `verdict_emitted` events that ship at debug level.

## Why

Surfaced from `/quantrix:troubleshooter 1.3` against PR #279 (#232 bricklink FP). A fresh `Save to disk` capture on 2026-05-06 confirmed the jsonl had only info-level events — `hunter_run:{name}: score=X, confidence=Y, flags=N` from `src/hunters/hunt-runner.ts:77` and the orchestrator's `chunk_created` / `probe_run` / `verdict_emitted` debug lines were dropped at source by `src/shared/logger.ts:29` (`minLevel='info'`). Without per-hunter scores we can't tell which of Spider / Hawk / Embeddings emits chunk-1's primitive on bricklink, which means we can't tell whether PR #279's negative-kind anti-anchor fix is even at the right layer. This unblocks that investigation.

## Diff scope

- `src/shared/constants.ts` — `STORAGE_KEY_LOG_LEVEL = 'honeyllm:log-level'`.
- `src/shared/log-level-bootstrap.ts` (new) — `bootstrapLogLevel()` reads + applies stored level, registers `chrome.storage.onChanged` listener (local area only); falls back to `'info'` on absent / removed / invalid value.
- `src/shared/log-level-bootstrap.test.ts` (new) — 8 unit tests.
- Wired into `src/service-worker/index.ts`, `src/offscreen/index.ts`, `src/content/index.ts` immediately after `setLogSink`.
- Surfaces map (`docs/agent-context/known-surfaces.md`) — storage-keys table row + Logging section subsection with the DevTools toggle command.

## Test plan

- [x] `npm run typecheck` ✓
- [x] `npm test` ✓ (1562 → 1570; +8 new tests)
- [x] `npm run build` ✓
- [x] Unit tests cover: absent key default-info, valid `'debug'` applies (debug events reach sink), invalid value ignored, onChanged re-applies, key removal reverts to info, non-local areas ignored, chrome unavailable swallowed, get() throw swallowed.
- [ ] Manual (after merge): `chrome.storage.local.set({'honeyllm:log-level': 'debug'})` from SW console → re-run cache-cleared bricklink scan → jsonl contains `hunter_run:{spider,hawk,embeddings}: score=X, confidence=Y, flags=N` lines per chunk + `verdict_emitted: status=X, confidence=Y` line.

## Why a separate issue (not folded into #232)

#232 is the bricklink false-positive fix (PR #279). This is diagnostic-infra that unblocks investigation of #232 and every future hunter-layer troubleshoot. Folding into #232 would conflate scope and bloat the v2 fix PR diff. Tracked as `Refs #232` so the troubleshoot trail joins up without close-gating either side.

Refs #232
Refs #226
Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)