### PR TITLE
chore(phase5-#117): 2-week install-secret rotation invariant verification — PASS

### DIFF
--- a/docs/testing/install-secret-invariant-checks.md
+++ b/docs/testing/install-secret-invariant-checks.md
@@ -1,0 +1,7 @@
+# Install-Secret Rotation Invariant Checks
+
+Periodic (2-week) verification that `ensureInstallSecret()` remains read-before-write idempotent and the `onInstalled`/`onStartup` handlers never rotate the secret.
+
+| Date | Result | Notes | HEAD commit |
+|---|---|---|---|
+| 2026-05-13 | PASS | no drift detected | 88edf930e0eca2a9828b6c3041b895a8c772fbf3 |


### PR DESCRIPTION
## Summary

Routine 2-week integrity check of the install-secret rotation invariant introduced in issue #117 (PR #139, merged 2026-04-29). No code changes — only a new row appended to `docs/testing/install-secret-invariant-checks.md`.

## Checks

| # | Check | Status |
|---|---|---|
| 1 | `npm test -- src/shared/install-secret.test.ts src/service-worker/stamp.test.ts` → 20/20 passed | **PASS** |
| 2 | `compute()` reads `chrome.storage.local` first; generates+sets only when `existing` is missing or non-string/empty | **PASS** |
| 3 | `ensureInstallSecret` caches via module-scope `cached`+`inFlight`; `storage.set` rejection propagates (catch sets `inFlight = null`, rethrows) | **PASS** |
| 4 | Both `chrome.runtime.onInstalled` and `chrome.runtime.onStartup` call `bootstrapInstallSecret()`; neither rotates the secret | **PASS** |
| 5 | `git log --since="2 weeks ago"` on the 3 key files: 5 commits to `index.ts`, 1 commit to `stamp.ts`/`install-secret.ts` (initial creation). Diffs reviewed — no changes to `compute()`, `ensureInstallSecret`, onInstalled/onStartup secret handlers, or `STORAGE_KEY_INSTALL_SECRET`. | **PASS** |

No action required.

Closes #117 (comment only — issue remains closed)

https://claude.ai/code/session_014CRQgZvgPHd1WPBg2wXt1k

---
_Generated by [Claude Code](https://claude.ai/code/session_014CRQgZvgPHd1WPBg2wXt1k)_